### PR TITLE
Add per-node BGP subnet configuration and IP pool IPIP Mode

### DIFF
--- a/lib/api/bgppeer.go
+++ b/lib/api/bgppeer.go
@@ -48,7 +48,7 @@ type BGPPeerMetadata struct {
 	Node string `json:"node,omitempty" validate:"omitempty,name"`
 
 	// The IP address of the peer.
-	PeerIP net.IP `json:"peerIP" validate:"omitempty,ip"`
+	PeerIP net.IP `json:"peerIP" validate:"omitempty"`
 }
 
 // BGPPeerSpec contains the specification for a BGPPeer resource.

--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -59,7 +59,7 @@ type HostEndpointSpec struct {
 	// 	endpoints, the ExpectedIPs field is used for that purpose. (If only the interface
 	// 	name is specified, Calico does not learn the IPs of the interface for use in match
 	// 	criteria.)
-	ExpectedIPs []net.IP `json:"expectedIPs,omitempty" validate:"omitempty,dive,ip"`
+	ExpectedIPs []net.IP `json:"expectedIPs,omitempty" validate:"omitempty"`
 
 	// A list of identifiers of security Profile objects that apply to this endpoint. Each
 	// profile is applied in the order that they appear in this list.  Profile rules are applied

--- a/lib/api/ippool.go
+++ b/lib/api/ippool.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -56,6 +57,13 @@ type IPIPConfiguration struct {
 	// When enabled is true, ipip tunneling will be used to deliver packets to
 	// destinations within this pool.
 	Enabled bool `json:"enabled,omitempty"`
+
+	// The IPIP mode.  This can be one of "always" or "cross-subnet".  A mode
+	// of "always" will also use IPIP tunneling for routing to destination IP
+	// addresses within this pool.  A mode of "cross-subnet" will only use IPIP
+	// tunneling when the destination node is on a different subnet to the
+	// originating node.  The default value (if not specified) is "always".
+	Mode ipip.Mode `json:"mode,omitempty"`
 }
 
 // NewIPPool creates a new (zeroed) Pool struct with the TypeMetadata initialised to the current

--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -61,13 +61,13 @@ type NodeBGPSpec struct {
 	// default value will be used.
 	ASNumber *numorstring.ASNumber `json:"asNumber,omitempty"`
 
-	// IPv4Address is the IPv4 address of this node.  At least one of the
-	// IPv4 and IPv6 addresses should be specified.
-	IPv4Address *net.IP `json:"ipv4Address,omitempty" validate:"omitempty,ipv4"`
+	// IPv4Address is the IPv4 address and network of this node.  At least
+	// one of the IPv4 and IPv6 addresses should be specified.
+	IPv4Address *net.IPNet `json:"ipv4Address,omitempty" validate:"omitempty"`
 
-	// IPv6Address is the IPv6 address of this node.  At least one of the
-	// IPv4 and IPv6 addresses should be specified.
-	IPv6Address *net.IP `json:"ipv6Address,omitempty" validate:"omitempty,ipv6"`
+	// IPv6Address is the IPv6 address and network of this node.  At least
+	// one of the IPv4 and IPv6 addresses should be specified.
+	IPv6Address *net.IPNet `json:"ipv6Address,omitempty" validate:"omitempty"`
 }
 
 // NewNode creates a new (zeroed) NodeList struct with the TypeMetadata initialised to the current

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -56,7 +56,7 @@ type WorkloadEndpointSpec struct {
 	// allowed to leave this interface if they come from an address in one of these subnets.
 	//
 	// Currently only /32 for IPv4 and /128 for IPv6 networks are supported.
-	IPNetworks []net.IPNet `json:"ipNetworks,omitempty" validate:"omitempty,dive,cidr"`
+	IPNetworks []net.IPNet `json:"ipNetworks,omitempty" validate:"omitempty"`
 
 	// IPNATs is a list of 1:1 NAT mappings to apply to the endpoint. Inbound connections
 	// to the external IP will be forwarded to the internal IP. Connections initiated from the
@@ -66,10 +66,10 @@ type WorkloadEndpointSpec struct {
 	IPNATs []IPNAT `json:"ipNATs,omitempty" validate:"omitempty,dive"`
 
 	// IPv4Gateway is the gateway IPv4 address for traffic from the workload.
-	IPv4Gateway *net.IP `json:"ipv4Gateway,omitempty" validate:"omitempty,ipv4"`
+	IPv4Gateway *net.IP `json:"ipv4Gateway,omitempty" validate:"omitempty"`
 
 	// IPv6Gateway is the gateway IPv6 address for traffic from the workload.
-	IPv6Gateway *net.IP `json:"ipv6Gateway,omitempty" validate:"omitempty,ipv6"`
+	IPv6Gateway *net.IP `json:"ipv6Gateway,omitempty" validate:"omitempty"`
 
 	// A list of security Profile resources that apply to this endpoint. Each profile is
 	// applied in the order that they appear in this list.  Profile rules are applied
@@ -87,10 +87,10 @@ type WorkloadEndpointSpec struct {
 type IPNAT struct {
 	// The internal IP address which must be associated with the owning endpoint via the
 	// configured IPNetworks for the endpoint.
-	InternalIP net.IP `json:"internalIP" validate:"ip"`
+	InternalIP net.IP `json:"internalIP"`
 
 	// The external IP address.
-	ExternalIP net.IP `json:"externalIP" validate:"ip"`
+	ExternalIP net.IP `json:"externalIP"`
 }
 
 // String returns a friendly form of an IPNAT.

--- a/lib/backend/backend_test.go
+++ b/lib/backend/backend_test.go
@@ -41,10 +41,10 @@ var _ = Describe("Backend tests", func() {
 
 		block = model.KVPair{
 			Key: model.BlockKey{
-				CIDR: testutils.MustParseCIDR("10.0.0.0/26"),
+				CIDR: testutils.MustParseNetwork("10.0.0.0/26"),
 			},
 			Value: model.AllocationBlock{
-				CIDR: testutils.MustParseCIDR("10.0.0.0/26"),
+				CIDR: testutils.MustParseNetwork("10.0.0.0/26"),
 			},
 		}
 
@@ -77,7 +77,7 @@ var _ = Describe("Backend tests", func() {
 
 		It("updates a kv pair", func() {
 			block.Value = model.AllocationBlock{
-				CIDR: testutils.MustParseCIDR("192.168.0.0/26"),
+				CIDR: testutils.MustParseNetwork("192.168.0.0/26"),
 			}
 
 			kv, err := etcdClient.Update(&block)
@@ -108,7 +108,7 @@ var _ = Describe("Backend tests", func() {
 
 		It("updates a kv pair", func() {
 			block.Value = model.AllocationBlock{
-				CIDR: testutils.MustParseCIDR("192.168.0.0/26"),
+				CIDR: testutils.MustParseNetwork("192.168.0.0/26"),
 			}
 
 			kv, err := etcdClient.Apply(&block)
@@ -122,7 +122,7 @@ var _ = Describe("Backend tests", func() {
 
 		It("creates a kv pair", func() {
 			block.Key = model.BlockKey{
-				CIDR: testutils.MustParseCIDR("192.168.0.0/26"),
+				CIDR: testutils.MustParseNetwork("192.168.0.0/26"),
 			}
 
 			kv, err := etcdClient.Apply(&block)
@@ -136,7 +136,7 @@ var _ = Describe("Backend tests", func() {
 
 		It("sets revision field", func() {
 			block.Value = model.AllocationBlock{
-				CIDR: testutils.MustParseCIDR("192.168.0.0/26"),
+				CIDR: testutils.MustParseNetwork("192.168.0.0/26"),
 			}
 
 			kv, err := etcdClient.Apply(&block)

--- a/lib/backend/k8s/resources/ippools_conversion.go
+++ b/lib/backend/k8s/resources/ippools_conversion.go
@@ -16,16 +16,16 @@ package resources
 
 import (
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	kapi "k8s.io/client-go/pkg/api"
 )
 
-// ThirdPartyToIPPool takes a Kubrnetes ThirdPartyResource representation
-// of a Calico IP Pool and returns the equivalen IPPool object.
+// ThirdPartyToIPPool takes a Kubernetes ThirdPartyResource representation
+// of a Calico IP Pool and returns the equivalent IPPool object.
 func ThirdPartyToIPPool(t *thirdparty.IpPool) *model.KVPair {
 	v := model.IPPool{}
 	err := json.Unmarshal([]byte(t.Spec.Value), &v)

--- a/lib/backend/model/ippool.go
+++ b/lib/backend/model/ippool.go
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -93,6 +94,7 @@ func (options IPPoolListOptions) KeyFromDefaultPath(path string) Key {
 type IPPool struct {
 	CIDR          net.IPNet `json:"cidr"`
 	IPIPInterface string    `json:"ipip"`
+	IPIPMode      ipip.Mode `json:"ipip_mode"`
 	Masquerade    bool      `json:"masquerade"`
 	IPAM          bool      `json:"ipam"`
 	Disabled      bool      `json:"disabled"`

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -43,8 +43,10 @@ type Node struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// BGP specific configuration
-	BGPIPv4     *net.IP
-	BGPIPv6     *net.IP
+	BGPIPv4Addr *net.IP
+	BGPIPv6Addr *net.IP
+	BGPIPv4Net  *net.IPNet
+	BGPIPv6Net  *net.IPNet
 	BGPASNumber *numorstring.ASNumber
 }
 

--- a/lib/client/ipam_test.go
+++ b/lib/client/ipam_test.go
@@ -125,7 +125,7 @@ var _ = Describe("IPAM tests", func() {
 		ic := setupIPAMClient(c, true)
 
 		host := "host-A"
-		pool1 := testutils.MustParseCIDR("10.0.0.0/24")
+		pool1 := testutils.MustParseNetwork("10.0.0.0/24")
 		var block cnet.IPNet
 
 		testutils.CreateNewIPPool(*c, "10.0.0.0/24", false, false, true)
@@ -183,7 +183,7 @@ var _ = Describe("IPAM tests", func() {
 		})
 
 		// Step-4: Create a new IP Pool.
-		pool2 := testutils.MustParseCIDR("20.0.0.0/24")
+		pool2 := testutils.MustParseNetwork("20.0.0.0/24")
 		testutils.CreateNewIPPool(*c, "20.0.0.0/24", false, false, true)
 
 		// Step-5: AutoAssign 1 IP without specifying a pool - expect the assigned IP is from pool2.
@@ -241,8 +241,8 @@ var _ = Describe("IPAM tests", func() {
 		ic := setupIPAMClient(c, true)
 
 		host := "host-A"
-		pool1 := testutils.MustParseCIDR("10.0.0.0/24")
-		pool2 := testutils.MustParseCIDR("20.0.0.0/24")
+		pool1 := testutils.MustParseNetwork("10.0.0.0/24")
+		pool2 := testutils.MustParseNetwork("20.0.0.0/24")
 		var block1, block2 cnet.IPNet
 
 		testutils.CreateNewIPPool(*c, "10.0.0.0/24", false, false, true)
@@ -341,8 +341,8 @@ var _ = Describe("IPAM tests", func() {
 		ic := setupIPAMClient(c, true)
 
 		host := "host-A"
-		pool1 := testutils.MustParseCIDR("10.0.0.0/24")
-		pool2 := testutils.MustParseCIDR("20.0.0.0/24")
+		pool1 := testutils.MustParseNetwork("10.0.0.0/24")
+		pool2 := testutils.MustParseNetwork("20.0.0.0/24")
 
 		testutils.CreateNewIPPool(*c, "10.0.0.0/24", false, false, true)
 		testutils.CreateNewIPPool(*c, "20.0.0.0/24", false, false, true)
@@ -485,7 +485,7 @@ var _ = Describe("IPAM tests", func() {
 
 	DescribeTable("ClaimAffinity: claim IPNet vs actual number of blocks claimed",
 		func(args testArgsClaimAff) {
-			inIPNet := testutils.MustParseCIDR(args.inNet)
+			inIPNet := testutils.MustParseNetwork(args.inNet)
 			c, _ := testutils.NewClient("")
 
 			// Wipe clean etcd, create a new client, and pools when cleanEnv flag is true.
@@ -609,7 +609,7 @@ func testIPAMAssignIP(inIP net.IP, host string, poolSubnet []string, cleanEnv bo
 // testIPAMAutoAssign takes number of requested IPv4 and IPv6, and hostname, and setus up/cleans up client and etcd,
 // then it calls AutoAssign (function under test) and returns the number of returned IPv4 and IPv6 addresses and returned error.
 func testIPAMAutoAssign(inv4, inv6 int, host string, cleanEnv bool, poolSubnet []string, usePool string) (int, int, error) {
-	fromPool := testutils.MustParseCIDR(usePool)
+	fromPool := testutils.MustParseNetwork(usePool)
 	args := client.AutoAssignArgs{
 		Num4:      inv4,
 		Num6:      inv6,

--- a/lib/client/ippool_e2e_test.go
+++ b/lib/client/ippool_e2e_test.go
@@ -43,6 +43,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -169,8 +170,8 @@ var _ = Describe("IPPool tests", func() {
 
 		// Test 1: Pass two fully populated IPPoolSpecs and expect the series of operations to succeed.
 		Entry("Two fully populated IPPoolSpecs",
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("10.0.0.0/24")},
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("192.168.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("10.0.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("192.168.0.0/24")},
 			api.IPPoolSpec{
 				IPIP: &api.IPIPConfiguration{
 					Enabled: true,
@@ -186,8 +187,8 @@ var _ = Describe("IPPool tests", func() {
 
 		// Test 2: Pass one partially populated IPPoolSpec and another fully populated IPPoolSpec and expect the series of operations to succeed.
 		Entry("One partially populated IPPoolSpec and another fully populated IPPoolSpec",
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("10.0.0.0/24")},
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("192.168.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("10.0.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("192.168.0.0/24")},
 			api.IPPoolSpec{
 				IPIP: &api.IPIPConfiguration{
 					Enabled: true,
@@ -201,8 +202,8 @@ var _ = Describe("IPPool tests", func() {
 
 		// Test 3: Pass one fully populated IPPoolSpec and another empty IPPoolSpec and expect the series of operations to succeed.
 		Entry("One fully populated IPPoolSpec and another empty IPPoolSpec",
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("10.0.0.0/24")},
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("192.168.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("10.0.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("192.168.0.0/24")},
 			api.IPPoolSpec{
 				IPIP: &api.IPIPConfiguration{
 					Enabled: true,
@@ -215,8 +216,8 @@ var _ = Describe("IPPool tests", func() {
 
 		// Test 4: Pass two fully populated IPPoolSpecs with two IPPoolMetadata (one IPv4 and another IPv6) and expect the series of operations to succeed.
 		Entry("Two fully populated IPPoolSpecs with two IPPoolMetadata (one IPv4 and another IPv6)",
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("10.0.0.0/24")},
-			api.IPPoolMetadata{CIDR: testutils.MustParseCIDR("fe80::00/120")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("10.0.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("fe80::00/120")},
 			api.IPPoolSpec{
 				IPIP: &api.IPIPConfiguration{
 					Enabled: true,
@@ -230,6 +231,38 @@ var _ = Describe("IPPool tests", func() {
 				},
 				NATOutgoing: false,
 				Disabled:    false,
-			}),
+			},
+		),
+
+		// Test 5: Test starting with IPIP (cross subnet mode) and moving to no IPIP
+		Entry("IPIP (cross subnet mode) and moving to no IPIP",
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("10.0.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("fe80::00/120")},
+			api.IPPoolSpec{
+				IPIP: &api.IPIPConfiguration{
+					Enabled: true,
+					Mode:    ipip.CrossSubnet,
+				},
+			},
+			api.IPPoolSpec{},
+		),
+
+		// Test 6: Test starting with IPIP (cross subnet mode) and moving to IPIP disabled (keeping IPIP mode)
+		Entry("IPIP (cross subnet mode) and moving to IPIP disabled (keeping IPIP mode)",
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("10.0.0.0/24")},
+			api.IPPoolMetadata{CIDR: testutils.MustParseNetwork("fe80::00/120")},
+			api.IPPoolSpec{
+				IPIP: &api.IPIPConfiguration{
+					Enabled: true,
+					Mode:    ipip.CrossSubnet,
+				},
+			},
+			api.IPPoolSpec{
+				IPIP: &api.IPIPConfiguration{
+					Enabled: false,
+					Mode:    ipip.CrossSubnet,
+				},
+			},
+		),
 	)
 })

--- a/lib/client/node_e2e_test.go
+++ b/lib/client/node_e2e_test.go
@@ -41,8 +41,8 @@ import (
 )
 
 var _ = Describe("Node tests", func() {
-	ipv4 := testutils.MustParseIP("1.2.3.4")
-	ipv6 := testutils.MustParseIP("aa::bb:dd")
+	cidrv4 := testutils.MustParseCIDR("1.2.3.5/24")
+	cidrv6 := testutils.MustParseCIDR("aa::bb00:0001/104")
 	asn := numorstring.ASNumber(12345)
 
 	DescribeTable("Node e2e tests",
@@ -158,31 +158,32 @@ var _ = Describe("Node tests", func() {
 			Expect(len(nodeList.Items)).To(Equal(0))
 		},
 
-		// Test 1: One IPv4 and one IPv6 nodespecs.  One with ASNumber, one without.
+		// Test 1: One IPv4 and one IPv6 nodespecs (+ opposite versioned networks).
+		//         One with ASNumber, one without.
 		Entry("Two fully populated NodeSpecs",
 			api.NodeMetadata{Name: "node1"},
 			api.NodeMetadata{Name: "node2"},
 			api.NodeSpec{
 				BGP: &api.NodeBGPSpec{
-					IPv4Address: &ipv4,
+					IPv4Address: &cidrv4,
 				},
 			},
 			api.NodeSpec{
 				BGP: &api.NodeBGPSpec{
-					IPv6Address: &ipv6,
+					IPv6Address: &cidrv6,
 					ASNumber:    &asn,
 				},
 			}),
 
-		// Test 2: BGP IPv4 and 6, and no BGP.
+		// Test 2: One with BGP IPv4 and 6, and one with no BGP.
 		Entry("Two fully populated NodeSpecs",
 			api.NodeMetadata{Name: "node1"},
 			api.NodeMetadata{Name: "node2"},
 			api.NodeSpec{},
 			api.NodeSpec{
 				BGP: &api.NodeBGPSpec{
-					IPv4Address: &ipv4,
-					IPv6Address: &ipv6,
+					IPv4Address: &cidrv4,
+					IPv6Address: &cidrv6,
 					ASNumber:    &asn,
 				},
 			}),

--- a/lib/client/rule.go
+++ b/lib/client/rule.go
@@ -17,6 +17,7 @@ package client
 import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // ruleActionAPIToBackend converts the rule action field value from the API
@@ -67,7 +68,7 @@ func ruleAPIToBackend(ar api.Rule) model.Rule {
 		SrcSelector: ar.Source.Selector,
 		SrcPorts:    ar.Source.Ports,
 		DstTag:      ar.Destination.Tag,
-		DstNet:      ar.Destination.Net,
+		DstNet:      normalizeIPNet(ar.Destination.Net),
 		DstSelector: ar.Destination.Selector,
 		DstPorts:    ar.Destination.Ports,
 
@@ -76,10 +77,19 @@ func ruleAPIToBackend(ar api.Rule) model.Rule {
 		NotSrcSelector: ar.Source.NotSelector,
 		NotSrcPorts:    ar.Source.NotPorts,
 		NotDstTag:      ar.Destination.NotTag,
-		NotDstNet:      ar.Destination.NotNet,
+		NotDstNet:      normalizeIPNet(ar.Destination.NotNet),
 		NotDstSelector: ar.Destination.NotSelector,
 		NotDstPorts:    ar.Destination.NotPorts,
 	}
+}
+
+// normalizeIPNet converts an IPNet to a network by ensuring the IP address
+// is correctly masked.
+func normalizeIPNet(n *net.IPNet) *net.IPNet {
+	if n == nil {
+		return nil
+	}
+	return n.Network()
 }
 
 // ruleBackendToAPI convert a Backend Rule structure to an API Rule structure.

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -126,9 +126,13 @@ func (w *workloadEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.K
 		return nil, err
 	}
 
+	// IP networks are stored in the datastore in separate IPv4 and IPv6
+	// fields.  We normalise the network to ensure the IP is correctly
+	// masked.
 	ipv4Nets := []net.IPNet{}
 	ipv6Nets := []net.IPNet{}
 	for _, n := range ah.Spec.IPNetworks {
+		n = *(n.Network())
 		if n.Version() == 4 {
 			ipv4Nets = append(ipv4Nets, n)
 		} else {

--- a/lib/client/workloadendpoint_e2e_test.go
+++ b/lib/client/workloadendpoint_e2e_test.go
@@ -49,10 +49,10 @@ import (
 )
 
 var _ = Describe("WorkloadEndpoint tests", func() {
-	cidr1 := testutils.MustParseCIDR("10.0.0.0/24")
-	cidr2 := testutils.MustParseCIDR("20.0.0.0/24")
-	cidr3 := testutils.MustParseCIDR("192.168.0.0/24")
-	cidr4 := testutils.MustParseCIDR("172.56.0.0/24")
+	cidr1 := testutils.MustParseNetwork("10.0.0.0/24")
+	cidr2 := testutils.MustParseNetwork("20.0.0.0/24")
+	cidr3 := testutils.MustParseNetwork("192.168.0.0/24")
+	cidr4 := testutils.MustParseNetwork("172.56.0.0/24")
 	mac1, _ := net.ParseMAC("01:23:45:67:89:ab")
 	mac2, _ := net.ParseMAC("CA:FE:00:01:02:03")
 	ipv41 := testutils.MustParseIP("10.0.0.0")

--- a/lib/ipip/doc.go
+++ b/lib/ipip/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package ipip implements a field type that represent different ipip modes.
+*/
+package ipip

--- a/lib/ipip/ipip.go
+++ b/lib/ipip/ipip.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipip
+
+type Mode string
+
+const (
+	Undefined   Mode = ""
+	Always           = "always"
+	CrossSubnet      = "cross-subnet"
+)
+
+const DefaultMode = Always

--- a/lib/testutils/net.go
+++ b/lib/testutils/net.go
@@ -19,12 +19,27 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
-func MustParseCIDR(c string) net.IPNet {
+// MustParseNetwork parses the string into a net.IPNet.  The IP address in the
+// IPNet is masked.
+func MustParseNetwork(c string) net.IPNet {
 	_, cidr, err := gonet.ParseCIDR(c)
 	if err != nil {
 		panic(err)
 	}
 	return net.IPNet{*cidr}
+}
+
+// MustParseCIDR parses the string into a net.IPNet.  The IP address in the
+// IPNet is not masked.
+func MustParseCIDR(c string) net.IPNet {
+	ip, cidr, err := gonet.ParseCIDR(c)
+	if err != nil {
+		panic(err)
+	}
+	n := net.IPNet{}
+	n.IP = ip
+	n.Mask = cidr.Mask
+	return n
 }
 
 func MustParseIP(i string) net.IP {

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -28,10 +28,10 @@ var numProtocol1 = numorstring.ProtocolFromInt(240)
 var icmpType1 = 100
 var icmpCode1 = 200
 
-var cidr1 = MustParseCIDR("10.0.0.1/24")
-var cidr2 = MustParseCIDR("20.0.0.1/24")
-var cidrv61 = MustParseCIDR("abcd:5555::/120")
-var cidrv62 = MustParseCIDR("abcd:2345::/120")
+var cidr1 = MustParseNetwork("10.0.0.1/24")
+var cidr2 = MustParseNetwork("20.0.0.1/24")
+var cidrv61 = MustParseNetwork("abcd:5555::/120")
+var cidrv62 = MustParseNetwork("abcd:2345::/120")
 
 var icmp1 = api.ICMPFields{
 	Type: &icmpType1,

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -240,13 +240,23 @@ func validateWorkloadEndpointSpec(v *validator.Validate, structLevel *validator.
 		}
 	}
 
+	if w.IPv4Gateway != nil && w.IPv4Gateway.Version() != 4 {
+		structLevel.ReportError(reflect.ValueOf(w.IPv4Gateway),
+			"IPv4Gateway", "", reason("invalid IPv4 gateway address specified"))
+	}
+
+	if w.IPv6Gateway != nil && w.IPv6Gateway.Version() != 6 {
+		structLevel.ReportError(reflect.ValueOf(w.IPv6Gateway),
+			"IPv6Gateway", "", reason("invalid IPv6 gateway address specified"))
+	}
+
 	// If NATs have been specified, then they should each be within the configured networks of
 	// the endpoint.
 	if len(w.IPNATs) > 0 {
-		// Check each NAT to ensure it is within the configured networks.  If any
-		// are not then exit without further checks.
 		valid := false
 		for _, nat := range w.IPNATs {
+			// Check each NAT to ensure it is within the configured networks.  If any
+			// are not then exit without further checks.
 			valid = false
 			for _, nw := range w.IPNetworks {
 				if nw.Contains(nat.InternalIP.IP) {
@@ -330,8 +340,20 @@ func validateRule(v *validator.Validate, structLevel *validator.StructLevel) {
 func validateNodeSpec(v *validator.Validate, structLevel *validator.StructLevel) {
 	ns := structLevel.CurrentStruct.Interface().(api.NodeSpec)
 
-	if ns.BGP != nil && ns.BGP.IPv4Address == nil && ns.BGP.IPv6Address == nil {
-		structLevel.ReportError(reflect.ValueOf(ns.BGP.IPv4Address),
-			"BGP.IPv4Address", "", reason("no BGP IP address specified"))
+	if ns.BGP != nil {
+		if ns.BGP.IPv4Address == nil && ns.BGP.IPv6Address == nil {
+			structLevel.ReportError(reflect.ValueOf(ns.BGP.IPv4Address),
+				"BGP.IPv4Address", "", reason("no BGP IP address and subnet specified"))
+		}
+
+		if ns.BGP.IPv4Address != nil && ns.BGP.IPv4Address.Version() != 4 {
+			structLevel.ReportError(reflect.ValueOf(ns.BGP.IPv4Address),
+				"BGP.IPv4Address", "", reason("invalid IPv4 address and subnet specified"))
+		}
+
+		if ns.BGP.IPv6Address != nil && ns.BGP.IPv6Address.Version() != 6 {
+			structLevel.ReportError(reflect.ValueOf(ns.BGP.IPv6Address),
+				"BGP.IPv6Address", "", reason("invalid IPv6 address and subnet specified"))
+		}
 	}
 }

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -42,15 +42,15 @@ func init() {
 	ipv4_2 := testutils.MustParseIP("100.200.0.0")
 	ipv6_1 := testutils.MustParseIP("aabb:aabb::ffff")
 	ipv6_2 := testutils.MustParseIP("aabb::abcd")
-	netv4_1 := testutils.MustParseCIDR("1.2.3.4/32")
-	netv4_2 := testutils.MustParseCIDR("1.2.0.0/32")
-	netv4_3 := testutils.MustParseCIDR("1.2.3.0/26")
-	netv4_4 := testutils.MustParseCIDR("1.2.3.4/10")
-	netv4_5 := testutils.MustParseCIDR("1.2.3.4/27")
-	netv6_1 := testutils.MustParseCIDR("aabb:aabb::ffff/128")
-	netv6_2 := testutils.MustParseCIDR("aabb:aabb::/128")
-	netv6_3 := testutils.MustParseCIDR("aabb:aabb::ffff/122")
-	netv6_4 := testutils.MustParseCIDR("aabb:aabb::ffff/10")
+	netv4_1 := testutils.MustParseNetwork("1.2.3.4/32")
+	netv4_2 := testutils.MustParseNetwork("1.2.0.0/32")
+	netv4_3 := testutils.MustParseNetwork("1.2.3.0/26")
+	netv4_4 := testutils.MustParseNetwork("1.2.3.4/10")
+	netv4_5 := testutils.MustParseNetwork("1.2.3.4/27")
+	netv6_1 := testutils.MustParseNetwork("aabb:aabb::ffff/128")
+	netv6_2 := testutils.MustParseNetwork("aabb:aabb::/128")
+	netv6_3 := testutils.MustParseNetwork("aabb:aabb::ffff/122")
+	netv6_4 := testutils.MustParseNetwork("aabb:aabb::ffff/10")
 
 	// Perform basic validation of different fields and structures to test simple valid/invalid
 	// scenarios.  This does not test precise error strings - but does cover a lot of the validation
@@ -422,10 +422,12 @@ func init() {
 			}, false),
 
 		// (API) NodeSpec
-		Entry("should accept node with IPv4 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: &ipv4_1}}, true),
-		Entry("should accept node with IPv6 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: &ipv6_1}}, true),
+		Entry("should accept node with IPv4 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: &netv4_1}}, true),
+		Entry("should accept node with IPv6 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: &netv6_1}}, true),
 		Entry("should accept node with no BGP", api.NodeSpec{}, true),
 		Entry("should reject node with BGP but no IPs", api.NodeSpec{BGP: &api.NodeBGPSpec{}}, false),
+		Entry("should reject node with IPv6 address in IPv4 field", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: &netv6_1}}, false),
+		Entry("should reject node with IPv4 address in IPv6 field", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: &netv4_1}}, false),
 	)
 }
 


### PR DESCRIPTION
@caseydavenport :  Added you to the PR, but basically same as we discussed.

This PR adds the IPv4 and IPv6 subnet fields to the node resource.  The calico/node will be updated to use this subnet information to determine whether to use IPIP (when it's enabled on the pool) or not based on whether the originating router is off sub-net.

-  If we don't have a configuration option on the pool that say "always use IPIP" or "Only use IPIP off subnet" then we might want to consider making these subnet fields more "IPIP" specific (i.e. making it clear that these are used for selective IPIP).
-  If we do introduce a config option for when to use IPIP then the name of these fields is probably just fine as it is.

Or start adding more subnet fields ... or .... :-)