### PR TITLE
Rip out hacky ipPool support from k8s backend

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -79,29 +79,6 @@ func (c converter) parseProfileName(profileName string) (string, error) {
 	return splits[1], nil
 }
 
-func (c converter) namespaceToIPPool(ns *k8sapi.Namespace) (*model.KVPair, error) {
-	if ns.ObjectMeta.Name != "kube-system" {
-		return nil, goerrors.New("Invalid namespace, must be kube-system")
-	}
-
-	// Get the serialized KVPair.
-	poolStr, ok := ns.ObjectMeta.Annotations["projectcalico.org/ipPool"]
-	if !ok {
-		// No pools exist.
-		return nil, goerrors.New("No Kubernetes Pod IP Pool configured")
-	}
-	pool := model.IPPool{}
-	err := json.Unmarshal([]byte(poolStr), &pool)
-	if err != nil {
-		return nil, err
-	}
-	return &model.KVPair{
-		Key:      model.IPPoolKey{CIDR: pool.CIDR},
-		Value:    &pool,
-		Revision: ns.ObjectMeta.ResourceVersion,
-	}, nil
-}
-
 func (c converter) namespaceToProfile(ns *k8sapi.Namespace) (*model.KVPair, error) {
 	// Determine the ingress action based off the DefaultDeny annotation.
 	ingressAction := "allow"


### PR DESCRIPTION
Removing this because it's not implemented the way we want to implement it (thirdpartyresources), and it isn't actually necessary to do policy-only mode (which is all that is supported right now).

I don't think we need to add support for this back in the v1.0.0 timeframe, but we'll want to at some point down the road using ThirdPartyResources instead.