### PR TITLE
Policy e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ test-containerized: run-etcd $(BUILD_CONTAINER_MARKER)
 	docker run --rm --privileged --net=host \
 	-e PLUGIN=calico \
 	-v ${PWD}:/go/src/github.com/projectcalico/libcalico-go:rw \
-	$(BUILD_CONTAINER_NAME) bash -c 'make ut; \
-	chown $(shell id -u):$(shell id -g) -R ./vendor'
+	$(BUILD_CONTAINER_NAME) bash -c 'make ut && chown $(shell id -u):$(shell id -g) -R ./vendor'
 
 ## Install or update the tools used by the build
 .PHONY: update-tools

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test cases (Policy object e2e):
+// Test 1: Pass two fully populated PolicySpecs and expect the series of operations to succeed.
+// Test 2: Pass one fully populated PolicySpec and another empty PolicySpec and expect the series of operations to succeed.
+// Test 3: Pass one partially populated PolicySpec and another fully populated PolicySpec and expect the series of operations to succeed.
+
+// Series of operations each test goes through:
+// Update meta1 - check for failure (because it doesn't exist).
+// Create meta1 with spec1.
+// Apply meta2 with spec2.
+// Get meta1 and meta2, compare spec1 and spec2.
+// Update meta1 with spec2.
+// Get meta1 compare spec2.
+// List (empty Meta) ... Get meta1 and meta2.
+// List (using Meta1) ... Get meta1.
+// Delete meta1.
+// Get meta1 ... fail.
+// Delete meta2.
+// List (empty Meta) ... Get no entries (should not error).
+
+package client_test
+
+import (
+	"errors"
+	"log"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var order1 = 99.999
+var order2 = 22.222
+
+var policySpec1 = api.PolicySpec{
+	Order:        &order1,
+	IngressRules: []api.Rule{testutils.InRule1, testutils.InRule2},
+	EgressRules:  []api.Rule{testutils.EgressRule1, testutils.EgressRule2},
+	Selector:     "policy1-selector",
+}
+
+var policySpec2 = api.PolicySpec{
+	Order:        &order2,
+	IngressRules: []api.Rule{testutils.InRule2, testutils.InRule1},
+	EgressRules:  []api.Rule{testutils.EgressRule2, testutils.EgressRule1},
+	Selector:     "policy2-selector",
+}
+
+var _ = Describe("Policy tests", func() {
+
+	DescribeTable("Policy e2e tests",
+		func(meta1, meta2 api.PolicyMetadata, spec1, spec2 api.PolicySpec) {
+
+			// Erase etcd clean.
+			testutils.CleanEtcd()
+
+			// Create a new client.
+			c, err := testutils.NewClient("")
+			if err != nil {
+				log.Println("Error creating client:", err)
+			}
+			By("Updating the policy before it is created")
+			_, outError := c.Policies().Update(&api.Policy{Metadata: meta1, Spec: spec1})
+
+			// Should return an error.
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: Policy(name=policy1)").Error()))
+
+			By("Create, Apply, Get and compare")
+
+			// Create a policy with meta1 and spec1.
+			_, outError = c.Policies().Create(&api.Policy{Metadata: meta1, Spec: spec1})
+
+			// Apply a policy with meta2 and spec2.
+			_, outError = c.Policies().Apply(&api.Policy{Metadata: meta2, Spec: spec2})
+
+			// Get policy with meta1.
+			outPolicy1, outError1 := c.Policies().Get(meta1)
+			log.Println("Out Policy object: ", outPolicy1)
+
+			// Get policy with meta2.
+			outPolicy2, outError2 := c.Policies().Get(meta2)
+			log.Println("Out Policy object: ", outPolicy2)
+
+			// Should match spec1 & outPolicy1 and outPolicy2 & spec2 and errors to be nil.
+			Expect(outPolicy1.Spec).To(Equal(spec1))
+			Expect(outPolicy2.Spec).To(Equal(spec2))
+			Expect(outError1).NotTo(HaveOccurred())
+			Expect(outError2).NotTo(HaveOccurred())
+
+			By("Update, Get and compare")
+
+			// Update meta1 policy with spec2.
+			c.Policies().Update(&api.Policy{Metadata: meta1, Spec: spec2})
+
+			// Get policy with meta1.
+			outPolicy1, outError1 = c.Policies().Get(meta1)
+
+			// Assert the Spec for policy with meta1 matches spec2 and no error.
+			Expect(outPolicy1.Spec).To(Equal(spec2))
+			Expect(outError1).NotTo(HaveOccurred())
+
+			By("List all the policies and compare")
+
+			// Get a list of policiess.
+			policyList, outError := c.Policies().List(api.PolicyMetadata{})
+			log.Println("Get policy list returns: ", policyList.Items)
+			metas := []api.PolicyMetadata{meta1, meta2}
+			expectedPolicies := []api.Policy{}
+			// Go through meta list and append them to expectedPolicies.
+			for _, v := range metas {
+				p, _ := c.Policies().Get(v)
+				expectedPolicies = append(expectedPolicies, *p)
+			}
+
+			// Assert the returned policyList is has the meta1 and meta2 policies.
+			Expect(policyList.Items).To(Equal(expectedPolicies))
+
+			By("List a specific policy and compare")
+
+			// Get a policy list with meta1.
+			policyList, outError = c.Policies().List(meta1)
+			log.Println("Get policy list returns: ", policyList.Items)
+
+			// Get a policy with meta1.
+			outPolicy1, outError1 = c.Policies().Get(meta1)
+
+			// Assert they are equal and no errors.
+			Expect(policyList.Items[0].Spec).To(Equal(outPolicy1.Spec))
+			Expect(outError1).NotTo(HaveOccurred())
+
+			By("Delete, Get and assert error")
+
+			// Delete a policy with meta1.
+			outError1 = c.Policies().Delete(meta1)
+
+			// Get a policy with meta1.
+			_, outError = c.Policies().Get(meta1)
+
+			// Expect an error since the policy was deleted.
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: Policy(name=policy1)").Error()))
+
+			// Delete the second policy with meta2.
+			outError1 = c.Policies().Delete(meta2)
+
+			By("Delete all the policies, Get policy list and expect empty policy list")
+
+			// Both policies are deleted in the calls above.
+			// Get the list of all the policys.
+			policyList, outError = c.Policies().List(api.PolicyMetadata{})
+			log.Println("Get policy list returns: ", policyList.Items)
+
+			// Create an empty policy list.
+			// Note: you can't use make([]api.Policy, 0) because it creates an empty underlying struct,
+			// whereas new([]api.Policy) just returns a pointer without creating an empty struct.
+			emptyPolicyList := new([]api.Policy)
+
+			// Expect returned policyList to contain empty policyList.
+			Expect(policyList.Items).To(Equal(*emptyPolicyList))
+
+		},
+
+		// Test 1: Pass two fully populated PolicySpecs and expect the series of operations to succeed.
+		Entry("Two fully populated PolicySpecs",
+			api.PolicyMetadata{Name: "policy1"},
+			api.PolicyMetadata{Name: "policy2"},
+			policySpec1,
+			policySpec2,
+		),
+
+		// Test 2: Pass one fully populated PolicySpec and another empty PolicySpec and expect the series of operations to succeed.
+		Entry("One fully populated PolicySpec and another empty PolicySpec",
+			api.PolicyMetadata{Name: "policy1"},
+			api.PolicyMetadata{Name: "policy2"},
+			policySpec1,
+			api.PolicySpec{},
+		),
+
+		// Test 3: Pass one partially populated PolicySpec and another fully populated PolicySpec and expect the series of operations to succeed.
+		Entry("One partially populated PolicySpec and another fully populated PolicySpec",
+			api.PolicyMetadata{Name: "policy1"},
+			api.PolicyMetadata{Name: "policy2"},
+			api.PolicySpec{
+				Selector: "policy1-selector",
+			},
+			policySpec2,
+		),
+	)
+})

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -98,10 +98,10 @@ var _ = Describe("Policy tests", func() {
 			log.Println("Out Policy object: ", outPolicy2)
 
 			// Should match spec1 & outPolicy1 and outPolicy2 & spec2 and errors to be nil.
-			Expect(outPolicy1.Spec).To(Equal(spec1))
-			Expect(outPolicy2.Spec).To(Equal(spec2))
 			Expect(outError1).NotTo(HaveOccurred())
 			Expect(outError2).NotTo(HaveOccurred())
+			Expect(outPolicy1.Spec).To(Equal(spec1))
+			Expect(outPolicy2.Spec).To(Equal(spec2))
 
 			By("Update, Get and compare")
 
@@ -112,8 +112,8 @@ var _ = Describe("Policy tests", func() {
 			outPolicy1, outError1 = c.Policies().Get(meta1)
 
 			// Assert the Spec for policy with meta1 matches spec2 and no error.
-			Expect(outPolicy1.Spec).To(Equal(spec2))
 			Expect(outError1).NotTo(HaveOccurred())
+			Expect(outPolicy1.Spec).To(Equal(spec2))
 
 			By("List all the policies and compare")
 
@@ -141,8 +141,8 @@ var _ = Describe("Policy tests", func() {
 			outPolicy1, outError1 = c.Policies().Get(meta1)
 
 			// Assert they are equal and no errors.
-			Expect(policyList.Items[0].Spec).To(Equal(outPolicy1.Spec))
 			Expect(outError1).NotTo(HaveOccurred())
+			Expect(policyList.Items[0].Spec).To(Equal(outPolicy1.Spec))
 
 			By("Delete, Get and assert error")
 

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -85,9 +85,11 @@ var _ = Describe("Policy tests", func() {
 
 			// Create a policy with meta1 and spec1.
 			_, outError = c.Policies().Create(&api.Policy{Metadata: meta1, Spec: spec1})
+			Expect(outError).NotTo(HaveOccurred())
 
 			// Apply a policy with meta2 and spec2.
 			_, outError = c.Policies().Apply(&api.Policy{Metadata: meta2, Spec: spec2})
+			Expect(outError).NotTo(HaveOccurred())
 
 			// Get policy with meta1.
 			outPolicy1, outError1 := c.Policies().Get(meta1)
@@ -106,7 +108,8 @@ var _ = Describe("Policy tests", func() {
 			By("Update, Get and compare")
 
 			// Update meta1 policy with spec2.
-			c.Policies().Update(&api.Policy{Metadata: meta1, Spec: spec2})
+			_, outError = c.Policies().Update(&api.Policy{Metadata: meta1, Spec: spec2})
+			Expect(outError).NotTo(HaveOccurred())
 
 			// Get policy with meta1.
 			outPolicy1, outError1 = c.Policies().Get(meta1)
@@ -119,12 +122,14 @@ var _ = Describe("Policy tests", func() {
 
 			// Get a list of policiess.
 			policyList, outError := c.Policies().List(api.PolicyMetadata{})
+			Expect(outError).NotTo(HaveOccurred())
 			log.Println("Get policy list returns: ", policyList.Items)
 			metas := []api.PolicyMetadata{meta1, meta2}
 			expectedPolicies := []api.Policy{}
 			// Go through meta list and append them to expectedPolicies.
 			for _, v := range metas {
-				p, _ := c.Policies().Get(v)
+				p, outError := c.Policies().Get(v)
+				Expect(outError).NotTo(HaveOccurred())
 				expectedPolicies = append(expectedPolicies, *p)
 			}
 
@@ -135,6 +140,7 @@ var _ = Describe("Policy tests", func() {
 
 			// Get a policy list with meta1.
 			policyList, outError = c.Policies().List(meta1)
+			Expect(outError).NotTo(HaveOccurred())
 			log.Println("Get policy list returns: ", policyList.Items)
 
 			// Get a policy with meta1.
@@ -148,6 +154,7 @@ var _ = Describe("Policy tests", func() {
 
 			// Delete a policy with meta1.
 			outError1 = c.Policies().Delete(meta1)
+			Expect(outError1).NotTo(HaveOccurred())
 
 			// Get a policy with meta1.
 			_, outError = c.Policies().Get(meta1)
@@ -157,12 +164,14 @@ var _ = Describe("Policy tests", func() {
 
 			// Delete the second policy with meta2.
 			outError1 = c.Policies().Delete(meta2)
+			Expect(outError1).NotTo(HaveOccurred())
 
 			By("Delete all the policies, Get policy list and expect empty policy list")
 
 			// Both policies are deleted in the calls above.
 			// Get the list of all the policys.
 			policyList, outError = c.Policies().List(api.PolicyMetadata{})
+			Expect(outError).NotTo(HaveOccurred())
 			log.Println("Get policy list returns: ", policyList.Items)
 
 			// Create an empty policy list.

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"net"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var ipv4 = 4
+var ipv6 = 6
+var strProtocol1 = numorstring.ProtocolFromString("icmp")
+var strProtocol2 = numorstring.ProtocolFromString("udp")
+var numProtocol1 = numorstring.ProtocolFromInt(240)
+
+var icmpType1 = 100
+var icmpCode1 = 200
+
+var _, cidr1, _ = net.ParseCIDR("10.0.0.1/24")
+var _, cidr2, _ = net.ParseCIDR("20.0.0.1/24")
+
+var icmp1 = api.ICMPFields{
+	Type: &icmpType1,
+	Code: &icmpCode1,
+}
+
+var InRule1 = api.Rule{
+	Action:    "allow",
+	IPVersion: &ipv4,
+	Protocol:  &strProtocol1,
+	ICMP:      &icmp1,
+	Source: api.EntityRule{
+		Tag: "tag1",
+		Net: &cnet.IPNet{
+			*cidr1,
+		},
+		Selector: "selector1",
+	},
+}
+
+var InRule2 = api.Rule{
+	Action:    "deny",
+	IPVersion: &ipv6,
+	Protocol:  &numProtocol1,
+	ICMP:      &icmp1,
+	Source: api.EntityRule{
+		Tag: "tag2",
+		Net: &cnet.IPNet{
+			net.IPNet{IP: net.ParseIP("abcd:2345::"), Mask: net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"))},
+		},
+		Selector: "selector2",
+	},
+}
+
+var EgressRule1 = api.Rule{
+	Action:    "deny",
+	IPVersion: &ipv4,
+	Protocol:  &numProtocol1,
+	ICMP:      &icmp1,
+	Source: api.EntityRule{
+		Tag: "tag3",
+		Net: &cnet.IPNet{
+			*cidr2,
+		},
+		Selector: "selector3",
+	},
+}
+
+var EgressRule2 = api.Rule{
+	Action:    "allow",
+	IPVersion: &ipv6,
+	Protocol:  &strProtocol2,
+	ICMP:      &icmp1,
+	Source: api.EntityRule{
+		Tag: "tag4",
+		Net: &cnet.IPNet{
+			net.IPNet{IP: net.ParseIP("abcd:5555::"), Mask: net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"))},
+		},
+		Selector: "selector4",
+	},
+}

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -31,8 +31,8 @@ var numProtocol1 = numorstring.ProtocolFromInt(240)
 var icmpType1 = 100
 var icmpCode1 = 200
 
-var _, cidr1, _ = net.ParseCIDR("10.0.0.1/24")
-var _, cidr2, _ = net.ParseCIDR("20.0.0.1/24")
+var cidr1 = MustParseCIDR("10.0.0.1/24")
+var cidr2 = MustParseCIDR("20.0.0.1/24")
 
 var icmp1 = api.ICMPFields{
 	Type: &icmpType1,
@@ -45,10 +45,8 @@ var InRule1 = api.Rule{
 	Protocol:  &strProtocol1,
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
-		Tag: "tag1",
-		Net: &cnet.IPNet{
-			*cidr1,
-		},
+		Tag:      "tag1",
+		Net:      &cidr1,
 		Selector: "selector1",
 	},
 }
@@ -73,10 +71,8 @@ var EgressRule1 = api.Rule{
 	Protocol:  &numProtocol1,
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
-		Tag: "tag3",
-		Net: &cnet.IPNet{
-			*cidr2,
-		},
+		Tag:      "tag3",
+		Net:      &cidr2,
 		Selector: "selector3",
 	},
 }

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -15,10 +15,7 @@
 package testutils
 
 import (
-	"net"
-
 	"github.com/projectcalico/libcalico-go/lib/api"
-	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
@@ -33,6 +30,8 @@ var icmpCode1 = 200
 
 var cidr1 = MustParseCIDR("10.0.0.1/24")
 var cidr2 = MustParseCIDR("20.0.0.1/24")
+var cidrv61 = MustParseCIDR("abcd:5555::/120")
+var cidrv62 = MustParseCIDR("abcd:2345::/120")
 
 var icmp1 = api.ICMPFields{
 	Type: &icmpType1,
@@ -57,10 +56,8 @@ var InRule2 = api.Rule{
 	Protocol:  &numProtocol1,
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
-		Tag: "tag2",
-		Net: &cnet.IPNet{
-			net.IPNet{IP: net.ParseIP("abcd:2345::"), Mask: net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"))},
-		},
+		Tag:      "tag2",
+		Net:      &cidrv61,
 		Selector: "selector2",
 	},
 }
@@ -83,10 +80,8 @@ var EgressRule2 = api.Rule{
 	Protocol:  &strProtocol2,
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
-		Tag: "tag4",
-		Net: &cnet.IPNet{
-			net.IPNet{IP: net.ParseIP("abcd:5555::"), Mask: net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"))},
-		},
+		Tag:      "tag4",
+		Net:      &cidrv62,
 		Selector: "selector4",
 	},
 }


### PR DESCRIPTION
**New tests**:

**Test cases (Policy object e2e)**:
**Test 1**: Pass two fully populated PolicySpecs and expect the series of operations to succeed.
**Test 2**: Pass one fully populated PolicySpec and another empty PolicySpec and expect the series of operations to succeed.
**Test 3**: Pass one partially populated PolicySpec and another fully populated PolicySpec and expect the series of operations to succeed.

**Series of operations each test goes through**:
Update meta1 - check for failure (because it doesn't exist).
Create meta1 with spec1.
Apply meta2 with spec2.
Get meta1 and meta2, compare spec1 and spec2.
Update meta1 with spec2.
Get meta1 compare spec2.
List (empty Meta) ... Get meta1 and meta2.
List (using Meta1) ... Get meta1.
Delete meta1.
Get meta1 ... fail.
Delete meta2.
List (empty Meta) ... Get no entries (should not error).


---

**Old test cases**:

**Test cases (Policy object e2e)**:
**Test 1**: Create, Get and compare - expect returned policy to be the same as the input policy.
**Test 2**: Create, Apply, Get and compare - expect returned policy to be the same as the "Applied" one.
**Test 3**: Create, Update, Get and compare - expect returned policy to be the same as the "Updated" one.
**Test 4**: Create, Delete, Get and assert error.
**Test 5**: Apply, Get and compare (without creating) - expect returned policy to be the same as "Applied" one.
**Test 6**: Update, Get and assert error (without creating).
**Test 7**: Delete, Get and assert error (without creating).