### PR TITLE
Fix deletion of parent directories.

### DIFF
--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -34,7 +34,7 @@ import (
 var (
 	etcdApplyOpts       = &etcd.SetOptions{PrevExist: etcd.PrevIgnore}
 	etcdCreateOpts      = &etcd.SetOptions{PrevExist: etcd.PrevNoExist}
-	etcdDeleteEmptyOpts = &etcd.DeleteOptions{Recursive: false}
+	etcdDeleteEmptyOpts = &etcd.DeleteOptions{Recursive: false, Dir: true}
 	etcdGetOpts         = &etcd.GetOptions{Quorum: true}
 	etcdListOpts        = &etcd.GetOptions{Quorum: true, Recursive: true, Sort: true}
 	clientTimeout       = 30 * time.Second


### PR DESCRIPTION
Requires `Dir: true` to avoid "not a file" error.

Fixes #195.