### PR TITLE
Common kv value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ bin
 release
 *.coverprofile
 vendor
-﻿calicoctl_build_container.created
+calicoctl_build_container.created

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -113,7 +113,7 @@ func (c *ModelAdaptor) Get(k model.Key) (*model.KVPair, error) {
 			p.Labels = l.Value.(map[string]string)
 		}
 		if r, err = c.client.Get(model.ProfileRulesKey{pk}); err == nil {
-			p.Rules = r.Value.(model.ProfileRules)
+			p.Rules = *r.Value.(*model.ProfileRules)
 		}
 		return &d, nil
 	}
@@ -134,7 +134,7 @@ func (c *ModelAdaptor) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
 // These separate KVPairs are used to write three separate objects that make up
 // a single profile.
 func toTagsLabelsRules(d *model.KVPair) (t, l, r *model.KVPair) {
-	p := d.Value.(model.Profile)
+	p := d.Value.(*model.Profile)
 	pk := d.Key.(model.ProfileKey)
 
 	t = &model.KVPair{
@@ -148,7 +148,7 @@ func toTagsLabelsRules(d *model.KVPair) (t, l, r *model.KVPair) {
 	}
 	r = &model.KVPair{
 		Key:   model.ProfileRulesKey{pk},
-		Value: p.Rules,
+		Value: &p.Rules,
 	}
 
 	// Fix up tags and labels so to be empty values rather than nil.  Felix does not

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -16,7 +16,6 @@ package etcd
 
 import (
 	goerrors "errors"
-	"reflect"
 	"strings"
 
 	"time"
@@ -172,16 +171,12 @@ func (c *EtcdClient) Get(k model.Key) (*model.KVPair, error) {
 		return nil, err
 	}
 	log.Infof("Get Key: %s", key)
-	if results, err := c.etcdKeysAPI.Get(context.Background(), key, etcdGetOpts); err != nil {
+	if r, err := c.etcdKeysAPI.Get(context.Background(), key, etcdGetOpts); err != nil {
 		return nil, convertEtcdError(err, k)
-	} else if object, err := model.ParseValue(k, []byte(results.Node.Value)); err != nil {
+	} else if v, err := model.ParseValue(k, []byte(r.Node.Value)); err != nil {
 		return nil, err
 	} else {
-		if reflect.ValueOf(object).Kind() == reflect.Ptr {
-			// Unwrap any pointers.
-			object = reflect.ValueOf(object).Elem().Interface()
-		}
-		return &model.KVPair{Key: k, Value: object, Revision: results.Node.ModifiedIndex}, nil
+		return &model.KVPair{Key: k, Value: v, Revision: r.Node.ModifiedIndex}, nil
 	}
 }
 
@@ -256,12 +251,8 @@ func filterEtcdList(n *etcd.Node, l model.ListInterface) []*model.KVPair {
 			kvs = append(kvs, filterEtcdList(node, l)...)
 		}
 	} else if k := l.KeyFromDefaultPath(n.Key); k != nil {
-		if object, err := model.ParseValue(k, []byte(n.Value)); err == nil {
-			if reflect.ValueOf(object).Kind() == reflect.Ptr {
-				// Unwrap any pointers.
-				object = reflect.ValueOf(object).Elem().Interface()
-			}
-			do := &model.KVPair{Key: k, Value: object, Revision: n.ModifiedIndex}
+		if v, err := model.ParseValue(k, []byte(n.Value)); err == nil {
+			do := &model.KVPair{Key: k, Value: v, Revision: n.ModifiedIndex}
 			kvs = append(kvs, do)
 		}
 	}

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -71,8 +71,15 @@ type ListInterface interface {
 	KeyFromDefaultPath(key string) Key
 }
 
-// KVPair holds a typed key and value struct as well as datastore specific
+// KVPair holds a typed key and value object as well as datastore specific
 // revision information.
+//
+// The Value is dependent on the Key, but in general will be on of the following
+// types:
+// -  A pointer to a struct
+// -  A slice or map
+// -  A bare string, boolean value or IP address (i.e. without quotes, so not
+//    JSON format).
 type KVPair struct {
 	Key      Key
 	Value    interface{}

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -196,13 +196,13 @@ func (_ *ProfileListOptions) ListConvert(ds []*KVPair) []*KVPair {
 		if !ok {
 			log.Infof("Initialise profile %v", name)
 			pd = &KVPair{
-				Value: Profile{},
+				Value: &Profile{},
 				Key:   ProfileKey{Name: name},
 			}
 			profiles[name] = pd
 		}
 
-		p := pd.Value.(Profile)
+		p := pd.Value.(*Profile)
 		switch t := d.Value.(type) {
 		case []string: // must be tags #TODO should type these
 			log.Infof("Store tags %v", t)
@@ -211,9 +211,9 @@ func (_ *ProfileListOptions) ListConvert(ds []*KVPair) []*KVPair {
 		case map[string]string: // must be labels
 			log.Infof("Store labels %v", t)
 			p.Labels = t
-		case ProfileRules: // must be rules
+		case *ProfileRules: // must be rules
 			log.Infof("Store rules %v", t)
-			p.Rules = t
+			p.Rules = *t
 		default:
 			panic(fmt.Errorf("Unexpected type: %v", t))
 		}

--- a/lib/client/bgppeer.go
+++ b/lib/client/bgppeer.go
@@ -113,7 +113,7 @@ func (h *bgpPeers) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.BGPPeer{
+		Value: &model.BGPPeer{
 			PeerIP: ap.Metadata.PeerIP,
 			ASNum:  ap.Spec.ASNumber,
 		},
@@ -126,7 +126,7 @@ func (h *bgpPeers) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 // to an API BGPPeer structure.
 // This is part of the conversionHelper interface.
 func (h *bgpPeers) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	backendBGPPeer := d.Value.(model.BGPPeer)
+	backendBGPPeer := d.Value.(*model.BGPPeer)
 	backendBGPPeerKey := d.Key.(model.BGPPeerKey)
 
 	apiBGPPeer := api.NewBGPPeer()

--- a/lib/client/hostendpoint.go
+++ b/lib/client/hostendpoint.go
@@ -142,7 +142,7 @@ func (h *hostEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.KVPai
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.HostEndpoint{
+		Value: &model.HostEndpoint{
 			Labels: ah.Metadata.Labels,
 
 			Name:              ah.Spec.InterfaceName,
@@ -159,7 +159,7 @@ func (h *hostEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.KVPai
 // to an API HostEndpoint structure.
 // This is part of the conversionHelper interface.
 func (h *hostEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bh := d.Value.(model.HostEndpoint)
+	bh := d.Value.(*model.HostEndpoint)
 	bk := d.Key.(model.HostEndpointKey)
 
 	ips := bh.ExpectedIPv4Addrs

--- a/lib/client/ipam_block.go
+++ b/lib/client/ipam_block.go
@@ -54,7 +54,7 @@ var ipv6 ipVersion = ipVersion{
 // Wrap the backend AllocationBlock struct so that we can
 // attach methods to it.
 type allocationBlock struct {
-	model.AllocationBlock
+	*model.AllocationBlock
 }
 
 func newBlock(cidr cnet.IPNet) allocationBlock {
@@ -69,7 +69,7 @@ func newBlock(cidr cnet.IPNet) allocationBlock {
 		b.Unallocated[i] = i
 	}
 
-	return allocationBlock{b}
+	return allocationBlock{&b}
 }
 
 func (b *allocationBlock) autoAssign(

--- a/lib/client/ipam_block_reader_writer.go
+++ b/lib/client/ipam_block_reader_writer.go
@@ -131,7 +131,7 @@ func (rw blockReaderWriter) claimBlockAffinity(subnet cnet.IPNet, host string, c
 	log.Infof("Host %s claiming block affinity for %s", host, subnet)
 	obj := model.KVPair{
 		Key:   model.BlockAffinityKey{Host: host, CIDR: subnet},
-		Value: model.BlockAffinity{},
+		Value: &model.BlockAffinity{},
 	}
 	_, err := rw.client.backend.Create(&obj)
 
@@ -143,7 +143,7 @@ func (rw blockReaderWriter) claimBlockAffinity(subnet cnet.IPNet, host string, c
 	// Create the new block in the datastore.
 	o := model.KVPair{
 		Key:   model.BlockKey{block.CIDR},
-		Value: block.AllocationBlock,
+		Value: &block.AllocationBlock,
 	}
 	_, err = rw.client.backend.Create(&o)
 	if err != nil {
@@ -157,7 +157,7 @@ func (rw blockReaderWriter) claimBlockAffinity(subnet cnet.IPNet, host string, c
 			}
 
 			// Pull out the allocationBlock object.
-			b := allocationBlock{obj.Value.(model.AllocationBlock)}
+			b := allocationBlock{obj.Value.(*model.AllocationBlock)}
 
 			if b.HostAffinity != nil && *b.HostAffinity == host {
 				// Block has affinity to this host, meaning another
@@ -192,7 +192,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR cnet.IPN
 			log.Errorf("Error getting block %s: %s", blockCIDR.String(), err)
 			return err
 		}
-		b := allocationBlock{obj.Value.(model.AllocationBlock)}
+		b := allocationBlock{obj.Value.(*model.AllocationBlock)}
 
 		// Check that the block affinity matches the given affinity.
 		if b.HostAffinity != nil && *b.HostAffinity != host {
@@ -221,7 +221,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR cnet.IPN
 
 			// Pass back the original KVPair with the new
 			// block information so we can do a CAS.
-			obj.Value = b
+			obj.Value = &b
 			_, err = rw.client.backend.Update(obj)
 			if err != nil {
 				if _, ok := err.(errors.ErrorResourceUpdateConflict); ok {

--- a/lib/client/ipam_handle.go
+++ b/lib/client/ipam_handle.go
@@ -23,7 +23,7 @@ import (
 )
 
 type allocationHandle struct {
-	model.IPAMHandle
+	*model.IPAMHandle
 }
 
 func (h allocationHandle) incrementBlock(blockCidr net.IPNet, num int) int {

--- a/lib/client/ipam_test.go
+++ b/lib/client/ipam_test.go
@@ -184,7 +184,7 @@ func testIPAMReleaseIPs(inIP net.IP, poolSubnet []string, cleanEnv bool, assignI
 			testutils.CreateNewPool(*c, v, false, false, true)
 		}
 	}
-	ic := setupIPMAClient(cleanEnv)
+	ic := setupIPAMClient(cleanEnv)
 
 	if len(assignIP) != 0 {
 		err := ic.AssignIP(client.AssignIPArgs{
@@ -229,7 +229,7 @@ func testIPAMAssignIP(inIP net.IP, host string, poolSubnet []string, cleanEnv bo
 			testutils.CreateNewPool(*c, v, false, false, true)
 		}
 	}
-	ic := setupIPMAClient(cleanEnv)
+	ic := setupIPAMClient(cleanEnv)
 	outErr := ic.AssignIP(args)
 
 	if outErr != nil {
@@ -255,7 +255,7 @@ func testIPAMAutoAssign(inv4, inv6 int, host string, cleanEnv bool, poolSubnet [
 			testutils.CreateNewPool(*c, v, false, false, true)
 		}
 	}
-	ic := setupIPMAClient(cleanEnv)
+	ic := setupIPAMClient(cleanEnv)
 	v4, v6, outErr := ic.AutoAssign(args)
 
 	if outErr != nil {
@@ -267,7 +267,7 @@ func testIPAMAutoAssign(inv4, inv6 int, host string, cleanEnv bool, poolSubnet [
 
 // setupIPMAClient sets up a client, and returns IPAMInterface.
 // It also resets IPAM config if cleanEnv is true.
-func setupIPMAClient(cleanEnv bool) client.IPAMInterface {
+func setupIPAMClient(cleanEnv bool) client.IPAMInterface {
 	ac := api.ClientConfig{BackendType: etcdType, BackendConfig: &etcdConfig}
 
 	bc, err := client.New(ac)

--- a/lib/client/policy.go
+++ b/lib/client/policy.go
@@ -143,7 +143,7 @@ func (h *policies) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.Policy{
+		Value: &model.Policy{
 			Order:         ap.Spec.Order,
 			InboundRules:  rulesAPIToBackend(ap.Spec.IngressRules),
 			OutboundRules: rulesAPIToBackend(ap.Spec.EgressRules),
@@ -158,7 +158,7 @@ func (h *policies) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 // to an API Policy structure.
 // This is part of the conversionHelper interface.
 func (h *policies) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bp := d.Value.(model.Policy)
+	bp := d.Value.(*model.Policy)
 	bk := d.Key.(model.PolicyKey)
 
 	ap := api.NewPolicy()

--- a/lib/client/pool.go
+++ b/lib/client/pool.go
@@ -117,7 +117,7 @@ func (h *pools) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.Pool{
+		Value: &model.Pool{
 			CIDR:          ap.Metadata.CIDR,
 			IPIPInterface: ipipInterface,
 			Masquerade:    ap.Spec.NATOutgoing,
@@ -133,7 +133,7 @@ func (h *pools) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 // to an API Pool structure.
 // This is part of the conversionHelper interface.
 func (h *pools) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	backendPool := d.Value.(model.Pool)
+	backendPool := d.Value.(*model.Pool)
 
 	apiPool := api.NewPool()
 	apiPool.Metadata.CIDR = backendPool.CIDR

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -108,7 +108,7 @@ func (h *profiles) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.Profile{
+		Value: &model.Profile{
 			Rules: model.ProfileRules{
 				InboundRules:  rulesAPIToBackend(ap.Spec.IngressRules),
 				OutboundRules: rulesAPIToBackend(ap.Spec.EgressRules),
@@ -125,7 +125,7 @@ func (h *profiles) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 // to an API Profile structure.
 // This is part of the conversionHelper interface.
 func (h *profiles) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bp := d.Value.(model.Profile)
+	bp := d.Value.(*model.Profile)
 	bk := d.Key.(model.ProfileKey)
 
 	ap := api.NewProfile()

--- a/lib/client/tier.go
+++ b/lib/client/tier.go
@@ -113,7 +113,7 @@ func (h *tiers) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.Tier{
+		Value: &model.Tier{
 			Order: at.Spec.Order,
 		},
 	}
@@ -125,7 +125,7 @@ func (h *tiers) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 // to an API Tier structure.
 // This is part of the conversionHelper interface.
 func (h *tiers) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bt := d.Value.(model.Tier)
+	bt := d.Value.(*model.Tier)
 	bk := d.Key.(model.TierKey)
 
 	at := api.NewTier()

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -149,7 +149,7 @@ func (w *workloadEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.K
 
 	d := model.KVPair{
 		Key: k,
-		Value: model.WorkloadEndpoint{
+		Value: &model.WorkloadEndpoint{
 			Labels:      ah.Metadata.Labels,
 			State:       "active",
 			Name:        ah.Spec.InterfaceName,
@@ -171,7 +171,7 @@ func (w *workloadEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.K
 // to an API WorkloadEndpoint structure.
 // This is part of the conversionHelper interface.
 func (w *workloadEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bh := d.Value.(model.WorkloadEndpoint)
+	bh := d.Value.(*model.WorkloadEndpoint)
 	bk := d.Key.(model.WorkloadEndpointKey)
 
 	nets := bh.IPv4Nets

--- a/test/policy-icmp-bad.yaml
+++ b/test/policy-icmp-bad.yaml
@@ -51,10 +51,9 @@
     name: profile1
   spec:
     tags: [a, b, c, a1]
-    rules:
-      ingress:
-        - action: deny
-      egress:
-        - action: deny
+    ingress:
+    - action: deny
+    egress:
+    - action: deny
     labels:
       type: database

--- a/test/policy.yaml
+++ b/test/policy.yaml
@@ -52,10 +52,9 @@
     name: profile1
   spec:
     tags: [a, b, c, a1]
-    rules:
-      ingress:
-        - action: deny
-      egress:
-        - action: deny
+    ingress:
+    - action: deny
+    egress:
+    - action: deny
     labels:
       type: database


### PR DESCRIPTION
Use common approach for Value in KVPair.

Value is always a pointer for structs, otherwise it is the actual element (string, boolean, slice, map)

Fixes #179 