### PR TITLE
Poll etcd's cluster ID to ensure we spot if the cluster is rebuilt.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,8 @@
-hash: f7d523998964cfa7e5002ad7038de8226a6d14ca40be50659136f26d2d2ecd67
-updated: 2016-09-27T13:20:15.990078148-07:00
+hash: f789d5a91746d174a834e03fefc78c62d8a418753ab8e19ef6d2f595505c7db1
+updated: 2016-10-25T10:29:40.766893026+01:00
 imports:
-- name: github.com/cloudfoundry-incubator/candiedyaml
-  version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
 - name: github.com/coreos/etcd
-  version: e93ee6179c64cac4d8764870b8267f05c1618c40
+  version: 8e5f34fd97c03025c531fa547e654838ca490f04
   subpackages:
   - client
   - pkg/fileutil
@@ -13,13 +11,11 @@ imports:
   - pkg/transport
   - pkg/types
 - name: github.com/coreos/go-systemd
-  version: bfdc81d0d7e0fb19447b08571f63b774495251ce
+  version: 61c7ee68bddeb1e66b491c3e1045c4f72b2cd6e3
   subpackages:
-  - daemon
   - journal
-  - util
 - name: github.com/coreos/pkg
-  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
+  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:
   - capnslog
 - name: github.com/docker/engine-api
@@ -27,46 +23,19 @@ imports:
 - name: github.com/docopt/docopt-go
   version: 784ddc588536785e7299f7272f39101f7faccc3f
 - name: github.com/ghodss/yaml
-  version: aa0c862057666179de291b67d9f093d12b5a8473
+  version: bea76d6a4713e18b7f5321a2b020738552def3ea
 - name: github.com/kelseyhightower/envconfig
-  version: 1e291572dcb9ba673cdcdb15e0f422702415ebaf
+  version: 9aca109c9aec4633fced9717c4a09ecab3d33111
 - name: github.com/mattn/go-runewidth
-  version: d6bea18f789704b5f83375793155289da36a3c7f
-- name: github.com/mitchellh/go-ps
-  version: e2d21980687ce16e58469d98dcee92d27fbbd7fb
+  version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/mcuadros/go-version
   version: d52711f8d6bea8dc01efafdb68ad95a4e2606630
-- name: github.com/Microsoft/go-winio
-  version: ce2922f643c8fd76b46cadc7f404a06282678b34
+- name: github.com/mitchellh/go-ps
+  version: e2d21980687ce16e58469d98dcee92d27fbbd7fb
 - name: github.com/olekukonko/tablewriter
-  version: daf2955e742cf123959884fdff4685aa79b63135
-- name: github.com/satori/go.uuid
-  version: 0aa62d5ddceb50dbcb909d790b5345affd3669b6
-- name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
-- name: github.com/termie/go-shutil
-  version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
-- name: github.com/ugorji/go
-  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
-  subpackages:
-  - codec
-- name: golang.org/x/net
-  version: 6acef71eb69611914f7a30939ea9f6e194c78172
-  subpackages:
-  - context
-- name: golang.org/x/sys
-  version: 9c60d1c508f5134d1ca726b4641db998f2523357
-  subpackages:
-  - unix
-- name: gopkg.in/go-playground/validator.v8
-  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
-- name: gopkg.in/tchap/go-patricia.v2
-  version: 666120de432aea38ab06bd5c818f04f4129882c9
-  subpackages:
-  - patricia
-testImports:
+  version: bdcc175572fd7abece6c831e643891b9331bc9e7
 - name: github.com/onsi/ginkgo
-  version: 7b6efc7d7b052568b49ac02d3141c9d7a5a494a4
+  version: a8ccd817611666211fdf6e6a752174a0db8374a8
   subpackages:
   - config
   - extensions/table
@@ -82,9 +51,38 @@ testImports:
   - internal/writer
   - reporters
   - reporters/stenographer
+  - reporters/stenographer/support/go-colorable
+  - reporters/stenographer/support/go-isatty
   - types
+- name: github.com/satori/go.uuid
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+- name: github.com/Sirupsen/logrus
+  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
+- name: github.com/termie/go-shutil
+  version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
+- name: github.com/ugorji/go
+  version: faddd6128c66c4708f45fdc007f575f75e592a3c
+  subpackages:
+  - codec
+- name: golang.org/x/net
+  version: 5695785b4430a2c4aa952323f1aed77bf3e7508e
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: c200b10b5d5e122be351b67af224adc6128af5bf
+  subpackages:
+  - unix
+- name: gopkg.in/go-playground/validator.v8
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+- name: gopkg.in/tchap/go-patricia.v2
+  version: 666120de432aea38ab06bd5c818f04f4129882c9
+  subpackages:
+  - patricia
+- name: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+testImports:
 - name: github.com/onsi/gomega
-  version: d59fa0ac68bb5dd932ee8d24eed631cdd519efc3
+  version: e46a88d81f5164c47e2d51c1c3d863dde7997993
   subpackages:
   - format
   - internal/assertion
@@ -97,5 +95,3 @@ testImports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
-- name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -24,7 +24,14 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/hwm"
 	"golang.org/x/net/context"
+	"math/rand"
 )
+
+// defaultEtcdClusterID is default value that an etcd cluster uses if it
+// hasn't been bootstrapped with an explicit value.
+const defaultEtcdClusterID = "7e27652122e8b2ae"
+
+const clusterIDPollInterval = 10 * time.Second
 
 func newSyncer(keysAPI etcd.KeysAPI, callbacks api.SyncerCallbacks) *etcdSyncer {
 	return &etcdSyncer{
@@ -50,6 +57,11 @@ func (syn *etcdSyncer) Start() {
 	if !syn.OneShot {
 		log.Info("Syncer not in one-shot mode, starting watcher thread")
 		go syn.watchEtcd(etcdEvents, triggerResync, initialSnapshotIndex)
+		// In order to make sure that we eventually spot if the etcd
+		// cluster is rebuilt, start a thread to poll the etcd
+		// Cluster ID.  If we don't spot a cluster rebuild then our
+		// watcher will start silently failing.
+		go syn.pollClusterID(clusterIDPollInterval)
 	}
 
 	// Start a background thread to read snapshots from etcd.  It will
@@ -231,6 +243,44 @@ func (syn *etcdSyncer) watchEtcd(etcdEvents chan<- event, triggerResync chan<- u
 				snapshotStarting: !inSync,
 			}
 		}
+	}
+}
+
+// pollClusterID polls etcd for its current cluster ID.  If the cluster ID changes
+// it terminates the process.
+func (syn *etcdSyncer) pollClusterID(interval time.Duration) {
+	log.Info("Cluster ID poll thread started")
+	lastSeenClusterID := ""
+	opts := client.GetOptions{}
+	for {
+		resp, err := syn.keysAPI.Get(context.Background(), "/calico/", &opts)
+		if err != nil {
+			log.WithError(err).Warn("Failed to poll etcd server cluster ID")
+		} else {
+			log.WithField("clusterID", resp.ClusterID).Debug(
+				"Polled etcd for cluster ID.")
+			if lastSeenClusterID == "" {
+				log.WithField("clusterID", resp.ClusterID).Info("etcd cluster ID now known")
+				lastSeenClusterID = resp.ClusterID
+				if resp.ClusterID == defaultEtcdClusterID {
+					log.Error("etcd server is using the default cluster ID; " +
+						"will not be able to spot if etcd is replaced with " +
+						"another cluster using the default cluster ID. " +
+						"Pass a unique --initial-cluster-token when creating " +
+						"your etcd cluster to set the cluster ID.")
+				}
+			} else if resp.ClusterID != "" && lastSeenClusterID != resp.ClusterID {
+				// The Syncer doesn't currently support this (hopefully rare)
+				// scenario.  Terminate the process rather than carry on with
+				// possibly out-of-sync etcd index.
+				log.WithFields(log.Fields{
+					"oldID": lastSeenClusterID,
+					"newID": resp.ClusterID,
+				}).Fatal("etcd cluster ID changed; must exit.")
+			}
+		}
+		// Jitter by 10% of interval.
+		time.Sleep(time.Duration(float64(interval) * (1 + (0.1 * rand.Float64()))))
 	}
 }
 


### PR DESCRIPTION
Closes an annoying corner case where the etcd cluster is rebuilt (for example in OpenStack where we have recommended running a transient etcd in a RAM disk).