### PR TITLE
Fix: CircleCI always receives 0 Exit code for test-containerized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ test-containerized: run-etcd $(BUILD_CONTAINER_MARKER)
 	docker run --rm --privileged --net=host \
 	-e PLUGIN=calico \
 	-v ${PWD}:/go/src/github.com/projectcalico/libcalico-go:rw \
-	$(BUILD_CONTAINER_NAME) bash -c 'make ut; \
-	chown $(shell id -u):$(shell id -g) -R ./vendor'
+	$(BUILD_CONTAINER_NAME) bash -c 'make ut && chown $(shell id -u):$(shell id -g) -R ./vendor'
 
 ## Install or update the tools used by the build
 .PHONY: update-tools


### PR DESCRIPTION
```bash
bash -c 'make ut; \
	chown $(shell id -u):$(shell id -g) -R ./vendor'
``` 
if the tests fail in `make ut`, but second operation after the `;` succeeds, it returns an Exit code of `0` so CircleCI doesn't catch failed tests