### PR TITLE
Rename hostname to node and fix IP version name

### DIFF
--- a/lib/api/rule.go
+++ b/lib/api/rule.go
@@ -31,7 +31,7 @@ type Rule struct {
 
 	// IPVersion is an optional field that restricts the rule to only match a specific IP
 	// version.
-	IPVersion *int `json:"ip_version,omitempty" validate:"omitempty,ipversion"`
+	IPVersion *int `json:"ipVersion,omitempty" validate:"omitempty,ipversion"`
 
 	// Protocol is an optional field that restricts the rule to only apply to traffic of
 	// a specific IP protocol. Required if any of the EntityRules contain Ports

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -55,7 +55,7 @@ func (key BGPPeerKey) defaultPath() (string, error) {
 		return e, nil
 	case scope.Node:
 		if key.Hostname == "" {
-			return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
+			return "", errors.ErrorInsufficientIdentifiers{Name: "node"}
 		}
 		e := fmt.Sprintf("/calico/bgp/v1/host/%s/peer_v%d/%s",
 			key.Hostname, key.PeerIP.Version(), key.PeerIP)
@@ -81,7 +81,7 @@ func (key BGPPeerKey) String() string {
 	if key.Scope == scope.Global {
 		return fmt.Sprintf("BGPPeer(global, ip=%s)", key.PeerIP)
 	} else {
-		return fmt.Sprintf("BGPPeer(hostname=%s, ip=%s)", key.Hostname, key.PeerIP)
+		return fmt.Sprintf("BGPPeer(node=%s, ip=%s)", key.Hostname, key.PeerIP)
 	}
 }
 

--- a/lib/backend/model/config.go
+++ b/lib/backend/model/config.go
@@ -123,7 +123,7 @@ func (key HostConfigKey) defaultDeletePath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	if key.Hostname == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
+		return "", errors.ErrorInsufficientIdentifiers{Name: "node"}
 	}
 	e := fmt.Sprintf("/calico/v1/host/%s/config/%s", key.Hostname, key.Name)
 	return e, nil

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -38,7 +38,7 @@ type HostEndpointKey struct {
 
 func (key HostEndpointKey) defaultPath() (string, error) {
 	if key.Hostname == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
+		return "", errors.ErrorInsufficientIdentifiers{Name: "node"}
 	}
 	if key.EndpointID == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
@@ -61,7 +61,7 @@ func (key HostEndpointKey) valueType() reflect.Type {
 }
 
 func (key HostEndpointKey) String() string {
-	return fmt.Sprintf("HostEndpoint(hostname=%s, name=%s)", key.Hostname, key.EndpointID)
+	return fmt.Sprintf("HostEndpoint(node=%s, name=%s)", key.Hostname, key.EndpointID)
 }
 
 type HostEndpointListOptions struct {

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -39,7 +39,7 @@ type WorkloadEndpointKey struct {
 
 func (key WorkloadEndpointKey) defaultPath() (string, error) {
 	if key.Hostname == "" {
-		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
+		return "", errors.ErrorInsufficientIdentifiers{Name: "node"}
 	}
 	if key.OrchestratorID == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "orchestrator"}
@@ -60,7 +60,7 @@ func (key WorkloadEndpointKey) defaultDeletePath() (string, error) {
 
 func (key WorkloadEndpointKey) defaultDeleteParentPaths() ([]string, error) {
 	if key.Hostname == "" {
-		return nil, errors.ErrorInsufficientIdentifiers{Name: "hostname"}
+		return nil, errors.ErrorInsufficientIdentifiers{Name: "node"}
 	}
 	if key.OrchestratorID == "" {
 		return nil, errors.ErrorInsufficientIdentifiers{Name: "orchestrator"}
@@ -79,7 +79,7 @@ func (key WorkloadEndpointKey) valueType() reflect.Type {
 }
 
 func (key WorkloadEndpointKey) String() string {
-	return fmt.Sprintf("WorkloadEndpoint(hostname=%s, orchestrator=%s, workload=%s, name=%s)",
+	return fmt.Sprintf("WorkloadEndpoint(node=%s, orchestrator=%s, workload=%s, name=%s)",
 		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID)
 }
 


### PR DESCRIPTION
This is a little hacky:  In the backend model we use the hostname naming rather than node.... so to propagate the "node" name up to the custom facing API I'm using the name node in the error message.

Ideally we'd handle this in the conversion layer in the client mapping all of the base error types to ensure the field names are mapped from the backend naming scheme to the API naming scheme.  Seems like a bit of an overkill for the time being since i daresay a lot of this mapping might change in API server land.