### PR TITLE
Use projectcalico/go-yaml-wrapper fork with UnmarshalStrict

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0d68f17ad8903c76d9fee088030faf3eb86d9a78e46db92270cc45d97eaac4ff
-updated: 2016-12-06T16:31:18.731516066-08:00
+hash: 6ce057b3c3970864d37e29e02d4253899e5d43a3ac11abe59aba6ca9f14dd27d
+updated: 2016-12-12T12:37:34.135822079-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -53,7 +53,7 @@ imports:
   - log
   - swagger
 - name: github.com/ghodss/yaml
-  version: a54de18a07046d8c4b26e9327698a2ebb9285b36
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -110,6 +110,14 @@ imports:
   - types
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/projectcalico/go-json
+  version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
+  subpackages:
+  - json
+- name: github.com/projectcalico/go-yaml
+  version: 955bc3e451ef0c9df8b9113bf2e341139cdafab2
+- name: github.com/projectcalico/go-yaml-wrapper
+  version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   subpackages:
   - client
   - pkg/transport
-- package: github.com/ghodss/yaml
+- package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/kelseyhightower/envconfig
 - package: github.com/onsi/ginkgo
 - package: github.com/satori/go.uuid

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/ghodss/yaml"
 	"github.com/kelseyhightower/envconfig"
+	yaml "github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend"
@@ -122,16 +122,16 @@ func LoadClientConfigFromBytes(b []byte) (*api.CalicoAPIConfig, error) {
 		},
 	}
 
-	if err := yaml.Unmarshal(b, &c); err != nil {
+	if err := yaml.UnmarshalStrict(b, &c); err != nil {
 		return nil, err
 	}
 
 	// Validate the version and kind.
 	if c.APIVersion != unversioned.VersionCurrent {
-		return nil, errors.New("unknown APIVersion '" + c.APIVersion + "'")
+		return nil, errors.New("invalid config file: unknown APIVersion '" + c.APIVersion + "'")
 	}
 	if c.Kind != "calicoApiConfig" {
-		return nil, errors.New("expected kind 'calicoApiConfig', got '" + c.Kind + "'")
+		return nil, errors.New("invalid config file: expected kind 'calicoApiConfig', got '" + c.Kind + "'")
 	}
 
 	log.Info("Datastore type: ", c.Spec.DatastoreType)

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -192,8 +192,8 @@ kind: notCalicoApiConfig
 
 		Entry("valid etcd configuration", data1, cfg1data, nil),
 		Entry("valid k8s configuration", data2, cfg2data, nil),
-		Entry("invalid version", data3, nil, errors.New("unknown APIVersion 'v2'")),
-		Entry("invalid kind", data4, nil, errors.New("expected kind 'calicoApiConfig', got 'notCalicoApiConfig'")),
+		Entry("invalid version", data3, nil, errors.New("invalid config file: unknown APIVersion 'v2'")),
+		Entry("invalid kind", data4, nil, errors.New("invalid config file: expected kind 'calicoApiConfig', got 'notCalicoApiConfig'")),
 	)
 
 	DescribeTable("Load client config by environment",


### PR DESCRIPTION
This is the current behavior (with config.cfg being invalid yaml) :
```bash
$ calicoctl apply -c config.cfg -f pool.yaml
No resources specified in file
``` 
With this change, error looks like:
```bash
$ calicoctl apply -c config.cfg -f pool.yaml
Failed to Calico API client: error parsing document: fields in document are not recognized or are in the wrong location: etcdCACertFile, etcdCertFile, etcdEndpoints, etcdKeyFile
exit status 1
``` 

which is much more clear! 