### PR TITLE
Create global config when creating node

### DIFF
--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -17,6 +17,8 @@ package k8s
 import (
 	"time"
 
+	"reflect"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/compat"
@@ -24,7 +26,6 @@ import (
 	k8sapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/watch"
-	"reflect"
 )
 
 func newSyncer(kc KubeClient, callbacks api.SyncerCallbacks) *kubeSyncer {

--- a/lib/client/config.go
+++ b/lib/client/config.go
@@ -66,6 +66,8 @@ type ConfigInterface interface {
 	SetNodeLogLevel(string, string) error
 	SetNodeLogLevelUseGlobal(string) error
 	GetNodeLogLevel(string) (string, ConfigLocation, error)
+	GetFelixConfig(string) (*string, error)
+	SetFelixConfig(string, *string) error
 }
 
 // config implements ConfigInterface
@@ -249,6 +251,26 @@ func (c *config) GetNodeLogLevel(node string) (string, ConfigLocation, error) {
 	} else {
 		return *s, ConfigLocationNode, nil
 	}
+}
+
+// GetFelixConfig provides a mechanism for getting arbitrary Felix configuration
+// in the datastore.
+func (c *config) GetFelixConfig(name string) (*string, error) {
+	return c.getValue(model.GlobalConfigKey{Name: name})
+}
+
+// SetFelixConfig provides a mechanism for setting arbitrary Felix configuration
+// in the datastore.  A nil value will remove the entry from the datastore.
+func (c *config) SetFelixConfig(name string, value *string) error {
+	key := model.GlobalConfigKey{Name: name}
+	if value == nil {
+		return c.deleteConfig(key)
+	}
+	_, err := c.c.backend.Apply(&model.KVPair{
+		Key:   key,
+		Value: *value,
+	})
+	return err
 }
 
 // setLogLevel sets the log level fields with the appropriate log string value.

--- a/lib/client/ippool.go
+++ b/lib/client/ippool.go
@@ -15,10 +15,10 @@
 package client
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	log "github.com/Sirupsen/logrus"
 )
 
 // PoolInterface has methods to work with Pool resources.

--- a/lib/client/node_e2e_test.go
+++ b/lib/client/node_e2e_test.go
@@ -187,4 +187,48 @@ var _ = Describe("Node tests", func() {
 				},
 			}),
 	)
+
+	Describe("Checking global config is set only once", func() {
+		testutils.CleanEtcd()
+		c, _ := testutils.NewClient("")
+		var guid string
+
+		// Step-1: Create node 1.
+		Context("Create node1", func() {
+			_, err := c.Nodes().Create(&api.Node{
+				Metadata: api.NodeMetadata{Name: "node1"},
+				Spec:     api.NodeSpec{},
+			})
+			It("should create the node", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should create the global GUID", func() {
+				guidp, err := c.Config().GetFelixConfig("ClusterGUID")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(guidp).NotTo(BeNil())
+				Expect(*guidp).NotTo(Equal(""))
+				guid = *guidp
+			})
+		})
+
+		// Step-2: Create node 2.
+		Context("Create node 2", func() {
+			_, err := c.Nodes().Create(&api.Node{
+				Metadata: api.NodeMetadata{Name: "node2"},
+				Spec:     api.NodeSpec{},
+			})
+			It("should create the node", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not change the global GUID", func() {
+				guidp, err := c.Config().GetFelixConfig("ClusterGUID")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(guidp).NotTo(BeNil())
+				Expect(*guidp).To(Equal(guid))
+			})
+		})
+	})
+
 })


### PR DESCRIPTION
This PR sets a couple of key global config parameters when creating a node resource.

-  The Ready flag
-  The GUID

Whilst this is handled as part of the calico/node image, this is not done when using a self-installed mechanism such as is likely when doing host security.

Fixes:  https://github.com/projectcalico/calico-containers/issues/1282