### PR TITLE
Update AutoAssignArgs to support a list of pools

### DIFF
--- a/lib/client/ipam_types.go
+++ b/lib/client/ipam_types.go
@@ -57,13 +57,13 @@ type AutoAssignArgs struct {
 	// to the value provided by os.Hostname.
 	Hostname string
 
-	// If specified, the previously configured IPv4 pool from which
+	// If specified, the previously configured IPv4 pools from which
 	// to assign IPv4 addresses.  If not specified, this defaults to all IPv4 pools.
-	IPv4Pool *net.IPNet
+	IPv4Pools []net.IPNet
 
-	// If specified, the previously configured IPv6 pool from which
+	// If specified, the previously configured IPv6 pools from which
 	// to assign IPv6 addresses.  If not specified, this defaults to all IPv6 pools.
-	IPv6Pool *net.IPNet
+	IPv6Pools []net.IPNet
 }
 
 // IPAMConfig contains global configuration options for Calico IPAM.


### PR DESCRIPTION
This addresses the first bullet of https://github.com/projectcalico/calico-cni/issues/212

I'm assuming we need to still support the old variant (single pool) of AutoAssignArgs too, otherwise we'd break existing users.  Should we deprecate the single flavor though or just keep both going forward?

/cc @lxpollitt @mikespreitzer

Signed-off-by: Doug Davis <dug@us.ibm.com>