### PR TITLE
Fix and simplify the etcdv2 Syncer

### DIFF
--- a/lib/api/ippool.go
+++ b/lib/api/ippool.go
@@ -74,7 +74,7 @@ func NewIPPool() *IPPool {
 type IPPoolList struct {
 	unversioned.TypeMetadata
 	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
-	Items    []IPPool                   `json:"items" validate:"dive"`
+	Items    []IPPool                 `json:"items" validate:"dive"`
 }
 
 // NewIPPool creates a new (zeroed) PoolList struct with the TypeMetadata initialised to the current

--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -128,7 +128,7 @@ type SyncerCallbacks interface {
 // by a Syncer callback.  Datastores that support it can report a failure to
 // parse a particular key or value.
 type SyncerParseFailCallbacks interface {
-	ParseFailed(rawKey string, rawValue *string)
+	ParseFailed(rawKey string, rawValue string)
 }
 
 // Update from the Syncer.  A KV pair plus extra metadata.

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -104,7 +104,7 @@ func newSyncer(keysAPI etcd.KeysAPI, callbacks api.SyncerCallbacks) *etcdSyncer 
 //
 // The watcher goroutine polls etcd for new events.  A typical use of the
 // etcd API would load a snapshot first, then start polling from the snapshot
-// index.  However, that approach deosn't work at high event throughput because
+// index.  However, that approach doesn't work at high event throughput because
 // etcd's event buffer can be exhausted before the snapshot is received, leading
 // to a resync loop.  We avoid that scenario by having the watcher be free
 // running.  If it loses sync, it immediately starts polling again from the

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -116,6 +116,10 @@ type watcherDeletion struct {
 	key           string
 }
 
+// snapshotRequest is sent by the merge thread to the snapshot thread when a new snapshot
+// is required.  Thread safety: the merge thead should only send this message when the
+// snapshot thread is quiesced, I.e. after it receives teh snapshotFinished message from
+// the previous snapshot.
 type snapshotRequest struct {
 	minRequiredSnapshotIndex uint64
 }

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -68,6 +68,55 @@ func newSyncer(keysAPI etcd.KeysAPI, callbacks api.SyncerCallbacks) *etcdSyncer 
 	}
 }
 
+// etcdSyncer loads snapshots from etcd and merges them with events from a
+// watch on our directory in etcd. It sends an "eventually consistent" stream of
+// events to its callback.
+//
+// Syncer architecture
+//
+// The syncer's processing is divided into four goroutines:
+//
+// The merge goroutine
+//
+// The merge goroutine receives updates about newly loaded snapshots (from the
+// snapshot reeading goroutine) and events (from the watcher goroutine) and
+// merges them into a consistent event stream.
+//
+// Since processing a snapshot takes some time and it happens concurrently with
+// polling for new events, the merge goroutine may be receiving updates from
+// a snapshot that occurred at etcd index 10, while the event stream is already
+// reporting updates at etcd index 11, 12, ...  The merge thread does the
+// bookkeeping to squash out-of-date snapshot updates in favour of newer
+// information from the watcher and to resolve deletions after losing sync.
+//
+// The merge goroutine also requests new snapshots when the watcher drops out
+// of sync.  While it's the watcher goroutine that detects the loss of sync,
+// sending the request via the merge goroutine makes for easier reasoning about
+// the thread safety.
+//
+// The snapshot reading goroutine
+//
+// When requested by the merge goroutine, the snapshot-reading goroutine
+// reads a consistent point-in-time snapshot from etcd and streams it to the
+// merge goroutine.  Then it waits for the next request.
+//
+// The watcher goroutine
+//
+// The watcher goroutine polls etcd for new events.  A typical use of the
+// etcd API would load a snapshot first, then start polling from the snapshot
+// index.  However, that approach deosn't work at high event throughput because
+// etcd's event buffer can be exhausted before the snapshot is received, leading
+// to a resync loop.  We avoid that scenario by having the watcher be free
+// running.  If it loses sync, it immediately starts polling again from the
+// current etcd index; then it triggers a snapshot read from the point it started
+// polling.
+//
+// The cluster ID poll goroutine
+//
+// This goroutine simply polls etcd for its cluster ID every few seconds and
+// kills the process if it changes.  This ensures that we recover if etcd is
+// blown away and rebuilt.  It's such a rare corner case that corrective action
+// isn't worth it (and would be likely to be buggy due to lack of exercise).
 type etcdSyncer struct {
 	callbacks api.SyncerCallbacks
 	keysAPI   etcd.KeysAPI
@@ -81,7 +130,20 @@ func (syn *etcdSyncer) Start() {
 	// it will signal on the resyncIndex channel.
 	log.Info("Starting etcd Syncer")
 
+	// Channel used to send updates from the watcher thread to the merge
+	// thread.  We give it a large buffer because we want the watcher thread
+	// to be free running and only block if we get really backed up.
 	watcherUpdateC := make(chan interface{}, 20000)
+	// Channel used to send updates from the snapshot thread to the merge
+	// thread.  No buffer: we want the snapshot to be slowed down if the
+	// merge thread is under load.
+	snapshotUpdateC := make(chan interface{})
+	// Channel used to signal from the merge thread to the snapshot thread
+	// that a new snapshot is required.  To avoid deadlock with the channel
+	// above, the merge only sends a new snapshot request once the old
+	// snapshot is finished.
+	snapshotRequestC := make(chan snapshotRequest)
+
 	if !syn.OneShot {
 		log.Info("Syncer not in one-shot mode, starting watcher thread")
 		go syn.watchEtcd(watcherUpdateC)
@@ -91,18 +153,15 @@ func (syn *etcdSyncer) Start() {
 		// watcher will start silently failing.
 		go syn.pollClusterID(clusterIDPollInterval)
 	}
-
-	// Start a background thread to read snapshots from etcd.  It will
-	// read a start-of-day snapshot and then wait to be signalled on the
-	// resyncIndex channel.
-	snapshotUpdateC := make(chan interface{})
-	snapshotRequestC := make(chan snapshotRequest)
 	go syn.readSnapshotsFromEtcd(snapshotUpdateC, snapshotRequestC)
 	go syn.mergeUpdates(snapshotUpdateC, watcherUpdateC, snapshotRequestC)
 }
 
 // readSnapshotsFromEtcd is a goroutine that, when requested, reads a new
-// snapshot from etcd and send it to the merge thread.
+// snapshot from etcd and send it to the merge thread.  A snapshot request
+// includes the required etcd index for the snapshot; in case of a read from a
+// stale replica, the snapshot thread retries until it reads a snapshot that is
+// new enough.
 func (syn *etcdSyncer) readSnapshotsFromEtcd(
 	snapshotUpdateC chan<- interface{},
 	snapshotRequestC <-chan snapshotRequest,
@@ -118,6 +177,9 @@ func (syn *etcdSyncer) readSnapshotsFromEtcd(
 		minRequiredSnapshotIndex = snapshotRequest.minRequiredSnapshotIndex
 		log.WithField("newMinIndex", minRequiredSnapshotIndex).Info("Asked for new snapshot")
 
+		// In case of read from stale replica, loop until we read a
+		// new-enough snapshot.  We don't do a quorum read to avoid
+		// pinning the read load to the etcd master.
 		for highestCompletedSnapshotIndex < minRequiredSnapshotIndex {
 			log.WithFields(log.Fields{
 				"requiredIdx": minRequiredSnapshotIndex,
@@ -140,16 +202,20 @@ func (syn *etcdSyncer) readSnapshotsFromEtcd(
 				continue
 			}
 
-			// If we get here, we should have a good
-			// snapshot.  Send it to the merge thread.
+			// If we get here, we should have a good snapshot.
+			// Send it to the merge thread.
 			snapshotUpdateC <- snapshotStarting{
 				snapshotIndex: resp.Index,
 			}
 			sendSnapshotNode(resp.Node, snapshotUpdateC, resp)
 			highestCompletedSnapshotIndex = resp.Index
-			snapshotUpdateC <- snapshotFinished{
-				snapshotIndex: resp.Index,
-			}
+		}
+		// Defensive: just in case we somehow got called without needing
+		// to execute the loop, send the snapshotFinished from outside
+		// the loop. This ensures that we always pair a snapshot
+		// finished to every snapshotRequest.
+		snapshotUpdateC <- snapshotFinished{
+			snapshotIndex: highestCompletedSnapshotIndex,
 		}
 	}
 }
@@ -158,10 +224,12 @@ func (syn *etcdSyncer) readSnapshotsFromEtcd(
 func sendSnapshotNode(node *client.Node, snapshotUpdates chan<- interface{}, resp *client.Response) {
 	if !node.Dir {
 		snapshotUpdates <- snapshotUpdate{
-			key:           node.Key,
-			modifiedIndex: node.ModifiedIndex,
 			snapshotIndex: resp.Index,
-			value:         node.Value,
+			kvPair: kvPair{
+				key:           node.Key,
+				value:         node.Value,
+				modifiedIndex: node.ModifiedIndex,
+			},
 		}
 	} else {
 		for _, child := range node.Nodes {
@@ -170,13 +238,15 @@ func sendSnapshotNode(node *client.Node, snapshotUpdates chan<- interface{}, res
 	}
 }
 
-// watchEtcd is a goroutine that watches etcd, sending events to the merge
-// thread when keys change or it loses sync.
+// watchEtcd is a goroutine that polls etcd for new events.  As described in the
+// comment for the etcdSyncer, the watcher goroutine is free-running; it always
+// tries to keep up with etcd but it emits events when it drops out of sync
+// so that the merge goroutine can trigger a new resync via snapshot.
 func (syn *etcdSyncer) watchEtcd(watcherUpdateC chan<- interface{}) {
 	log.Info("etcd watch thread started.")
 	// Each trip around the outer loop establishes the current etcd index
-	// of the cluster, triggers a new snapshot read from that index and then
-	// starts watching from that index.
+	// of the cluster, triggers a new snapshot read from that index (via
+	// message to the merge goroutine) and starts watching from that index.
 	for {
 		// Do a non-recursive get on the Ready flag to find out the
 		// current etcd index.  We'll trigger a snapshot/start polling from that.
@@ -202,7 +272,7 @@ func (syn *etcdSyncer) watchEtcd(watcherUpdateC chan<- interface{}) {
 			Recursive:  true,
 		}
 		watcher := syn.keysAPI.Watcher("/calico/v1", &watcherOpts)
-	watchLoop:
+	watchLoop: // We'll stay in this poll loop unless we drop out of sync.
 		for {
 			// Wait for the next event from the watcher.
 			resp, err := watcher.Next(context.Background())
@@ -231,11 +301,11 @@ func (syn *etcdSyncer) watchEtcd(watcherUpdateC chan<- interface{}) {
 			}
 
 			if actionType == actionSetOrUpdate {
-				watcherUpdateC <- watcherUpdate{
+				watcherUpdateC <- watcherUpdate{kvPair: kvPair{
 					modifiedIndex: node.ModifiedIndex,
 					key:           resp.Node.Key,
 					value:         node.Value,
-				}
+				}}
 			} else {
 				watcherUpdateC <- watcherDeletion{
 					modifiedIndex: node.ModifiedIndex,
@@ -353,82 +423,17 @@ func (syn *etcdSyncer) mergeUpdates(
 			log.WithField("event", event).Debug("Watcher update")
 		}
 
-		var updatedLastSeenIndex, updatedModifiedIndex uint64
-		var updatedKey string
-		var updatedValue string
-
-		switch e := event.(type) {
-		case watcherNeedsSnapshot:
-			// Watcher has lost sync.  Record the snapshot index
-			// that we now require to bring us into sync.  We'll start
-			// a new snapshot below if we can.
-			log.Info("Watcher out-of-sync, starting to track deletions")
-			minRequiredSnapshotIndex = e.minSnapshotIndex
-		case snapshotStarting:
-			// Informational message from the snapshot thread.  Makes the logs clearer.
-			log.WithField("snapshotIndex", e.snapshotIndex).Info("Started receiving snapshot")
-		case snapshotFinished:
-			// Snapshot is ending, we need to check if this snapshot is still new enough to
-			// mean that we're really in sync (because the watcher may have fallen
-			// out of sync again after it requested the snapshot).
-			logCxt := log.WithFields(log.Fields{
-				"snapshotIndex":    e.snapshotIndex,
-				"minSnapshotIndex": minRequiredSnapshotIndex,
-			})
-			logCxt.Info("Finished receiving snapshot, cleaning up old keys.")
-			snapshotInProgress = false
-			hwms.StopTrackingDeletions()
-			deletedKeys := hwms.DeleteOldKeys(e.snapshotIndex)
-			logCxt.WithField("numDeletedKeys", len(deletedKeys)).Info(
-				"Deleted old keys that weren't seen in snapshot.")
-			syn.sendDeletions(deletedKeys, e.snapshotIndex)
-
-			if e.snapshotIndex >= minRequiredSnapshotIndex {
-				// Now in sync.
-				logCxt.Info("Snapshot brought us into sync.")
-				syn.callbacks.OnStatusUpdated(api.InSync)
-			} else {
-				// Watcher is already out-of-sync.  We'll restart the
-				// snapshot below.
-				logCxt.Warn("Snapshot was stale before it finished.")
-			}
-		case snapshotUpdate:
-			// Update from a snapshot.  We update the HWM to be the
-			// index of the snapshot, not the modified index.  This
-			// lets us spot keys that have been deleted once the snapshot
-			// is finished because any keys that were deleted will have
-			// last seen indexes that are lower than the snapshot index.
-			updatedLastSeenIndex = e.snapshotIndex
-			updatedModifiedIndex = e.modifiedIndex
-			updatedKey = e.key
-			updatedValue = e.value
-		case watcherUpdate:
-			// Normal watcher update, last-seen equal to the modified
-			// index.
-			updatedLastSeenIndex = e.modifiedIndex
-			updatedModifiedIndex = e.modifiedIndex
-			updatedKey = e.key
-			updatedValue = e.value
-		case watcherDeletion:
-			deletedKeys := hwms.StoreDeletion(e.key, e.modifiedIndex)
-			log.WithFields(log.Fields{
-				"prefix":  e.key,
-				"numKeys": len(deletedKeys),
-			}).Debug("Prefix deleted")
-			syn.sendDeletions(deletedKeys, e.modifiedIndex)
-		}
-
-		if updatedLastSeenIndex != 0 {
-			// Common update processing, shared between snapshot and
-			// watcher updates.
+		switch event := event.(type) {
+		case update:
+			// Common update processing, shared between snapshot and watcher updates.
+			updatedLastSeenIndex := event.lastSeenIndex()
+			kv := event.kvPair()
 			log.WithFields(log.Fields{
 				"indexToStore": updatedLastSeenIndex,
-				"modIdx":       updatedModifiedIndex,
-				"key":          updatedKey,
-				"value":        updatedValue,
-			}).Debug("Snapshot/watcher update to store")
-			oldIdx := hwms.StoreUpdate(updatedKey, updatedLastSeenIndex)
-			if oldIdx < updatedModifiedIndex {
+				"kv":           kv,
+			}).Debug("Snapshot/watcher update")
+			oldIdx := hwms.StoreUpdate(kv.key, updatedLastSeenIndex)
+			if oldIdx < kv.modifiedIndex {
 				// Event is newer than value for that key.
 				// Send the update.
 				var updateType api.UpdateType
@@ -439,11 +444,55 @@ func (syn *etcdSyncer) mergeUpdates(
 					log.WithField("oldIdx", oldIdx).Debug("Set is a new key")
 					updateType = api.UpdateTypeKVNew
 				}
-				syn.sendUpdate(updatedKey, &updatedValue, updatedModifiedIndex, updateType)
+				syn.sendUpdate(kv.key, kv.value, kv.modifiedIndex, updateType)
 			}
+		case watcherDeletion:
+			deletedKeys := hwms.StoreDeletion(event.key, event.modifiedIndex)
+			log.WithFields(log.Fields{
+				"prefix":  event.key,
+				"numKeys": len(deletedKeys),
+			}).Debug("Prefix deleted")
+			syn.sendDeletions(deletedKeys, event.modifiedIndex)
+		case watcherNeedsSnapshot:
+			// Watcher has lost sync.  Record the snapshot index
+			// that we now require to bring us into sync.  We'll start
+			// a new snapshot below if we can.
+			log.Info("Watcher out-of-sync, starting to track deletions")
+			minRequiredSnapshotIndex = event.minSnapshotIndex
+		case snapshotStarting:
+			// Informational message from the snapshot thread.  Makes the logs clearer.
+			log.WithField("snapshotIndex", event.snapshotIndex).Info("Started receiving snapshot")
+		case snapshotFinished:
+			// Snapshot is ending, we need to check if this snapshot is still new enough to
+			// mean that we're really in sync (because the watcher may have fallen
+			// out of sync again after it requested the snapshot).
+			logCxt := log.WithFields(log.Fields{
+				"snapshotIndex":    event.snapshotIndex,
+				"minSnapshotIndex": minRequiredSnapshotIndex,
+			})
+			logCxt.Info("Finished receiving snapshot, cleaning up old keys.")
+			snapshotInProgress = false
+			hwms.StopTrackingDeletions()
+			deletedKeys := hwms.DeleteOldKeys(event.snapshotIndex)
+			logCxt.WithField("numDeletedKeys", len(deletedKeys)).Info(
+				"Deleted old keys that weren't seen in snapshot.")
+			syn.sendDeletions(deletedKeys, event.snapshotIndex)
+
+			if event.snapshotIndex >= minRequiredSnapshotIndex {
+				// Now in sync.
+				logCxt.Info("Snapshot brought us into sync.")
+				syn.callbacks.OnStatusUpdated(api.InSync)
+			} else {
+				// Watcher is already out-of-sync.  We'll restart the
+				// snapshot below.
+				logCxt.Warn("Snapshot was stale before it finished.")
+			}
+		default:
+			log.WithField("event", event).Panic("Unknown event type")
 		}
 
-		if !snapshotInProgress && highestCompletedSnapshotIndex < minRequiredSnapshotIndex {
+		outOfSync := highestCompletedSnapshotIndex < minRequiredSnapshotIndex
+		if outOfSync && !snapshotInProgress {
 			log.Info("Watcher is out-of-sync but no snapshot in progress, starting one.")
 			snapshotRequestC <- snapshotRequest{
 				minRequiredSnapshotIndex: minRequiredSnapshotIndex,
@@ -459,7 +508,7 @@ func (syn *etcdSyncer) mergeUpdates(
 }
 
 // sendUpdate parses and sends an update to the callback API.
-func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64, updateType api.UpdateType) {
+func (syn *etcdSyncer) sendUpdate(key string, value string, revision uint64, updateType api.UpdateType) {
 	log.Debugf("Parsing etcd key %#v", key)
 	parsedKey := model.KeyFromDefaultPath(key)
 	if parsedKey == nil {
@@ -473,13 +522,13 @@ func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64, up
 
 	var parsedValue interface{}
 	var err error
-	if value != nil {
-		parsedValue, err = model.ParseValue(parsedKey, []byte(*value))
-		if err != nil {
-			log.Warningf("Failed to parse value for %v: %#v", key, *value)
-		}
-		log.Debugf("Parsed value: %#v", parsedValue)
+
+	parsedValue, err = model.ParseValue(parsedKey, []byte(value))
+	if err != nil {
+		log.Warningf("Failed to parse value for %v: %#v", key, value)
 	}
+	log.Debugf("Parsed value: %#v", parsedValue)
+
 	updates := []api.Update{
 		{
 			KVPair: model.KVPair{
@@ -501,7 +550,7 @@ func (syn *etcdSyncer) sendDeletions(deletedKeys []string, revision uint64) {
 		if parsedKey == nil {
 			log.Debugf("Failed to parse key %v", key)
 			if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {
-				cb.ParseFailed(key, nil)
+				cb.ParseFailed(key, "")
 			}
 			continue
 		}
@@ -529,20 +578,39 @@ type snapshotFinished struct {
 	snapshotIndex uint64
 }
 
-// snapshotUpdate is the event sent by the snapshot thread when it find a key/value in the
-// snapshot.
-type snapshotUpdate struct {
+type kvPair struct {
 	modifiedIndex uint64
-	snapshotIndex uint64
 	key           string
 	value         string
 }
 
+func (k kvPair) kvPair() kvPair {
+	return k
+}
+
+// snapshotUpdate is the event sent by the snapshot thread when it find a key/value in the
+// snapshot.
+type snapshotUpdate struct {
+	kvPair
+	snapshotIndex uint64
+}
+
+func (u snapshotUpdate) lastSeenIndex() uint64 {
+	return u.snapshotIndex
+}
+
 // watcherUpdate is sent by the watcher thread to the merge thread when a key is updated.
 type watcherUpdate struct {
-	modifiedIndex uint64
-	key           string
-	value         string
+	kvPair
+}
+
+func (u watcherUpdate) lastSeenIndex() uint64 {
+	return u.modifiedIndex
+}
+
+type update interface {
+	lastSeenIndex() uint64
+	kvPair() kvPair
 }
 
 // watcherDeletion is sent by the watcher thread to the merge thread when a key is removed.

--- a/lib/backend/model/ippool.go
+++ b/lib/backend/model/ippool.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	matchIPPool = regexp.MustCompile("^/?calico/v1/ipam/v./pool/([^/]+)$")
-	typeIPPool = reflect.TypeOf(IPPool{})
+	typeIPPool  = reflect.TypeOf(IPPool{})
 )
 
 type IPPoolKey struct {

--- a/lib/client/config_e2e_test.go
+++ b/lib/client/config_e2e_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/projectcalico/libcalico-go/lib/testutils"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 var _ = Describe("with config option API tests", func() {


### PR DESCRIPTION
I found a potential race and a real bug in the etcdv2 Syncer.  This change reworks the Syncer to fix the issue and simplify the snapshot start processing.

The bug was that, after the watcher went out-of-sync, it wouldn't start a new snapshot until it received the next event.  Hence, if nothing was going on, you could be out-of-sync indefinitely.  The watcher now explicitly establishes the current etcd index by reading the Ready flag (which has the nice side effect of stalling the watcher until the Ready flag appears).

The snapshot initiation logic was based on a dubious triangle of channels and I couldn't convince myself that there wasn't a race lurking in there.  I've simplified that so that the watcher thread tells the merge thread that it needs a new snapshot; then the merge thread sends the message to the snapshot thread.  That way there can't be a race between merge thread being told a snapshot is starting and receiving the first update from the snapshot thread.

Along the way, I also cleaned up the channels to use real message types rather than a single struct for everything.  That makes the unpacking code much cleaner.