### PR TITLE
Change Syncer API to return an Update object with additional metadata.

### DIFF
--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -121,7 +121,7 @@ type SyncerCallbacks interface {
 	//
 	// When a recursive delete is made, deleting many leaf keys, the Syncer
 	// generates deletion updates for all the leaf keys.
-	OnUpdates(updates []model.KVPair)
+	OnUpdates(updates []model.Update)
 }
 
 // SyncerParseFailCallbacks is an optional interface that can be implemented

--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -121,7 +121,7 @@ type SyncerCallbacks interface {
 	//
 	// When a recursive delete is made, deleting many leaf keys, the Syncer
 	// generates deletion updates for all the leaf keys.
-	OnUpdates(updates []model.Update)
+	OnUpdates(updates []Update)
 }
 
 // SyncerParseFailCallbacks is an optional interface that can be implemented
@@ -130,3 +130,18 @@ type SyncerCallbacks interface {
 type SyncerParseFailCallbacks interface {
 	ParseFailed(rawKey string, rawValue *string)
 }
+
+// Update from the Syncer.  A KV pair plus extra metadata.
+type Update struct {
+	model.KVPair
+	UpdateType UpdateType
+}
+
+type UpdateType uint8
+
+const (
+	UpdateTypeKVUnknown UpdateType = iota
+	UpdateTypeKVNew
+	UpdateTypeKVUpdated
+	UpdateTypeKVDeleted
+)

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -273,13 +273,13 @@ func (syn *etcdSyncer) mergeUpdates(snapshotUpdates <-chan event, watcherUpdates
 			if oldIdx < e.modifiedIndex {
 				// Event is newer than value for that key.
 				// Send the update to Felix.
-				var updateType model.UpdateType
+				var updateType api.UpdateType
 				if oldIdx > 0 {
 					log.WithField("oldIdx", oldIdx).Debug("Set updates known key")
-					updateType = model.UpdateTypeKVUpdated
+					updateType = api.UpdateTypeKVUpdated
 				} else {
 					log.WithField("oldIdx", oldIdx).Debug("Set is a new key")
-					updateType = model.UpdateTypeKVNew
+					updateType = api.UpdateTypeKVNew
 				}
 				syn.sendUpdate(e.key, &e.value, e.modifiedIndex, updateType)
 			}
@@ -304,7 +304,7 @@ func (syn *etcdSyncer) mergeUpdates(snapshotUpdates <-chan event, watcherUpdates
 	}
 }
 
-func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64, updateType model.UpdateType) {
+func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64, updateType api.UpdateType) {
 	log.Debugf("Parsing etcd key %#v", key)
 	parsedKey := model.KeyFromDefaultPath(key)
 	if parsedKey == nil {
@@ -325,7 +325,7 @@ func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64, up
 		}
 		log.Debugf("Parsed value: %#v", parsedValue)
 	}
-	updates := []model.Update{
+	updates := []api.Update{
 		{
 			KVPair: model.KVPair{
 				Key:      parsedKey,
@@ -339,7 +339,7 @@ func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64, up
 }
 
 func (syn *etcdSyncer) sendDeletions(deletedKeys []string, revision uint64) {
-	updates := make([]model.Update, 0, len(deletedKeys))
+	updates := make([]api.Update, 0, len(deletedKeys))
 	for _, key := range deletedKeys {
 		parsedKey := model.KeyFromDefaultPath(key)
 		if parsedKey == nil {
@@ -349,13 +349,13 @@ func (syn *etcdSyncer) sendDeletions(deletedKeys []string, revision uint64) {
 			}
 			continue
 		}
-		updates = append(updates, model.Update{
+		updates = append(updates, api.Update{
 			KVPair: model.KVPair{
 				Key:      parsedKey,
 				Value:    nil,
 				Revision: revision,
 			},
-			UpdateType: model.UpdateTypeKVDeleted,
+			UpdateType: api.UpdateTypeKVDeleted,
 		})
 	}
 	syn.callbacks.OnUpdates(updates)

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -87,21 +87,6 @@ type KVPair struct {
 	TTL      time.Duration // For writes, if non-zero, key has a TTL.
 }
 
-// Update from the Syncer.  A KV pair plus extra metadata.
-type Update struct {
-	KVPair
-	UpdateType UpdateType
-}
-
-type UpdateType uint8
-
-const (
-	UpdateTypeKVUnknown UpdateType = iota
-	UpdateTypeKVNew
-	UpdateTypeKVUpdated
-	UpdateTypeKVDeleted
-)
-
 // KeyToDefaultPath converts one of the Keys from this package into a unique
 // '/'-delimited path, which is suitable for use as the key when storing the
 // value in a hierarchical (i.e. one with directories and leaves) key/value

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -87,6 +87,21 @@ type KVPair struct {
 	TTL      time.Duration // For writes, if non-zero, key has a TTL.
 }
 
+// Update from the Syncer.  A KV pair plus extra metadata.
+type Update struct {
+	KVPair
+	UpdateType UpdateType
+}
+
+type UpdateType uint8
+
+const (
+	UpdateTypeKVUnknown UpdateType = iota
+	UpdateTypeKVNew
+	UpdateTypeKVUpdated
+	UpdateTypeKVDeleted
+)
+
 // KeyToDefaultPath converts one of the Keys from this package into a unique
 // '/'-delimited path, which is suitable for use as the key when storing the
 // value in a hierarchical (i.e. one with directories and leaves) key/value


### PR DESCRIPTION
Felix uses the new metadata to count keys as they churn.
