### PR TITLE
Use glide cache to build go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test: ut
 
 ## Use this to populate the vendor directory after checking out the repository.
 ## To update upstream dependencies, delete the glide.lock file first.
-vendor: 
+vendor:
 	glide install -strip-vendor
 
 .PHONY: ut
@@ -23,11 +23,13 @@ ut: vendor
 
 .PHONY: test-containerized
 ## Run the tests in a container. Useful for CI, Mac dev.
-test-containerized: $(BUILD_CONTAINER_MARKER) run-kubernetes-master 
+test-containerized: $(BUILD_CONTAINER_MARKER) run-kubernetes-master
+	mkdir -p ${HOME}/.glide
 	docker run --rm --privileged --net=host \
 	-e PLUGIN=calico \
+	-v ${HOME}/.glide:/root/.glide:rw \
 	-v ${PWD}:/go/src/github.com/projectcalico/libcalico-go:rw \
-	$(BUILD_CONTAINER_NAME) bash -c 'make WHAT=$(WHAT) ut && chown $(shell id -u):$(shell id -g) -R ./vendor'
+	$(BUILD_CONTAINER_NAME) bash -c 'make WHAT=$(WHAT) ut && chown $(shell id -u):$(shell id -g) -R ./vendor /root/.glide'
 
 ## Install or update the tools used by the build
 .PHONY: update-tools


### PR DESCRIPTION
Use cache as much as possible from CI user (~/.glide) also with
fixing permissions

We need to have an ability to run calico build in isolated environment
(without access to 3rd part repos) and cache usage is one step to this
direction