### PR TITLE
Relax the unmarshaling of the block affinity

### DIFF
--- a/lib/backend/model/block_affinity.go
+++ b/lib/backend/model/block_affinity.go
@@ -27,7 +27,24 @@ import (
 
 var (
 	matchBlockAffinity = regexp.MustCompile("^/?calico/ipam/v2/host/([^/]+)/ipv./block/([^/]+)$")
-	typeBlockAff       = reflect.TypeOf(BlockAffinity{})
+
+	// The BlockAffinity is stored as a raw string type.  It currently does
+	// not contain any information since all required information is stored
+	// in the key (hostname and block CIDR).  If we end up needing to store
+	// data in the BlockAffinity then care will need to be taken to ensure
+	// existing versions of the value (an empty string) can be successfully
+	// unmarshalled.
+	// - The Python version of IPAM wrote an empty string, but can handle
+	//   any value written into the data.
+	// - The original golang port of IPAM wrote "{}" into the data (the JSON
+	//   value for an empty dict).  It was unable to handle reading of an
+	//   empty string written out by the Python IPAM.
+	// - The current version of the golang port now has the BlockAffinity
+	//   as a raw-string type so that it can handle reading in any value.
+	//   We write in a fixed value of "{}" so that we are compatible with
+	//   both the Python and the original golang port.
+	BlockAffinityValue = "{}"
+	typeBlockAff       = rawStringType
 )
 
 type BlockAffinityKey struct {
@@ -93,7 +110,4 @@ func (options BlockAffinityListOptions) KeyFromDefaultPath(path string) Key {
 		return nil
 	}
 	return BlockAffinityKey{CIDR: *cidr, Host: host}
-}
-
-type BlockAffinity struct {
 }

--- a/lib/client/ipam_block_reader_writer.go
+++ b/lib/client/ipam_block_reader_writer.go
@@ -141,11 +141,12 @@ func (rw blockReaderWriter) claimNewAffineBlock(
 }
 
 func (rw blockReaderWriter) claimBlockAffinity(subnet cnet.IPNet, host string, config IPAMConfig) error {
-	// Claim the block affinity for this host.
+	// Claim the block affinity for this host.  See model.BlockAffinityValue
+	// for details on the hard-coded value that is used.
 	log.Infof("Host %s claiming block affinity for %s", host, subnet)
 	obj := model.KVPair{
 		Key:   model.BlockAffinityKey{Host: host, CIDR: subnet},
-		Value: &model.BlockAffinity{},
+		Value: model.BlockAffinityValue,
 	}
 	_, err := rw.client.backend.Create(&obj)
 


### PR DESCRIPTION
Convert the AffinityBlock to be a raw string type.

Python code handles any value being assigned for the block, so it will be fine with pre GA releases of golang IPAM.

It was not sufficient to just add an unmarshal method because the unmarshaling code hooks into the son unmarshaller which does not handle empty string values.   Migrating to be a raw string type is a much safer approach.