### PR TITLE
Removed label value validation and related tests

### DIFF
--- a/lib/selector/tokenizer/tokenizer.go
+++ b/lib/selector/tokenizer/tokenizer.go
@@ -54,7 +54,7 @@ type Token struct {
 }
 
 const (
-	identifierExpr = `[a-zA-Z_./-][a-zA-Z0-9_./-]*`
+	identifierExpr = `([a-zA-Z0-9.-]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])*`
 	hasExpr        = `has\(\s*(` + identifierExpr + `)\s*\)`
 	allExpr        = `all\(\s*\)`
 	notInExpr      = `not\s*in\b`

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -34,7 +34,8 @@ var validate *validator.Validate
 var (
 	nameRegex          = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
 	interfaceRegex     = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
-	labelRegex         = regexp.MustCompile("^[a-zA-Z_./-][a-zA-Z0-9_./-]{0,127}$")
+	labelRegex         = regexp.MustCompile("^([a-zA-Z0-9.-]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
+	labelValueRegex    = regexp.MustCompile("^[a-zA-Z0-9]?([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
 	actionRegex        = regexp.MustCompile("^(allow|deny|log|pass)$")
 	backendActionRegex = regexp.MustCompile("^(allow|deny|log|next-tier|)$")
 	protocolRegex      = regexp.MustCompile("^(tcp|udp|icmp|icmpv6|sctp|udplite)$")
@@ -166,7 +167,7 @@ func validateLabels(v *validator.Validate, topStruct reflect.Value, currentStruc
 	l := field.Interface().(map[string]string)
 	log.Debugf("Validate labels: %s", l)
 	for k, v := range l {
-		if !labelRegex.MatchString(k) || !labelRegex.MatchString(v) {
+		if !labelRegex.MatchString(k) || !labelValueRegex.MatchString(v) {
 			return false
 		}
 	}

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -110,10 +110,19 @@ func init() {
 
 		// (API) Labels.
 		Entry("should accept a valid label", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "gold._0-9"}}, true),
-		Entry("should reject label key starting with 0-9", api.HostEndpointMetadata{Labels: map[string]string{"2rank": "gold"}}, false),
-		Entry("should reject label value starting with 0-9", api.HostEndpointMetadata{Labels: map[string]string{"rank": "2gold"}}, false),
+		Entry("should accept label key starting with 0-9", api.HostEndpointMetadata{Labels: map[string]string{"2rank": "gold"}}, true),
+		Entry("should accept label value starting with 0-9", api.HostEndpointMetadata{Labels: map[string]string{"rank": "2gold"}}, true),
+		Entry("should accept label key with dns prefix", api.HostEndpointMetadata{Labels: map[string]string{"calico/k8s_ns": "kube-system"}}, true),
+		Entry("should accept label key where prefix is 253 characters", api.HostEndpointMetadata{Labels: map[string]string{"Projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org12/k8s_ns": "gold"}}, true),
+		Entry("should accept label key where name segment is 63 character", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org/gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._012": "gold"}}, true),
 		Entry("should reject label key with !", api.HostEndpointMetadata{Labels: map[string]string{"rank!": "gold"}}, false),
-		Entry("should reject label value with !", api.HostEndpointMetadata{Labels: map[string]string{"rank": "gold!"}}, false),
+		Entry("should reject label key starting with ~", api.HostEndpointMetadata{Labels: map[string]string{"~rank_.0-9": "gold"}}, false),
+		Entry("should reject label key ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9~": "gold"}}, false),
+		Entry("should reject label key with multiple /", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org/a/b": "gold"}}, false),
+		Entry("should reject label key where prefix > 253 characters", api.HostEndpointMetadata{Labels: map[string]string{"Projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org123/k8s_ns": "gold"}}, false),
+		Entry("should reject label key where name segment > 63 character", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org/gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._0123": "gold"}}, false),
+		Entry("should reject label value starting with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "~gold"}}, false),
+		Entry("should reject label value ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "gold~"}}, false),
 
 		// (API) Interface.
 		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "ValidIntface0-9"}, true),


### PR DESCRIPTION
The Label value validation was causing us to be unable to delete
workload endpoints via calicoctl.