### PR TITLE
Rename API fields: hostname, workloadID, orchestratorID

### DIFF
--- a/lib/api/bgppeer.go
+++ b/lib/api/bgppeer.go
@@ -42,10 +42,10 @@ type BGPPeerMetadata struct {
 	// peers with the specified Calico node (specified by the node hostname).
 	Scope scope.Scope `json:"scope" validate:"omitempty,scopeglobalornode"`
 
-	// The hostname of the compute server that is peering with this peer.  When modifying a
-	// BGP peer, the hostname must be specified when the scope is `node`, and must
-	// be omitted when the scope is `global`.
-	Hostname string `json:"hostname,omitempty" validate:"omitempty,name"`
+	// The node name identifying the Calico node instance that is peering with this peer.
+	// When modifying a BGP peer, the node must be specified when the scope is `node`, and
+	// must be omitted when the scope is `global`.
+	Node string `json:"node,omitempty" validate:"omitempty,name"`
 
 	// The IP address of the peer.
 	PeerIP net.IP `json:"peerIP" validate:"omitempty,ip"`

--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -34,8 +34,8 @@ type HostEndpointMetadata struct {
 	// The name of the endpoint.
 	Name string `json:"name,omitempty" validate:"omitempty,name"`
 
-	// The hostname of the compute server.
-	Hostname string `json:"hostname,omitempty" validate:"omitempty,name"`
+	// The node name identifying the Calico node instance.
+	Node string `json:"node,omitempty" validate:"omitempty,name"`
 
 	// The labels applied to the host endpoint.  It is expected that many endpoints share
 	// the same labels. For example, they could be used to label all “production” workloads

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -36,13 +36,13 @@ type WorkloadEndpointMetadata struct {
 	Name string `json:"name,omitempty" validate:"omitempty,name"`
 
 	// The name of the workload.
-	WorkloadID string `json:"workloadID,omitempty" valid:"omitempty,name"`
+	Workload string `json:"workload,omitempty" valid:"omitempty,name"`
 
 	// The name of the orchestrator.
-	OrchestratorID string `json:"orchestratorID,omitempty" valid:"omitempty,name"`
+	Orchestrator string `json:"orchestrator,omitempty" valid:"omitempty,name"`
 
-	// The name of the node.
-	Hostname string `json:"hostname,omitempty" valid:"omitempty,name"`
+	// The node name identifying the Calico node instance.
+	Node string `json:"node,omitempty" valid:"omitempty,name"`
 
 	// The labels applied to the workload endpoint.  It is expected that many endpoints share
 	// the same labels. For example, they could be used to label all “production” workloads

--- a/lib/client/bgppeer.go
+++ b/lib/client/bgppeer.go
@@ -84,7 +84,7 @@ func (h *bgpPeers) convertMetadataToListInterface(m unversioned.ResourceMetadata
 	l := model.BGPPeerListOptions{
 		Scope:    pm.Scope,
 		PeerIP:   pm.PeerIP,
-		Hostname: pm.Hostname,
+		Hostname: pm.Node,
 	}
 	return l, nil
 }
@@ -96,7 +96,7 @@ func (h *bgpPeers) convertMetadataToKey(m unversioned.ResourceMetadata) (model.K
 	k := model.BGPPeerKey{
 		Scope:    pm.Scope,
 		PeerIP:   pm.PeerIP,
-		Hostname: pm.Hostname,
+		Hostname: pm.Node,
 	}
 	return k, nil
 }
@@ -132,7 +132,7 @@ func (h *bgpPeers) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, er
 	apiBGPPeer := api.NewBGPPeer()
 	apiBGPPeer.Metadata.Scope = backendBGPPeerKey.Scope
 	apiBGPPeer.Metadata.PeerIP = backendBGPPeerKey.PeerIP
-	apiBGPPeer.Metadata.Hostname = backendBGPPeerKey.Hostname
+	apiBGPPeer.Metadata.Node = backendBGPPeerKey.Hostname
 	apiBGPPeer.Spec.ASNumber = backendBGPPeer.ASNum
 
 	return apiBGPPeer, nil

--- a/lib/client/hostendpoint.go
+++ b/lib/client/hostendpoint.go
@@ -103,7 +103,7 @@ func (h *hostEndpoints) List(metadata api.HostEndpointMetadata) (*api.HostEndpoi
 func (h *hostEndpoints) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	hm := m.(api.HostEndpointMetadata)
 	l := model.HostEndpointListOptions{
-		Hostname:   hm.Hostname,
+		Hostname:   hm.Node,
 		EndpointID: hm.Name,
 	}
 	return l, nil
@@ -114,7 +114,7 @@ func (h *hostEndpoints) convertMetadataToListInterface(m unversioned.ResourceMet
 func (h *hostEndpoints) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	hm := m.(api.HostEndpointMetadata)
 	k := model.HostEndpointKey{
-		Hostname:   hm.Hostname,
+		Hostname:   hm.Node,
 		EndpointID: hm.Name,
 	}
 	return k, nil
@@ -166,7 +166,7 @@ func (h *hostEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Resourc
 	ips = append(ips, bh.ExpectedIPv6Addrs...)
 
 	ah := api.NewHostEndpoint()
-	ah.Metadata.Hostname = bk.Hostname
+	ah.Metadata.Node = bk.Hostname
 	ah.Metadata.Name = bk.EndpointID
 	ah.Metadata.Labels = bh.Labels
 	ah.Spec.InterfaceName = bh.Name

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -95,9 +95,9 @@ func (w *workloadEndpoints) setCreateDefaults(wep *api.WorkloadEndpoint) {
 func (w *workloadEndpoints) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	hm := m.(api.WorkloadEndpointMetadata)
 	l := model.WorkloadEndpointListOptions{
-		Hostname:       hm.Hostname,
-		OrchestratorID: hm.OrchestratorID,
-		WorkloadID:     hm.WorkloadID,
+		Hostname:       hm.Node,
+		OrchestratorID: hm.Orchestrator,
+		WorkloadID:     hm.Workload,
 		EndpointID:     hm.Name,
 	}
 	return l, nil
@@ -108,9 +108,9 @@ func (w *workloadEndpoints) convertMetadataToListInterface(m unversioned.Resourc
 func (w *workloadEndpoints) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	hm := m.(api.WorkloadEndpointMetadata)
 	k := model.WorkloadEndpointKey{
-		Hostname:       hm.Hostname,
-		OrchestratorID: hm.OrchestratorID,
-		WorkloadID:     hm.WorkloadID,
+		Hostname:       hm.Node,
+		OrchestratorID: hm.Orchestrator,
+		WorkloadID:     hm.Workload,
 		EndpointID:     hm.Name,
 	}
 	return k, nil
@@ -186,9 +186,9 @@ func (w *workloadEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Res
 	}
 
 	ah := api.NewWorkloadEndpoint()
-	ah.Metadata.Hostname = bk.Hostname
-	ah.Metadata.OrchestratorID = bk.OrchestratorID
-	ah.Metadata.WorkloadID = bk.WorkloadID
+	ah.Metadata.Node = bk.Hostname
+	ah.Metadata.Orchestrator = bk.OrchestratorID
+	ah.Metadata.Workload = bk.WorkloadID
 	ah.Metadata.Name = bk.EndpointID
 	ah.Metadata.Labels = bh.Labels
 	ah.Spec.InterfaceName = bh.Name


### PR DESCRIPTION
Rename of API fields:

hostname -> node
workloadID -> workload
orchestratorID -> orchestrator

Focus on this is primarily fix up of resources and calicoctl - this does not yet focus on the IPAM interface.