### PR TITLE
Add workload endpoints as a resource type

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -25,7 +25,8 @@ func Apply(args []string) error {
 	doc := EtcdIntro + `Apply a resource by filename or stdin.  This creates a resource
 if it does not exist, and replaces a resource if it does exist.
 
-Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.
+Valid resource kinds are bgpPeer, hostEndpoint, workloadEndpoint, policy, pool, profile
+and tier.
 
 Usage:
   calicoctl apply --filename=<FILENAME> [--config=<CONFIG>]

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -24,7 +24,8 @@ import (
 func Create(args []string) error {
 	doc := EtcdIntro + `Create a resource by filename or stdin.
 
-Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.
+Valid resource kinds are bgpPeer, hostEndpoint, workloadEndpoint, policy, pool, profile
+and tier.
 
 Usage:
   calicoctl create --filename=<FILENAME> [--skip-exists] [--config=<CONFIG>]

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -25,11 +25,12 @@ import (
 func Delete(args []string) error {
 	doc := EtcdIntro + `Delete a resource identified by file, stdin or resource type and name.
 
-Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.  The <KIND>
-parameter is case insensitive and may be pluralized.
+Valid resource kinds are bgpPeer, hostEndpoint, workloadEndpoint, policy, pool, profile and tier.
+The <KIND> parameter is case insensitive and may be pluralized.
 
 Usage:
-  calicoctl delete (([--tier=<TIER>] [--hostname=<HOSTNAME>] [--scope=<SCOPE>] <KIND> <NAME>) |
+  calicoctl delete ([--tier=<TIER>] [--hostname=<HOSTNAME>] [--orchestrator=<ORCH>] [--workload=<WORKLOAD>] [--scope=<SCOPE>]
+                    (<KIND> [<NAME>])
                     --filename=<FILE>)
                    [--skip-not-exists] [--config=<CONFIG>]
 
@@ -51,6 +52,8 @@ Options:
   -f --filename=<FILENAME>     Filename to use to delete the resource.  If set to "-" loads from stdin.
   -t --tier=<TIER>             The policy tier.
   -n --hostname=<HOSTNAME>     The hostname.
+     --orchestrator=<ORCH>     The orchestrator (only used for workload endpoints).
+     --workload=<WORKLOAD>     The workload (only used for workload endpoints).
   --scope=<SCOPE>              The scope of the resource type.  One of global, node.  This is only valid
                                for BGP peers and is used to indicate whether the peer is a global peer
                                or node-specific.

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -26,14 +26,15 @@ import (
 func Get(args []string) error {
 	doc := EtcdIntro + `Display one or many resources identified by file, stdin or resource type and name.
 
-Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.  The <KIND>
-parameter is case insensitive and may be pluralized.
+Valid resource kinds are bgpPeer, hostEndpoint, workloadEndpoint, policy, pool, profile and tier.
+The <KIND> parameter is case insensitive and may be pluralized.
 
 By specifying the output as 'go-template' and providing a Go template as the value
 of the --go-template flag, you can filter the attributes of the fetched resource(s).
 
 Usage:
-  calicoctl get ([--tier=<TIER>] [--hostname=<HOSTNAME>] [--scope=<SCOPE>] (<KIND> [<NAME>]) |
+  calicoctl get ([--tier=<TIER>] [--hostname=<HOSTNAME>] [--orchestrator=<ORCH>] [--workload=<WORKLOAD>] [--scope=<SCOPE>]
+                 (<KIND> [<NAME>]) |
                  --filename=<FILENAME>)
                 [--output=<OUTPUT>] [--config=<CONFIG>]
 
@@ -51,6 +52,8 @@ Options:
                                go-template=..., go-template-file=...   [Default: ps]
   -t --tier=<TIER>             The policy tier.
   -n --hostname=<HOSTNAME>     The hostname.
+     --orchestrator=<ORCH>     The orchestrator (only used for workload endpoints).
+     --workload=<WORKLOAD>     The workload (only used for workload endpoints).
   --scope=<SCOPE>              The scope of the resource type.  One of global, node.  This is only valid
                                for BGP peers and is used to indicate whether the peer is a global peer
                                or node-specific.

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -25,7 +25,8 @@ import (
 func Replace(args []string) error {
 	doc := EtcdIntro + `Replace a resource by filename or stdin.
 
-Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.
+Valid resource kinds are bgpPeer, hostEndpoint, workloadEndpoint, policy, pool, profile
+and tier.
 
 If replacing an existing resource, the complete resource spec must be provided. This can be obtained by
 $ calicoctl get -o yaml <TYPE> <NAME>

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -96,6 +96,8 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 	name := argStringOrBlank(args, "<NAME>")
 	tier := argStringOrBlank(args, "--tier")
 	hostname := argStringOrBlank(args, "--hostname")
+	workload := argStringOrBlank(args, "--workload")
+	orchestrator := argStringOrBlank(args, "--orchestrator")
 	resScope := argStringOrBlank(args, "--scope")
 	switch strings.ToLower(kind) {
 	case "hostendpoints":
@@ -103,6 +105,15 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 	case "hostendpoint":
 		h := api.NewHostEndpoint()
 		h.Metadata.Name = name
+		h.Metadata.Hostname = hostname
+		return *h, nil
+	case "workloadendpoints":
+		fallthrough
+	case "workloadendpoint":
+		h := api.NewWorkloadEndpoint()
+		h.Metadata.Name = name
+		h.Metadata.OrchestratorID = orchestrator
+		h.Metadata.WorkloadID = workload
 		h.Metadata.Hostname = hostname
 		return *h, nil
 	case "tiers":

--- a/calicoctl/resourcemgr/workloadendpoint.go
+++ b/calicoctl/resourcemgr/workloadendpoint.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewWorkloadEndpoint(),
+		api.NewWorkloadEndpointList(),
+		[]string{"HOSTNAME", "ORCHESTRATOR", "WORKLOAD", "NAME"},
+		[]string{"HOSTNAME", "ORCHESTRATOR", "WORKLOAD", "NAME", "NETWORKS", "NATS", "INTERFACE", "PROFILES"},
+		map[string]string{
+			"HOSTNAME":     "{{.Metadata.Hostname}}",
+			"ORCHESTRATOR": "{{.Metadata.OrchestratorID}}",
+			"WORKLOAD":     "{{.Metadata.WorkloadID}}",
+			"NAME":         "{{.Metadata.Name}}",
+			"NETWORKS":     "{{join .Spec.IPNetworks \",\"}}",
+			"NATS":         "{{join .Spec.IPNATs \",\"}}",
+			"IPV4GATEWAY":  "{{.Spec.IPv4Gateway}}",
+			"IPV6GATEWAY":  "{{.Spec.IPv4Gateway}}",
+			"PROFILES":     "{{join .Spec.Profiles \",\"}}",
+			"INTERFACE":    "{{.Spec.InterfaceName}}",
+			"MAC":          "{{.Spec.MAC}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.WorkloadEndpoint)
+			return client.WorkloadEndpoints().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.WorkloadEndpoint)
+			return client.WorkloadEndpoints().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.WorkloadEndpoint)
+			return client.WorkloadEndpoints().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.WorkloadEndpoint)
+			return nil, client.WorkloadEndpoints().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.WorkloadEndpoint)
+			return client.WorkloadEndpoints().List(r.Metadata)
+		},
+	)
+}

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
@@ -29,7 +31,8 @@ type WorkloadEndpoint struct {
 type WorkloadEndpointMetadata struct {
 	unversioned.ObjectMetadata
 
-	// The name of the endpoint.
+	// The name of the endpoint.  This may be omitted on a create, in which case an endpoint
+	// ID will be automatically created, and the endpoint ID will be included in the response.
 	Name string `json:"name,omitempty" validate:"omitempty,name"`
 
 	// The name of the workload.
@@ -60,10 +63,10 @@ type WorkloadEndpointSpec struct {
 	// internal IP will not have their source address changed, except when an endpoint attempts
 	// to connect one of its own external IPs. Each internal IP must be associated with the same
 	// endpoint via the configured IPNetworks.
-	IPNATs []IPNAT `json:"ipNAT,omitempty" validate:"omitempty,dive"`
+	IPNATs []IPNAT `json:"ipNATs,omitempty" validate:"omitempty,dive"`
 
 	// IPv4Gateway is the gateway IPv4 address for traffic from the workload.
-	IPv4Gateway net.IP `json:"ipv6Gateway,omitempty" validate:"omitempty,ipv4"`
+	IPv4Gateway net.IP `json:"ipv4Gateway,omitempty" validate:"omitempty,ipv4"`
 
 	// IPv6Gateway is the gateway IPv6 address for traffic from the workload.
 	IPv6Gateway net.IP `json:"ipv6Gateway,omitempty" validate:"omitempty,ipv6"`
@@ -88,6 +91,11 @@ type IPNAT struct {
 
 	// The external IP address.
 	ExternalIP net.IP `json:"externalIP" validate:"ip"`
+}
+
+// String returns a friendly form of an IPNAT.
+func (i IPNAT) String() string {
+	return fmt.Sprintf("%s<>%s", i.InternalIP, i.ExternalIP)
 }
 
 // NewWorkloadEndpoint creates a new (zeroed) WorkloadEndpoint struct with the TypeMetadata

--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -82,6 +82,11 @@ type Client interface {
 	// Some keys are hierarchical, and Delete is a recursive operation.
 	// For example, deleting a Tier also deletes all the policies under
 	// that Tier.
+	//
+	// Any objects that were implicitly added by a Create operation should
+	// also be removed when deleting the objects that implicitly created it.
+	// For example, deleting the last WorkloadEndpoint in a Workload will
+	// also remove the Workload.
 	Delete(object *model.KVPair) error
 
 	// Get returns the object identified by the given key as a KVPair with

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -33,11 +33,12 @@ import (
 )
 
 var (
-	etcdApplyOpts  = &etcd.SetOptions{PrevExist: etcd.PrevIgnore}
-	etcdCreateOpts = &etcd.SetOptions{PrevExist: etcd.PrevNoExist}
-	etcdGetOpts    = &etcd.GetOptions{Quorum: true}
-	etcdListOpts   = &etcd.GetOptions{Quorum: true, Recursive: true, Sort: true}
-	clientTimeout  = 30 * time.Second
+	etcdApplyOpts       = &etcd.SetOptions{PrevExist: etcd.PrevIgnore}
+	etcdCreateOpts      = &etcd.SetOptions{PrevExist: etcd.PrevNoExist}
+	etcdDeleteEmptyOpts = &etcd.DeleteOptions{Recursive: false}
+	etcdGetOpts         = &etcd.GetOptions{Quorum: true}
+	etcdListOpts        = &etcd.GetOptions{Quorum: true, Recursive: true, Sort: true}
+	clientTimeout       = 30 * time.Second
 )
 
 type EtcdConfig struct {
@@ -142,6 +143,22 @@ func (c *EtcdClient) Delete(d *model.KVPair) error {
 	}
 	log.Infof("Delete Key: %s", key)
 	_, err = c.etcdKeysAPI.Delete(context.Background(), key, etcdDeleteOpts)
+
+	// If there are parents to be deleted, delete these as well provided there
+	// are no more children.
+	parents, err := model.KeyToDefaultDeleteParentPaths(d.Key)
+	if err != nil {
+		return err
+	}
+	for _, parent := range parents {
+		log.Infof("Delete empty Key: %s", parent)
+		_, err2 := c.etcdKeysAPI.Delete(context.Background(), parent, etcdDeleteEmptyOpts)
+		if err2 != nil {
+			log.Infof("Unable to delete parent: %s", err2)
+			break
+		}
+	}
+
 	return convertEtcdError(err, d.Key)
 }
 

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -68,6 +68,10 @@ func (key BGPPeerKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key BGPPeerKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key BGPPeerKey) valueType() reflect.Type {
 	return typeBGPPeer
 }

--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -47,6 +47,10 @@ func (key BlockKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key BlockKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key BlockKey) valueType() reflect.Type {
 	return typeBlock
 }

--- a/lib/backend/model/block_affinity.go
+++ b/lib/backend/model/block_affinity.go
@@ -48,6 +48,10 @@ func (key BlockAffinityKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key BlockAffinityKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key BlockAffinityKey) valueType() reflect.Type {
 	return typeBlockAff
 }

--- a/lib/backend/model/config.go
+++ b/lib/backend/model/config.go
@@ -43,6 +43,10 @@ func (key ReadyFlagKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key ReadyFlagKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key ReadyFlagKey) valueType() reflect.Type {
 	return typeReadyFlag
 }
@@ -62,6 +66,10 @@ func (key GlobalConfigKey) defaultDeletePath() (string, error) {
 	}
 	e := fmt.Sprintf("/calico/v1/config/%s", key.Name)
 	return e, nil
+}
+
+func (key GlobalConfigKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
 }
 
 func (key GlobalConfigKey) valueType() reflect.Type {
@@ -119,6 +127,10 @@ func (key HostConfigKey) defaultDeletePath() (string, error) {
 	}
 	e := fmt.Sprintf("/calico/v1/host/%s/config/%s", key.Hostname, key.Name)
 	return e, nil
+}
+
+func (key HostConfigKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
 }
 
 func (key HostConfigKey) valueType() reflect.Type {

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -52,6 +52,10 @@ func (key HostEndpointKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key HostEndpointKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key HostEndpointKey) valueType() reflect.Type {
 	return typeHostEndpoint
 }

--- a/lib/backend/model/hostendpointstatus.go
+++ b/lib/backend/model/hostendpointstatus.go
@@ -51,6 +51,10 @@ func (key HostEndpointStatusKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key HostEndpointStatusKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key HostEndpointStatusKey) valueType() reflect.Type {
 	return typeHostEndpointStatus
 }

--- a/lib/backend/model/hostip.go
+++ b/lib/backend/model/hostip.go
@@ -39,6 +39,10 @@ func (key HostIPKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key HostIPKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key HostIPKey) valueType() reflect.Type {
 	return typeHostIp
 }

--- a/lib/backend/model/ipam_config.go
+++ b/lib/backend/model/ipam_config.go
@@ -14,11 +14,7 @@
 
 package model
 
-import (
-	"reflect"
-
-	"github.com/projectcalico/libcalico-go/lib/errors"
-)
+import "reflect"
 
 var (
 	typeIPAMConfig = reflect.TypeOf(IPAMConfig{})
@@ -32,7 +28,11 @@ func (key IPAMConfigKey) defaultPath() (string, error) {
 }
 
 func (key IPAMConfigKey) defaultDeletePath() (string, error) {
-	return "", errors.ErrorResourceUpdateConflict{"Cannot delete IPAMConfig"}
+	return key.defaultPath()
+}
+
+func (key IPAMConfigKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
 }
 
 func (key IPAMConfigKey) valueType() reflect.Type {

--- a/lib/backend/model/ipam_handle.go
+++ b/lib/backend/model/ipam_handle.go
@@ -44,6 +44,10 @@ func (key IPAMHandleKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key IPAMHandleKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key IPAMHandleKey) valueType() reflect.Type {
 	return typeHandle
 }

--- a/lib/backend/model/ipam_host.go
+++ b/lib/backend/model/ipam_host.go
@@ -41,6 +41,10 @@ func (key IPAMHostKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key IPAMHostKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key IPAMHostKey) valueType() reflect.Type {
 	return typeIPAMHost
 }

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -34,8 +34,26 @@ var rawBoolType = reflect.TypeOf(rawBool(true))
 
 // Key represents a parsed datastore key.
 type Key interface {
+	// defaultPath() returns a common path representation of the object used by
+	// etcdv2 and other datastores.
 	defaultPath() (string, error)
+
+	// defaultDeletePath() returns a common path representation used by etcdv2
+	// and other datastores to delete the object.
 	defaultDeletePath() (string, error)
+
+	// defaultDeleteParentPaths() returns an ordered slice of paths that should
+	// be removed after deleting the primary path (given by defaultDeletePath),
+	// provided there are no child entries associated with those paths.  This is
+	// only used by directory based KV stores (such as etcdv2).  With a directory
+	// based KV store, creation of a resource may also create parent directory entries
+	// that could be shared by multiple resources, and therefore the parent directories
+	// can only be removed when there are no more resources under them.  The list of
+	// parent paths is ordered, and directories should be removed in the order supplied
+	// in the slice and only if the directory is empty.
+	defaultDeleteParentPaths() ([]string, error)
+
+	// valueType returns the object type associated with this key.
 	valueType() reflect.Type
 }
 
@@ -113,6 +131,33 @@ func KeyToDefaultPath(key Key) (string, error) {
 //     "/calico/v1/policy/tier/a/policy/b"
 func KeyToDefaultDeletePath(key Key) (string, error) {
 	return key.defaultDeletePath()
+}
+
+// KeyToDefaultDeleteParentPaths returns a slice of '/'-delimited
+// paths which are used to delete parent entries that may be auto-created
+// by directory-based KV stores (e.g. etcd v2).  These paths should also be
+// removed provided they have no more child entries.
+//
+// The list of parent paths is ordered, and directories should be removed
+// in the order supplied in the slice and only if the directory is empty.
+//
+// For example,
+// 	KeyToDefaultDeletePaths(WorkloadEndpointKey{
+//		Hostname: "h",
+//		OrchestratorID: "o",
+//		WorkloadID: "w",
+//		EndpointID: "e",
+//	})
+// returns
+//
+// ["/calico/v1/host/h/workload/o/w/endpoint",
+//  "/calico/v1/host/h/workload/o/w"]
+//
+// indicating that these paths should also be deleted when they are empty.
+// In this example it is equivalent to deleting the workload when there are
+// no more endpoints in the workload.
+func KeyToDefaultDeleteParentPaths(key Key) ([]string, error) {
+	return key.defaultDeleteParentPaths()
 }
 
 // ListOptionsToDefaultPathRoot converts list options struct into a

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -52,6 +52,10 @@ func (key PolicyKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key PolicyKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key PolicyKey) valueType() reflect.Type {
 	return typePolicy
 }

--- a/lib/backend/model/pool.go
+++ b/lib/backend/model/pool.go
@@ -48,6 +48,10 @@ func (key PoolKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key PoolKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key PoolKey) valueType() reflect.Type {
 	return typePool
 }

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -50,6 +50,10 @@ func (key ProfileKey) defaultDeletePath() (string, error) {
 	return key.defaultPath()
 }
 
+func (key ProfileKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key ProfileKey) valueType() reflect.Type {
 	return typeProfile // FIXME is this required?
 }

--- a/lib/backend/model/statusreports.go
+++ b/lib/backend/model/statusreports.go
@@ -34,7 +34,8 @@ type ActiveStatusReportKey struct {
 }
 
 func (key ActiveStatusReportKey) defaultPath() (string, error) {
-	return key.defaultDeletePath()
+	k, err := key.defaultDeletePath()
+	return k + "/metadata", err
 }
 
 func (key ActiveStatusReportKey) defaultDeletePath() (string, error) {
@@ -43,6 +44,10 @@ func (key ActiveStatusReportKey) defaultDeletePath() (string, error) {
 	}
 	e := fmt.Sprintf("/calico/felix/v1/host/%s/status", key.Hostname)
 	return e, nil
+}
+
+func (key ActiveStatusReportKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
 }
 
 func (key ActiveStatusReportKey) valueType() reflect.Type {
@@ -86,7 +91,8 @@ type LastStatusReportKey struct {
 }
 
 func (key LastStatusReportKey) defaultPath() (string, error) {
-	return key.defaultDeletePath()
+	k, err := key.defaultDeletePath()
+	return k + "/metadata", err
 }
 
 func (key LastStatusReportKey) defaultDeletePath() (string, error) {
@@ -95,6 +101,10 @@ func (key LastStatusReportKey) defaultDeletePath() (string, error) {
 	}
 	e := fmt.Sprintf("/calico/felix/v1/host/%s/last_reported_status", key.Hostname)
 	return e, nil
+}
+
+func (key LastStatusReportKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
 }
 
 func (key LastStatusReportKey) valueType() reflect.Type {

--- a/lib/backend/model/tier.go
+++ b/lib/backend/model/tier.go
@@ -46,6 +46,10 @@ func (key TierKey) defaultDeletePath() (string, error) {
 	return e, nil
 }
 
+func (key TierKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
 func (key TierKey) valueType() reflect.Type {
 	return typeTier
 }

--- a/lib/backend/model/workloadendpointstatus.go
+++ b/lib/backend/model/workloadendpointstatus.go
@@ -47,28 +47,30 @@ func (key WorkloadEndpointStatusKey) defaultPath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "workload"}
 	}
 	if key.EndpointID == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "endpointID"}
+		return "", errors.ErrorInsufficientIdentifiers{Name: "endpoint"}
 	}
 	return fmt.Sprintf("/calico/felix/v1/host/%s/workload/%s/%s/endpoint/%s",
 		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID), nil
 }
 
 func (key WorkloadEndpointStatusKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
+}
+
+func (key WorkloadEndpointStatusKey) defaultDeleteParentPaths() ([]string, error) {
 	if key.Hostname == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
+		return nil, errors.ErrorInsufficientIdentifiers{Name: "hostname"}
 	}
 	if key.OrchestratorID == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "orchestrator"}
+		return nil, errors.ErrorInsufficientIdentifiers{Name: "orchestrator"}
 	}
 	if key.WorkloadID == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "workload"}
+		return nil, errors.ErrorInsufficientIdentifiers{Name: "workload"}
 	}
-	if key.EndpointID == "" {
-		return fmt.Sprintf("/calico/felix/v1/host/%s/workload/%s/%s/",
-			key.Hostname, key.OrchestratorID, key.WorkloadID), nil
-	}
-	return fmt.Sprintf("/calico/felix/v1/host/%s/workload/%s/%s/endpoint/%s",
-		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID), nil
+	workload := fmt.Sprintf("/calico/felix/v1/host/%s/workload/%s/%s",
+		key.Hostname, key.OrchestratorID, key.WorkloadID)
+	endpoints := workload + "/endpoint"
+	return []string{endpoints, workload}, nil
 }
 
 func (key WorkloadEndpointStatusKey) valueType() reflect.Type {

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -136,16 +136,31 @@ func (w *workloadEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.K
 		}
 	}
 
+	ipv4NAT := []model.IPNAT{}
+	ipv6NAT := []model.IPNAT{}
+	for _, n := range ah.Spec.IPNATs {
+		nat := model.IPNAT{IntIP: n.InternalIP, ExtIP: n.ExternalIP}
+		if n.InternalIP.Version() == 4 {
+			ipv4NAT = append(ipv4NAT, nat)
+		} else {
+			ipv6NAT = append(ipv6NAT, nat)
+		}
+	}
+
 	d := model.KVPair{
 		Key: k,
 		Value: model.WorkloadEndpoint{
-			Labels:     ah.Metadata.Labels,
-			State:      "active",
-			Name:       ah.Spec.InterfaceName,
-			Mac:        ah.Spec.MAC,
-			ProfileIDs: ah.Spec.Profiles,
-			IPv4Nets:   ipv4Nets,
-			IPv6Nets:   ipv6Nets,
+			Labels:      ah.Metadata.Labels,
+			State:       "active",
+			Name:        ah.Spec.InterfaceName,
+			Mac:         ah.Spec.MAC,
+			ProfileIDs:  ah.Spec.Profiles,
+			IPv4Nets:    ipv4Nets,
+			IPv6Nets:    ipv6Nets,
+			IPv4NAT:     ipv4NAT,
+			IPv6NAT:     ipv6NAT,
+			IPv4Gateway: ah.Spec.IPv4Gateway,
+			IPv6Gateway: ah.Spec.IPv6Gateway,
 		},
 	}
 
@@ -159,8 +174,16 @@ func (w *workloadEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Res
 	bh := d.Value.(model.WorkloadEndpoint)
 	bk := d.Key.(model.WorkloadEndpointKey)
 
-	n := bh.IPv4Nets
-	n = append(n, bh.IPv6Nets...)
+	nets := bh.IPv4Nets
+	nets = append(nets, bh.IPv6Nets...)
+
+	nats := []api.IPNAT{}
+	mnats := bh.IPv4NAT
+	mnats = append(mnats, bh.IPv6NAT...)
+	for _, mnat := range mnats {
+		nat := api.IPNAT{InternalIP: mnat.IntIP, ExternalIP: mnat.ExtIP}
+		nats = append(nats, nat)
+	}
 
 	ah := api.NewWorkloadEndpoint()
 	ah.Metadata.Hostname = bk.Hostname
@@ -171,7 +194,10 @@ func (w *workloadEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Res
 	ah.Spec.InterfaceName = bh.Name
 	ah.Spec.MAC = bh.Mac
 	ah.Spec.Profiles = bh.ProfileIDs
-	ah.Spec.IPNetworks = n
+	ah.Spec.IPNetworks = nets
+	ah.Spec.IPNATs = nats
+	ah.Spec.IPv4Gateway = bh.IPv4Gateway
+	ah.Spec.IPv6Gateway = bh.IPv6Gateway
 
 	return ah, nil
 }

--- a/lib/net/ipnet.go
+++ b/lib/net/ipnet.go
@@ -59,3 +59,11 @@ func ParseCIDR(c string) (*IP, *IPNet, error) {
 	}
 	return &IP{netIP}, &IPNet{*netIPNet}, e
 }
+
+// String returns a friendly name for the network.  The standard net package
+// implements String() on the pointer, which means it will not be invoked on a
+// struct type, so we re-implement on the struct type.
+func (i IPNet) String() string {
+	ip := &i.IPNet
+	return ip.String()
+}

--- a/test/policy-icmp-bad.yaml
+++ b/test/policy-icmp-bad.yaml
@@ -5,10 +5,6 @@
   spec:
     order: 12.345
 - apiVersion: v1
-  kind: tier
-  metadata:
-    name: tier2
-- apiVersion: v1
   kind: policy
   metadata:
     name: policy1
@@ -19,12 +15,11 @@
       - action: nextTier
         protocol: udp
         icmp:
-          type: 10
           code: 100
         source:
           tag: web
           net: 1.2.3.4/10
-          selector: has(THING_THING8)
+          selector:
           ports: [1,2,3,4]
         destination:
           tag: database
@@ -38,15 +33,8 @@
           "!tag": abcd
           "!net": aa:bb:cc::ff/100
           "!selector": 
-          "!ports": [100,"3:4",65535,"20:20","20:40"]
+          "!ports": [100]
     selector:
-- apiVersion: v1
-  kind: policy
-  metadata:
-    name: policy2
-    tier: tier2
-  spec:
-    order: 0
 - apiVersion: v1
   kind: hostEndpoint
   metadata:
@@ -57,44 +45,16 @@
   spec:
     interface: eth0
     profiles: [prof1, prof2]
-    expectedIPs: [1.2.3.4, "00:bb::aa"]
 - apiVersion: v1
   kind: profile
   metadata:
     name: profile1
+  spec:
+    tags: [a, b, c, a1]
+    rules:
+      ingress:
+        - action: deny
+      egress:
+        - action: deny
     labels:
       type: database
-      THING4: VALUE10/2-F
-  spec:
-    tags: [a, b, c, a1, update]
-    ingress:
-      - action: deny
-    egress:
-      - action: deny
-- apiVersion: v1
-  kind: profile
-  metadata:
-    name: empty
-  spec:
-    ingress:
-      - action: deny
-- apiVersion: v1
-  kind: bgpPeer
-  metadata:
-    scope: global
-    peerIP: 1.2.3.4
-  spec:
-    asNumber: 1234
-- apiVersion: v1
-  kind: bgpPeer
-  metadata:
-    scope: node
-    hostname: fred
-    peerIP: 1.3.5.6
-  spec:
-    asNumber: 145794
-- apiVersion: v1
-  kind: pool
-  metadata:
-    cidr: 10.10.0.0/16
-

--- a/test/workload.yaml
+++ b/test/workload.yaml
@@ -10,8 +10,12 @@
   spec:
     interface: eth0
     profiles: [prof1, prof2]
-    ipNetworks: [1.2.3.4/32, "00:bb::aa/10"]
+    ipNetworks: ["1.2.3.4/32", "00:bb::aa/128"]
+    ipNATs:
+    - externalIP: 10.20.30.40
+      internalIP: 1.2.3.4
     mac: "ee:ee:ee:ee:ee:ee"
+    interfaceName: eth0
 - apiVersion: v1
   kind: workloadEndpoint
   metadata:
@@ -23,5 +27,6 @@
       type: otherthing
   spec:
     interface: eth0
-    ipNetworks: [1.2.3.4/22]
+    ipNetworks: [1.2.3.4/32]
     mac: "ab:cd:ef:12:34:56"
+    interfaceName: eth0


### PR DESCRIPTION
This adds workload endpoints as a resource type to calicoctl.  The workload is automatically deleted when the last endpoint is deleted.  Workloads themselves are not explicit resource types (neither are orchestrators), but they do appear as additional IDs in the workload endpoint.

Note that imports still refer to tigers.  There is a separate issue to fix up tigera imports.