### PR TITLE
Fix int accuracy of certain types, and fix bugs in marshalling

### DIFF
--- a/docs/calicoctl/resources/bgppeer.md
+++ b/docs/calicoctl/resources/bgppeer.md
@@ -37,4 +37,4 @@ spec:
 #### Spec
 | name     | description                 | requirements               | schema  |
 |----------|-----------------------------|----------------------------|---------|
-| asNumber | The AS Number of this peer. | Must be a valid AS Number. | integer |
+| asNumber | The AS Number of this peer. | Must be a valid AS Number.  The YAML or JSON format may be a string and may be specified in dotted notation. | integer |

--- a/docs/calicoctl/resources/policy.md
+++ b/docs/calicoctl/resources/policy.md
@@ -27,20 +27,20 @@ spec:
       tag: footag
       net: 10.0.0.0/16
       selector: type=='application'
-      ports: 1234,10:20
+      ports: [1234,"10:20"]
       "!tag": bartag
       "!net": 10.1.0.0/16
       "!selector": type=='database'
-      "!ports": 1050
+      "!ports": [1050]
     destination:
       tag: alphatag
       net: 10.2.0.0/16
       selector: type=='application'
-      ports: 100:200
+      ports: ["100:200"]
       "!tag": type=='bananas'
       "!net": 10.3.0.0/16
       "!selector": type=='apples'
-      "!ports": 1050:110
+      "!ports": ["1050:110"]
   egress:
   - action: allow
     source:

--- a/docs/calicoctl/resources/profile.md
+++ b/docs/calicoctl/resources/profile.md
@@ -27,20 +27,20 @@ spec:
       tag: group=='production'
       net: 10.0.0.0/16
       selector: type=='application'
-      ports: 1234,10:20
+      ports: [1234,"10:20"]
       "!tag": bartag
       "!net": 10.1.0.0/16
       "!selector": type=='database'
-      "!ports": 1050
+      "!ports": [1050]
     destination:
       tag: alphatag
       net: 10.2.0.0/16
       selector: type=='application'
-      ports: 100:200
+      ports: ["100:200"]
       "!tag": type=='bananas'
       "!net": 10.3.0.0/16
       "!selector": type=='apples'
-      "!ports": 1050:110
+      "!ports": ["1050:110"]
   egress:
   - action: allow
     source:

--- a/lib/api/bgppeer.go
+++ b/lib/api/bgppeer.go
@@ -17,6 +17,7 @@ package api
 import (
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/scope"
 )
 
@@ -53,7 +54,7 @@ type BGPPeerMetadata struct {
 // BGPPeerSpec contains the specification for a BGPPeer resource.
 type BGPPeerSpec struct {
 	// The AS Number of the peer.
-	ASNumber int `json:"asNumber" validate:"asn"`
+	ASNumber numorstring.ASNumber `json:"asNumber"`
 }
 
 // NewBGPPeer creates a new (zeroed) BGPPeer struct with the TypeMetadata initialised to the current

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -144,7 +144,7 @@ func (c *EtcdClient) Delete(d *model.KVPair) error {
 	log.Infof("Delete Key: %s", key)
 	_, err = c.etcdKeysAPI.Delete(context.Background(), key, etcdDeleteOpts)
 	if err != nil {
-		return err
+		return convertEtcdError(err, d.Key)
 	}
 
 	// If there are parents to be deleted, delete these as well provided there

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/scope"
 )
 
@@ -154,6 +155,6 @@ func (options BGPPeerListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type BGPPeer struct {
-	PeerIP net.IP `json:"ip"`
-	ASNum  int    `json:"as_num"`
+	PeerIP net.IP               `json:"ip"`
+	ASNum  numorstring.ASNumber `json:"as_num"`
 }

--- a/lib/backend/model/hostip.go
+++ b/lib/backend/model/hostip.go
@@ -16,9 +16,10 @@ package model
 
 import (
 	"fmt"
-	"github.com/projectcalico/libcalico-go/lib/net"
 	"reflect"
 	"regexp"
+
+	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 var (

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -19,10 +19,11 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/projectcalico/libcalico-go/lib/net"
 	net2 "net"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // RawString is used a value type to indicate that the value is a bare non-JSON string

--- a/lib/backend/model/rule_test.go
+++ b/lib/backend/model/rule_test.go
@@ -35,12 +35,13 @@ var icmpProto = numorstring.ProtocolFromString("icmp")
 var intProto = numorstring.ProtocolFromInt(123)
 var icmpType = 10
 var icmpCode = 6
+var portRange, _ = numorstring.PortFromRange(10, 20)
 var ports = []numorstring.Port{
-	numorstring.PortFromInt(1234),
-	numorstring.PortFromRange(10, 20),
+	numorstring.SinglePort(1234),
+	portRange,
 }
 var ports2 = []numorstring.Port{
-	numorstring.PortFromInt(4567),
+	numorstring.SinglePort(4567),
 }
 var _, cidr, _ = net.ParseCIDR("10.0.0.0/16")
 

--- a/lib/client/rule.go
+++ b/lib/client/rule.go
@@ -85,20 +85,26 @@ func ruleAPIToBackend(ar api.Rule) model.Rule {
 
 // ruleBackendToAPI convert a Backend Rule structure to an API Rule structure.
 func ruleBackendToAPI(br model.Rule) api.Rule {
-	return api.Rule{
-		Action:    ruleActionBackendToAPI(br.Action),
-		IPVersion: br.IPVersion,
-		Protocol:  br.Protocol,
-		ICMP: &api.ICMPFields{
+	var icmp, notICMP *api.ICMPFields
+	if br.ICMPCode != nil || br.ICMPType != nil {
+		icmp = &api.ICMPFields{
 			Code: br.ICMPCode,
 			Type: br.ICMPType,
-		},
-		NotProtocol: br.NotProtocol,
-		NotICMP: &api.ICMPFields{
+		}
+	}
+	if br.NotICMPCode != nil || br.NotICMPType != nil {
+		notICMP = &api.ICMPFields{
 			Code: br.NotICMPCode,
 			Type: br.NotICMPType,
-		},
-
+		}
+	}
+	return api.Rule{
+		Action:      ruleActionBackendToAPI(br.Action),
+		IPVersion:   br.IPVersion,
+		Protocol:    br.Protocol,
+		ICMP:        icmp,
+		NotProtocol: br.NotProtocol,
+		NotICMP:     notICMP,
 		Source: api.EntityRule{
 			Tag:         br.SrcTag,
 			Net:         br.SrcNet,

--- a/lib/numorstring/asnumber.go
+++ b/lib/numorstring/asnumber.go
@@ -23,6 +23,8 @@ import (
 
 type ASNumber uint32
 
+// ASNumberFromString creates an ASNumber struct from a string value.  The
+// string value may simply be a number or may be the ASN in dotted notation.
 func ASNumberFromString(s string) (ASNumber, error) {
 	if num, err := strconv.ParseUint(s, 10, 32); err == nil {
 		return ASNumber(num), nil
@@ -38,7 +40,7 @@ func ASNumberFromString(s string) (ASNumber, error) {
 	} else if num2, err := strconv.ParseUint(parts[1], 10, 16); err != nil {
 		return 0, errors.New("invalid AS Number format")
 	} else {
-		return ASNumber((num2 << 16) + num1), nil
+		return ASNumber((num1 << 16) + num2), nil
 	}
 }
 

--- a/lib/numorstring/asnumber.go
+++ b/lib/numorstring/asnumber.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numorstring
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+type ASNumber uint32
+
+func ASNumberFromString(s string) (ASNumber, error) {
+	if num, err := strconv.ParseUint(s, 10, 32); err == nil {
+		return ASNumber(num), nil
+	}
+
+	parts := strings.Split(s, ".")
+	if len(parts) != 2 {
+		return 0, errors.New("invalid AS Number format")
+	}
+
+	if num1, err := strconv.ParseUint(parts[0], 10, 16); err != nil {
+		return 0, errors.New("invalid AS Number format")
+	} else if num2, err := strconv.ParseUint(parts[1], 10, 16); err != nil {
+		return 0, errors.New("invalid AS Number format")
+	} else {
+		return ASNumber((num2 << 16) + num1), nil
+	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaller uinterface.
+func (a *ASNumber) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, (*uint32)(a)); err == nil {
+		return nil
+	} else {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+
+		if v, err := ASNumberFromString(s); err != nil {
+			return err
+		} else {
+			*a = v
+			return nil
+		}
+	}
+}
+
+// String returns the string value, or the Itoa of the uint value.
+func (a ASNumber) String() string {
+	return strconv.FormatUint(uint64(a), 10)
+}

--- a/lib/numorstring/doc.go
+++ b/lib/numorstring/doc.go
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 /*
-Package numorstring implements a set of type definitions that represent either a
-number or a string.  In a JSON/YAML representation each type is a single field,
-but the marshalling/unmarshalling deals with 3 fields in each type struct, one
-indicating the type, a string value (for string type), and a numerical value
-(for number type).
+Package numorstring implements a set of type definitions that in YAML or JSON
+format may be represented by either a number or a string.
 */
 package numorstring

--- a/lib/numorstring/numorstring_test.go
+++ b/lib/numorstring/numorstring_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numorstring_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+func init() {
+
+	asNumberType := reflect.TypeOf(numorstring.ASNumber(0))
+	protocolType := reflect.TypeOf(numorstring.Protocol{})
+	portType := reflect.TypeOf(numorstring.Port{})
+
+	// Perform tests of JSON unmarshaling of the various field types.
+	DescribeTable("NumOrStringJSONUnmarshaling",
+		func(jtext string, typ reflect.Type, expected interface{}) {
+			new := reflect.New(typ)
+			err := json.Unmarshal([]byte(jtext), new.Interface())
+			if err == nil {
+				Expect(expected).To(Equal(new.Elem().Interface()),
+					"expected value not same as json unmarshalled value")
+			} else {
+				Expect(expected).To(BeNil(),
+					"expected json unmarshal to error")
+			}
+		},
+		// ASNumber tests.
+		Entry("should accept 0 AS number as int", "0", asNumberType, numorstring.ASNumber(0)),
+		Entry("should accept 4294967295 AS number as int", "4294967295", asNumberType, numorstring.ASNumber(4294967295)),
+		Entry("should accept 0 AS number as string", "\"0\"", asNumberType, numorstring.ASNumber(0)),
+		Entry("should accept 4294967295 AS number as string", "\"4294967295\"", asNumberType, numorstring.ASNumber(4294967295)),
+		Entry("should accept 1.10 AS number as string", "\"1.10\"", asNumberType, numorstring.ASNumber(65546)),
+		Entry("should accept 00.00 AS number as string", "\"00.00\"", asNumberType, numorstring.ASNumber(0)),
+		Entry("should accept 00.01 AS number as string", "\"00.01\"", asNumberType, numorstring.ASNumber(1)),
+		Entry("should accept 65535.65535 AS number as string", "\"65535.65535\"", asNumberType, numorstring.ASNumber(4294967295)),
+		Entry("should reject 1.1.1 AS number as string", "\"1.1.1\"", asNumberType, nil),
+		Entry("should reject 65536.65535 AS number as string", "\"65536.65535\"", asNumberType, nil),
+		Entry("should reject 65535.65536 AS number as string", "\"65535.65536\"", asNumberType, nil),
+		Entry("should reject 0.-1 AS number as string", "\"0.-1\"", asNumberType, nil),
+		Entry("should reject -1 AS number as int", "-1", asNumberType, nil),
+		Entry("should reject 4294967296 AS number as int", "4294967296", asNumberType, nil),
+
+		// Port tests.
+		Entry("should accept 0 port as int", "0", portType, numorstring.SinglePort(0)),
+		Entry("should accept 65535 port as int", "65535", portType, numorstring.SinglePort(65535)),
+		Entry("should accept 0:65535 port range as string", "\"0:65535\"", portType, portFromRange(0, 65535)),
+		Entry("should accept 1:10 port range as string", "\"1:10\"", portType, portFromRange(1, 10)),
+		Entry("should reject -1 port as int", "-1", portType, nil),
+		Entry("should reject 65536 port as int", "65536", portType, nil),
+		Entry("should reject 0:65536 port range as string", "\"0:65536\"", portType, nil),
+		Entry("should reject -1:65535 port range as string", "\"-1:65535\"", portType, nil),
+		Entry("should reject 10:1 port range as string", "\"10:1\"", portType, nil),
+		Entry("should reject 1:2:3 port range as string", "\"1:2:3\"", portType, nil),
+		Entry("should reject bad string", "\"1:2", portType, nil),
+
+		// Protocol tests.  Invalid integer values will be stored as strings.
+		Entry("should accept 0 protocol as int", "0", protocolType, numorstring.ProtocolFromInt(0)),
+		Entry("should accept 255 protocol as int", "255", protocolType, numorstring.ProtocolFromInt(255)),
+		Entry("should accept tcp protocol as string", "\"tcp\"", protocolType, numorstring.ProtocolFromString("tcp")),
+		Entry("should accept tcp protocol as string", "\"tcp\"", protocolType, numorstring.ProtocolFromString("tcp")),
+		Entry("should accept 0 protocol as string", "\"0\"", protocolType, numorstring.ProtocolFromInt(0)),
+		Entry("should accept 0 protocol as string", "\"255\"", protocolType, numorstring.ProtocolFromInt(255)),
+		Entry("should accept 256 protocol as string", "\"256\"", protocolType, numorstring.ProtocolFromString("256")),
+		Entry("should reject bad string", "\"25", protocolType, nil),
+	)
+
+	// Perform tests of JSON marshaling of the various field types.
+	DescribeTable("NumOrStringJSONMarshaling",
+		func(field interface{}, jtext string) {
+			b, err := json.Marshal(field)
+			if err == nil {
+				Expect(jtext).To(Equal(string(b)),
+					"expected json not same as marshalled value")
+			} else {
+				Expect(jtext).To(Equal(""),
+					"expected json marshal to error")
+			}
+		},
+		// ASNumber tests.
+		Entry("should marshal ASN of 0", numorstring.ASNumber(0), "0"),
+		Entry("should marshal ASN of 4294967295", numorstring.ASNumber(4294967295), "4294967295"),
+
+		// Port tests.
+		Entry("should marshal port of 0", numorstring.SinglePort(0), "0"),
+		Entry("should marshal port of 65535", portFromRange(65535, 65535), "65535"),
+		Entry("should marshal port of 10", portFromString("10"), "10"),
+		Entry("should marshal port range of 10:20", portFromRange(10, 20), "\"10:20\""),
+		Entry("should marshal port range of 20:30", portFromRange(20, 30), "\"20:30\""),
+
+		// Protocol tests.
+		Entry("should marshal protocol of 0", numorstring.ProtocolFromInt(0), "0"),
+		Entry("should marshal protocol of udp", numorstring.ProtocolFromString("udp"), "\"udp\""),
+	)
+
+	// Perform tests of JSON marshaling of the various field types.
+	DescribeTable("NumOrStringJSONMarshaling",
+		func(field interface{}, jtext string) {
+			b, err := json.Marshal(field)
+			if err == nil {
+				Expect(jtext).To(Equal(string(b)),
+					"expected json not same as marshalled value")
+			} else {
+				Expect(jtext).To(Equal(""),
+					"expected json marshal to error")
+			}
+		},
+		// ASNumber tests.
+		Entry("should marshal ASN of 0", numorstring.ASNumber(0), "0"),
+		Entry("should marshal ASN of 4294967295", numorstring.ASNumber(4294967295), "4294967295"),
+
+		// Port tests.
+		Entry("should marshal port of 0", numorstring.SinglePort(0), "0"),
+		Entry("should marshal port of 65535", portFromRange(65535, 65535), "65535"),
+		Entry("should marshal port of 10", portFromString("10"), "10"),
+		Entry("should marshal port range of 10:20", portFromRange(10, 20), "\"10:20\""),
+		Entry("should marshal port range of 20:30", portFromRange(20, 30), "\"20:30\""),
+
+		// Protocol tests.
+		Entry("should marshal protocol of 0", numorstring.ProtocolFromInt(0), "0"),
+		Entry("should marshal protocol of udp", numorstring.ProtocolFromString("udp"), "\"udp\""),
+	)
+
+	// Perform tests of Stringer interface various field types.
+	DescribeTable("NumOrStringStringify",
+		func(field interface{}, s string) {
+			a := fmt.Sprint(field)
+			Expect(a).To(Equal(s),
+				"expected String() value to match")
+		},
+		// ASNumber tests.
+		Entry("should stringify ASN of 0", numorstring.ASNumber(0), "0"),
+		Entry("should stringify ASN of 4294967295", numorstring.ASNumber(4294967295), "4294967295"),
+
+		// Port tests.
+		Entry("should stringify port of 20", numorstring.SinglePort(20), "20"),
+		Entry("should stringify port range of 10:20", portFromRange(10, 20), "10:20"),
+
+		// Protocol tests.
+		Entry("should stringify protocol of 0", numorstring.ProtocolFromInt(0), "0"),
+		Entry("should stringify protocol of udp", numorstring.ProtocolFromString("udp"), "udp"),
+	)
+
+	// Perform tests of Protocols supporting ports.
+	DescribeTable("NumOrStringProtocolsSupportingPorts",
+		func(protocol numorstring.Protocol, supportsPorts bool) {
+			Expect(protocol.SupportsPorts()).To(Equal(supportsPorts),
+				"expected protocol port support to match")
+		},
+		// Protocol tests.
+		Entry("protocol 6 supports ports", numorstring.ProtocolFromInt(6), true),
+		Entry("protocol 17 supports ports", numorstring.ProtocolFromInt(17), true),
+		Entry("protocol udp supports ports", numorstring.ProtocolFromString("udp"), true),
+		Entry("protocol udp supports ports", numorstring.ProtocolFromString("tcp"), true),
+		Entry("protocol foo does not support ports", numorstring.ProtocolFromString("foo"), false),
+		Entry("protocol 2 does not support ports", numorstring.ProtocolFromInt(2), false),
+	)
+}
+
+func portFromRange(minPort, maxPort uint16) numorstring.Port {
+	p, _ := numorstring.PortFromRange(minPort, maxPort)
+	return p
+}
+
+func portFromString(s string) numorstring.Port {
+	p, _ := numorstring.PortFromString(s)
+	return p
+}

--- a/lib/numorstring/port.go
+++ b/lib/numorstring/port.go
@@ -27,10 +27,12 @@ type Port struct {
 	MaxPort uint16
 }
 
+// SinglePort creates a Port struct representing a single port.
 func SinglePort(port uint16) Port {
 	return Port{port, port}
 }
 
+// PortFromRange creates a Port struct representing a range of ports.
 func PortFromRange(minPort, maxPort uint16) (Port, error) {
 	port := Port{minPort, maxPort}
 	if minPort > maxPort {
@@ -39,6 +41,8 @@ func PortFromRange(minPort, maxPort uint16) (Port, error) {
 	return port, nil
 }
 
+// PortFromString creates a Port struct from its string representation.  A port
+// may either be single value "1234" or a range of values "100:200".
 func PortFromString(s string) (Port, error) {
 	if num, err := strconv.ParseUint(s, 10, 16); err == nil {
 		return SinglePort(uint16(num)), nil

--- a/lib/numorstring/port.go
+++ b/lib/numorstring/port.go
@@ -14,29 +14,92 @@
 
 package numorstring
 
-import "fmt"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 type Port struct {
-	Int32OrString
+	MinPort uint16
+	MaxPort uint16
 }
 
-func PortFromInt(p int32) Port {
-	return Port{Int32OrString{
-		Type:   NumOrStringNum,
-		NumVal: p,
-	}}
+func SinglePort(port uint16) Port {
+	return Port{port, port}
 }
 
-func PortFromRange(from, to int32) Port {
-	return Port{Int32OrString{
-		Type:   NumOrStringString,
-		StrVal: fmt.Sprintf("%v:%v", from, to),
-	}}
+func PortFromRange(minPort, maxPort uint16) (Port, error) {
+	port := Port{minPort, maxPort}
+	if minPort > maxPort {
+		return port, errors.New("minimum port number is greater than maximum port number in port range")
+	}
+	return port, nil
 }
 
-func PortFromString(p string) Port {
-	return Port{Int32OrString{
-		Type:   NumOrStringString,
-		StrVal: p,
-	}}
+func PortFromString(s string) (Port, error) {
+	if num, err := strconv.ParseUint(s, 10, 16); err == nil {
+		return SinglePort(uint16(num)), nil
+	}
+
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return Port{}, errors.New("invalid port format")
+	}
+
+	if pmin, err := strconv.ParseUint(parts[0], 10, 16); err != nil {
+		return Port{}, errors.New("invalid minimum port number in range")
+	} else if pmax, err := strconv.ParseUint(parts[1], 10, 16); err != nil {
+		return Port{}, errors.New("invalid maximum port number in range")
+	} else {
+		return PortFromRange(uint16(pmin), uint16(pmax))
+	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (p *Port) UnmarshalJSON(b []byte) error {
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+
+		if v, err := PortFromString(s); err != nil {
+			return err
+		} else {
+			*p = v
+			return nil
+		}
+	}
+
+	// It's not a string, it must be a single int.
+	var i uint16
+	if err := json.Unmarshal(b, &i); err != nil {
+		return err
+	}
+	v := SinglePort(i)
+	*p = v
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (p Port) MarshalJSON() ([]byte, error) {
+	if p.MinPort == p.MaxPort {
+		return json.Marshal(p.MinPort)
+	} else {
+		return json.Marshal(p.String())
+	}
+}
+
+// String returns the string value.  If the min and max port are the same
+// this returns a single string representation of the port number, otherwise
+// if returns a colon separated range of ports.
+func (p Port) String() string {
+	if p.MinPort == p.MaxPort {
+		return strconv.FormatUint(uint64(p.MinPort), 10)
+	} else {
+		return fmt.Sprintf("%d:%d", p.MinPort, p.MaxPort)
+	}
 }

--- a/lib/numorstring/protocol.go
+++ b/lib/numorstring/protocol.go
@@ -14,23 +14,42 @@
 
 package numorstring
 
-type Protocol struct {
-	Int32OrString
-}
+type Protocol Uint8OrString
 
-func ProtocolFromInt(p int32) Protocol {
-	return Protocol{
-		Int32OrString{Type: NumOrStringNum, NumVal: p},
-	}
+func ProtocolFromInt(p uint8) Protocol {
+	return Protocol(
+		Uint8OrString{Type: NumOrStringNum, NumVal: p},
+	)
 }
 
 func ProtocolFromString(p string) Protocol {
-	return Protocol{
-		Int32OrString{Type: NumOrStringString, StrVal: p},
-	}
+	return Protocol(
+		Uint8OrString{Type: NumOrStringString, StrVal: p},
+	)
 }
 
-// SupportsPorts returns whether this protocol supports ports.  This returns true if
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (p *Protocol) UnmarshalJSON(b []byte) error {
+	return (*Uint8OrString)(p).UnmarshalJSON(b)
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (p Protocol) MarshalJSON() ([]byte, error) {
+	return Uint8OrString(p).MarshalJSON()
+}
+
+// String returns the string value, or the Itoa of the int value.
+func (p Protocol) String() string {
+	return (Uint8OrString)(p).String()
+}
+
+// NumValue returns the NumVal if type Int, or if
+// it is a String, will attempt a conversion to int.
+func (p Protocol) NumValue() (uint8, error) {
+	return (Uint8OrString)(p).NumValue()
+}
+
+// SupportsProtocols returns whether this protocol supports ports.  This returns true if
 // the numerical or string verion of the protocol indicates TCP (6) or UDP (17).
 func (p Protocol) SupportsPorts() bool {
 	num, err := p.NumValue()

--- a/lib/numorstring/protocol.go
+++ b/lib/numorstring/protocol.go
@@ -16,12 +16,14 @@ package numorstring
 
 type Protocol Uint8OrString
 
+// ProtocolFromInt creates a Protocol struct from an integer value.
 func ProtocolFromInt(p uint8) Protocol {
 	return Protocol(
 		Uint8OrString{Type: NumOrStringNum, NumVal: p},
 	)
 }
 
+// ProtocolFromString creates a Protocol struct from a string value.
 func ProtocolFromString(p string) Protocol {
 	return Protocol(
 		Uint8OrString{Type: NumOrStringString, StrVal: p},

--- a/lib/numorstring/uint8orstring.go
+++ b/lib/numorstring/uint8orstring.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 208 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,22 +19,21 @@ import (
 	"strconv"
 )
 
-// Int32OrString is a type that can hold an int32 or a string.  When used in
+// UInt8OrString is a type that can hold an uint8 or a string.  When used in
 // JSON or YAML marshalling and unmarshalling, it produces or consumes the
 // inner type.  This allows you to have, for example, a JSON field that can
 // accept a name or number.
-type Int32OrString struct {
+type Uint8OrString struct {
 	Type   NumOrStringType
-	NumVal int32
+	NumVal uint8
 	StrVal string
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.
-func (i *Int32OrString) UnmarshalJSON(b []byte) error {
+func (i *Uint8OrString) UnmarshalJSON(b []byte) error {
 	if b[0] == '"' {
 		i.Type = NumOrStringString
-		err := json.Unmarshal(b, &i.StrVal)
-		if err != nil {
+		if err := json.Unmarshal(b, &i.StrVal); err != nil {
 			return err
 		}
 
@@ -52,30 +51,29 @@ func (i *Int32OrString) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &i.NumVal)
 }
 
-// String returns the string value, or the Itoa of the int value.
-func (i *Int32OrString) String() string {
-	if i.Type == NumOrStringString {
-		return i.StrVal
-	}
-	return strconv.Itoa(int(i.NumVal))
-}
-
-// NumValue returns the NumVal if type Int, or if
-// it is a String, will attempt a conversion to int.
-func (i *Int32OrString) NumValue() (int32, error) {
-	if i.Type == NumOrStringString {
-		num, err := strconv.ParseInt(i.StrVal, 10, 32)
-		return int32(num), err
-	}
-	return i.NumVal, nil
-}
-
 // MarshalJSON implements the json.Marshaller interface.
-func (i Int32OrString) MarshalJSON() ([]byte, error) {
-	num, err := i.NumValue()
-	if err != nil {
+func (i Uint8OrString) MarshalJSON() ([]byte, error) {
+	if num, err := i.NumValue(); err == nil {
 		return json.Marshal(num)
 	} else {
 		return json.Marshal(i.StrVal)
 	}
+}
+
+// String returns the string value, or the Itoa of the int value.
+func (i Uint8OrString) String() string {
+	if i.Type == NumOrStringString {
+		return i.StrVal
+	}
+	return strconv.FormatUint(uint64(i.NumVal), 10)
+}
+
+// NumValue returns the NumVal if type Int, or if
+// it is a String, will attempt a conversion to int.
+func (i Uint8OrString) NumValue() (uint8, error) {
+	if i.Type == NumOrStringString {
+		num, err := strconv.ParseInt(i.StrVal, 10, 8)
+		return uint8(num), err
+	}
+	return i.NumVal, nil
 }

--- a/lib/numorstring/uint8orstring.go
+++ b/lib/numorstring/uint8orstring.go
@@ -1,4 +1,4 @@
-// Copyright (c) 208 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,17 +32,18 @@ type Uint8OrString struct {
 // UnmarshalJSON implements the json.Unmarshaller interface.
 func (i *Uint8OrString) UnmarshalJSON(b []byte) error {
 	if b[0] == '"' {
-		i.Type = NumOrStringString
-		if err := json.Unmarshal(b, &i.StrVal); err != nil {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
 			return err
 		}
 
-		// If this string is actually a number then tweak to return
-		// a number type.
-		num, err := i.NumValue()
+		num, err := strconv.ParseUint(s, 10, 8)
 		if err == nil {
 			i.Type = NumOrStringNum
-			i.NumVal = num
+			i.NumVal = uint8(num)
+		} else {
+			i.Type = NumOrStringString
+			i.StrVal = s
 		}
 
 		return nil
@@ -72,7 +73,7 @@ func (i Uint8OrString) String() string {
 // it is a String, will attempt a conversion to int.
 func (i Uint8OrString) NumValue() (uint8, error) {
 	if i.Type == NumOrStringString {
-		num, err := strconv.ParseInt(i.StrVal, 10, 8)
+		num, err := strconv.ParseUint(i.StrVal, 10, 8)
 		return uint8(num), err
 	}
 	return i.NumVal, nil

--- a/lib/selector/parser/stringset_test.go
+++ b/lib/selector/parser/stringset_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/selector/parser"
 
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -160,7 +160,7 @@ func validateProtocol(v *validator.Validate, structLevel *validator.StructLevel)
 	// The protocol field may be an integer 1-255 (i.e. not 0), or one of the valid protocol
 	// names.
 	if num, err := p.NumValue(); err == nil {
-		if (num == 0) {
+		if num == 0 {
 			structLevel.ReportError(reflect.ValueOf(p.NumVal), "Protocol", "protocol", "protocol number invalid")
 		}
 	} else if !protocolRegex.MatchString(p.String()) {

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -17,8 +17,6 @@ package validator
 import (
 	"reflect"
 	"regexp"
-	"strconv"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
@@ -53,7 +51,6 @@ func init() {
 	registerFieldValidator("selector", validateSelector)
 	registerFieldValidator("tag", validateTag)
 	registerFieldValidator("labels", validateLabels)
-	registerFieldValidator("asn", validateASNum)
 	registerFieldValidator("scopeglobalornode", validateScopeGlobalOrNode)
 	registerFieldValidator("ipversion", validateIPVersion)
 
@@ -150,12 +147,6 @@ func validateLabels(v *validator.Validate, topStruct reflect.Value, currentStruc
 	return true
 }
 
-func validateASNum(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
-	f := field.Interface().(int)
-	log.Debugf("Validate AS number: %v", f)
-	return f >= 0 && f <= 4294967295
-}
-
 func validateScopeGlobalOrNode(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
 	f := field.Interface().(scope.Scope)
 	log.Debugf("Validate scope: %v", f)
@@ -166,9 +157,10 @@ func validateProtocol(v *validator.Validate, structLevel *validator.StructLevel)
 	p := structLevel.CurrentStruct.Interface().(numorstring.Protocol)
 	log.Debugf("Validate protocol: %v %s %d", p.Type, p.StrVal, p.NumVal)
 
-	// The protocol field may be an integer 1-254, or one of the valid protocol names.
+	// The protocol field may be an integer 1-255 (i.e. not 0), or one of the valid protocol
+	// names.
 	if num, err := p.NumValue(); err == nil {
-		if (num < 1) || (num > 255) {
+		if (num == 0) {
 			structLevel.ReportError(reflect.ValueOf(p.NumVal), "Protocol", "protocol", "protocol number invalid")
 		}
 	} else if !protocolRegex.MatchString(p.String()) {
@@ -179,39 +171,11 @@ func validateProtocol(v *validator.Validate, structLevel *validator.StructLevel)
 func validatePort(v *validator.Validate, structLevel *validator.StructLevel) {
 	p := structLevel.CurrentStruct.Interface().(numorstring.Port)
 
-	// A port may be specified either as a single port or a range of ports.  Port values are
-	// integers 0-65535.  A range of ports is specified as a string X:Y where X,Y are valid
-	// port values and X <= Y.
-	log.Debugf("Validate port: %v %s %v", p.Type, p.StrVal, p.NumVal)
-	if p.Type == numorstring.NumOrStringNum && ((p.NumVal < 0) || (p.NumVal > 65535)) {
-		structLevel.ReportError(reflect.ValueOf(p.NumVal), "Port", "port", "port number invalid")
-		return
-	} else if p.Type == numorstring.NumOrStringString {
-		ports := strings.Split(p.StrVal, ":")
-		if len(ports) > 2 {
-			structLevel.ReportError(reflect.ValueOf(p.StrVal), "Port", "port", "port range invalid")
-			return
-		}
-		first := 0
-		for _, port := range ports {
-			log.Debugf("Validate range, checking port %s", port)
-			num, err := strconv.Atoi(port)
-			if err != nil {
-				structLevel.ReportError(reflect.ValueOf(p.StrVal), "Port", "port", "port range invalid")
-				return
-			}
-
-			if num < 0 || num > 65535 {
-				structLevel.ReportError(reflect.ValueOf(p.StrVal), "Port", "port", "port number invalid")
-				return
-			}
-
-			if num < first {
-				structLevel.ReportError(reflect.ValueOf(p.StrVal), "Port", "port", "port range invalid")
-				return
-			}
-			first = num
-		}
+	// Check that the port range is in the correct order.  The YAML parsing also checks this,
+	// but this protects against misuse of the programmatic API.
+	log.Debugf("Validate port: %s")
+	if p.MinPort > p.MaxPort {
+		structLevel.ReportError(reflect.ValueOf(p.MaxPort), "Port", "port", "port range invalid")
 	}
 }
 

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -125,11 +125,6 @@ func init() {
 		Entry("should reject . in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid.Intface"}, false),
 		Entry("should reject : in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid:Intface"}, false),
 
-		// (API) AS number.
-		Entry("should accept the min value AS number", api.BGPPeerSpec{ASNumber: 0}, true),
-		Entry("should accept the max value AS number", api.BGPPeerSpec{ASNumber: 4294967295}, true),
-		Entry("should reject an AS number too high", api.BGPPeerSpec{ASNumber: 4294967296}, false),
-
 		// (API) Scope
 		Entry("should accept no scope", api.BGPPeerMetadata{}, true),
 		Entry("should accept scope global", api.BGPPeerMetadata{Scope: scope.Global}, true),
@@ -145,32 +140,14 @@ func init() {
 		Entry("should accept protocol udplite", protocolFromString("udplite"), true),
 		Entry("should accept protocol 1 as int", protocolFromInt(1), true),
 		Entry("should accept protocol 255 as int", protocolFromInt(255), true),
+		Entry("should accept protocol 255 as string", protocolFromString("255"), false),
 		Entry("should accept protocol 1 as string", protocolFromString("1"), true),
-		Entry("should accept protocol 255 as string", protocolFromString("255"), true),
 		Entry("should reject protocol 0 as int", protocolFromInt(0), false),
-		Entry("should reject protocol 256 as int", protocolFromString("256"), false),
+		Entry("should reject protocol 256 as string", protocolFromString("256"), false),
 		Entry("should reject protocol 0 as string", protocolFromString("0"), false),
-		Entry("should reject protocol 256 as string", protocolFromInt(256), false),
 		Entry("should reject protocol tcpfoo", protocolFromString("tcpfoo"), false),
 		Entry("should reject protocol footcp", protocolFromString("footcp"), false),
 		Entry("should reject protocol TCP", protocolFromString("TCP"), false),
-
-		// (API) Port
-		Entry("should accept min port number", numorstring.PortFromInt(0), true),
-		Entry("should accept max port number", numorstring.PortFromInt(65535), true),
-		Entry("should accept min port number as string", numorstring.PortFromString("0"), true),
-		Entry("should accept max port number as string", numorstring.PortFromString("65535"), true),
-		Entry("should accept valid port range", numorstring.PortFromRange(0, 60000), true),
-		Entry("should accept valid port range as string", numorstring.PortFromString("1:10"), true),
-		Entry("should accept valid port range length 0", numorstring.PortFromString("10:10"), true),
-		Entry("should reject port number too low", numorstring.PortFromInt(-1), false),
-		Entry("should accept port number too high", numorstring.PortFromInt(65536), false),
-		Entry("should reject port number too low as string", numorstring.PortFromString("-1"), false),
-		Entry("should accept port number too high as string", numorstring.PortFromString("65536"), false),
-		Entry("should reject port range 2nd < 1st", numorstring.PortFromRange(10, 1), false),
-		Entry("should reject port range too many values", numorstring.PortFromString("1:2:3"), false),
-		Entry("should reject port range dash not colon", numorstring.PortFromString("1-2"), false),
-		Entry("should reject port range contains letter", numorstring.PortFromString("a"), false),
 
 		// (API) IPNAT
 		Entry("should accept valid IPNAT IPv4",
@@ -304,7 +281,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromInt(6),
 				Source: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.PortFromInt(1)},
+					Ports: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, true),
 		Entry("should accept Rule with empty source ports and protocol type 7",
@@ -320,7 +297,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromInt(17),
 				Source: api.EntityRule{
-					NotPorts: []numorstring.Port{numorstring.PortFromInt(1)},
+					NotPorts: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, true),
 		Entry("should accept Rule with empty source !ports and protocol type 100",
@@ -336,7 +313,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.PortFromInt(1)},
+					Ports: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, true),
 		Entry("should accept Rule with empty dest ports and protocol type sctp",
@@ -360,7 +337,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromInt(7),
 				Source: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.PortFromInt(1)},
+					Ports: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, false),
 		Entry("should reject Rule with source !ports and protocol type 100",
@@ -368,7 +345,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromInt(100),
 				Source: api.EntityRule{
-					NotPorts: []numorstring.Port{numorstring.PortFromInt(1)},
+					NotPorts: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, false),
 		Entry("should reject Rule with dest ports and protocol type tcp",
@@ -376,7 +353,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("sctp"),
 				Destination: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.PortFromInt(1)},
+					Ports: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, false),
 		Entry("should reject Rule with dest !ports and protocol type udp",
@@ -384,7 +361,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("icmp"),
 				Destination: api.EntityRule{
-					NotPorts: []numorstring.Port{numorstring.PortFromInt(1)},
+					NotPorts: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, false),
 		Entry("should reject Rule with invalid source ports and protocol type tcp",
@@ -392,7 +369,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Source: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.PortFromString("foo")},
+					Ports: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with invalid source !ports and protocol type tcp",
@@ -400,7 +377,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Source: api.EntityRule{
-					NotPorts: []numorstring.Port{numorstring.PortFromString("foo")},
+					NotPorts: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with invalid dest ports and protocol type tcp",
@@ -408,7 +385,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.PortFromString("foo")},
+					Ports: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with invalid dest !ports and protocol type tcp",
@@ -416,7 +393,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
-					NotPorts: []numorstring.Port{numorstring.PortFromString("foo")},
+					NotPorts: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 	)
@@ -427,7 +404,7 @@ func protocolFromString(s string) *numorstring.Protocol {
 	return &p
 }
 
-func protocolFromInt(i int32) *numorstring.Protocol {
+func protocolFromInt(i uint8) *numorstring.Protocol {
 	p := numorstring.ProtocolFromInt(i)
 	return &p
 }

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -140,7 +140,7 @@ func init() {
 		Entry("should accept protocol udplite", protocolFromString("udplite"), true),
 		Entry("should accept protocol 1 as int", protocolFromInt(1), true),
 		Entry("should accept protocol 255 as int", protocolFromInt(255), true),
-		Entry("should accept protocol 255 as string", protocolFromString("255"), false),
+		Entry("should accept protocol 255 as string", protocolFromString("255"), true),
 		Entry("should accept protocol 1 as string", protocolFromString("1"), true),
 		Entry("should reject protocol 0 as int", protocolFromInt(0), false),
 		Entry("should reject protocol 256 as string", protocolFromString("256"), false),

--- a/test/all.yaml
+++ b/test/all.yaml
@@ -92,7 +92,7 @@
     hostname: fred
     peerIP: 1.3.5.6
   spec:
-    asNumber: 145794
+    asNumber: "1.1"
 - apiVersion: v1
   kind: pool
   metadata:


### PR DESCRIPTION
Shaun can you review?

Tentatively Fixes #173 
by changing the ASNumber field to use an int64 rather than an int.

Fixes #137 

Fixes some bugs Lance was seeing with port and protocol not being marshalled to JSON correctly (incorrect logic in the Int32OrString type)

Note that I defined ASNumber as an num or string type.  Reason for this is we may eventually want to support dotted AS notation at some point and it feels to me that the format of the value we store in the datastore should match the format of the value we retrieve from the datastore.  WDYT - should we just store as an int32 and be done with it?  If we leave as is, I need to update some docs.

Note that I've limited the size of the various ints we use for the protocol / port and asNumber.  I could just take them all uint64 or int64.  WDYT?   I assume this will have knock on effects with your code.

Also - it feels the current representation of a port as a string or int may not be ideal -  I wonder if I should scrap the string and store as a range of ints?  WDYT?