### PR TITLE
Fix containerized test/build operations

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -18,4 +18,5 @@ RUN apk add --update bash git iproute2 curl make gcc alpine-sdk linux-headers &&
 
 RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/onsi/gomega
+RUN go get github.com/Masterminds/glide
 WORKDIR /go/src/github.com/projectcalico/libcalico-go

--- a/Makefile
+++ b/Makefile
@@ -48,19 +48,21 @@ release/calicoctl: clean
 # Build calicoctl in a container.
 build-containerized: $(BUILD_CONTAINER_MARKER)
 	mkdir -p dist
-	docker run -ti --rm --privileged --net=host \
+	docker run --rm --privileged --net=host \
 	-e PLUGIN=calico \
 	-v ${PWD}:/go/src/github.com/projectcalico/libcalico-go:rw \
 	-v ${PWD}/dist:/go/src/github.com/projectcalico/libcalico-go/dist:rw \
-	$(BUILD_CONTAINER_NAME) make bin/calicoctl
+	$(BUILD_CONTAINER_NAME) bash -c 'make bin/calicoctl; \
+	chown $(shell id -u):$(shell id -g) -R ./'
 
 # Run the tests in a container. Useful for CI, Mac dev.
 .PHONY: test-containerized
 test-containerized: run-etcd $(BUILD_CONTAINER_MARKER)
-	docker run -ti --rm --privileged --net=host \
+	docker run --rm --privileged --net=host \
 	-e PLUGIN=calico \
 	-v ${PWD}:/go/src/github.com/projectcalico/libcalico-go:rw \
-	$(BUILD_CONTAINER_NAME) make ut
+	$(BUILD_CONTAINER_NAME) bash -c 'make ut; \
+	chown $(shell id -u):$(shell id -g) -R ./'
 	
 $(BUILD_CONTAINER_MARKER): Dockerfile.build
 	docker build -f Dockerfile.build -t $(BUILD_CONTAINER_NAME) .


### PR DESCRIPTION
Currently make test-containerized and make build-containerized commands fail with the following error:

glide install -strip-vendor -strip-vcs --cache
make: glide: Command not found
Makefile:23: recipe for target 'vendor/.up-to-date' failed
make: *** [vendor/.up-to-date] Error 127

Fixing that by installing glide tool into the build container.

Remove '-i' and '-t' flags for docker run in order to fix the error:

the input device is not a TTY

Also set correct owner to the stuff created inside container.