### PR TITLE
Add IP Pool support to k8s backend

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -178,11 +178,7 @@ func (c *KubeClient) createThirdPartyResources() error {
 	}
 
 	// Ensure the IP Pool TPR exists.
-	err = c.ipPoolClient.EnsureInitialized()
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.ipPoolClient.EnsureInitialized()
 }
 
 // waitForClusterType polls until GlobalConfig is ready, or until 30 seconds have passed.

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"k8s.io/client-go/pkg/api/unversioned"
 	k8sapi "k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
@@ -400,6 +402,56 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(updGC.Value.(string)).To(Equal(gc.Value.(string)))
 			Expect(updGC.Key.(model.GlobalConfigKey).Name).To(Equal("ClusterGUID"))
 			Expect(updGC.Revision).NotTo(BeNil())
+		})
+	})
+
+	It("should support setting and getting IP Pools", func() {
+		By("listing IP pools when none have been created", func() {
+			_, err := c.List(model.IPPoolListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("creating an IP Pool and getting it back", func() {
+			_, cidr, _ := cnet.ParseCIDR("192.168.0.0/16")
+			pool := &model.KVPair{
+				Key: model.IPPoolKey{
+					CIDR: *cidr,
+				},
+				Value: &model.IPPool{
+					CIDR:          *cidr,
+					IPIPInterface: "tunl0",
+					Masquerade:    true,
+					IPAM:          true,
+					Disabled:      true,
+				},
+			}
+			_, err := c.Create(pool)
+			Expect(err).NotTo(HaveOccurred())
+
+			receivedPool, err := c.Get(pool.Key)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedPool.Value.(*model.IPPool).CIDR).To(Equal(*cidr))
+			Expect(receivedPool.Value.(*model.IPPool).IPIPInterface).To(Equal("tunl0"))
+			Expect(receivedPool.Value.(*model.IPPool).Masquerade).To(Equal(true))
+			Expect(receivedPool.Value.(*model.IPPool).IPAM).To(Equal(true))
+			Expect(receivedPool.Value.(*model.IPPool).Disabled).To(Equal(true))
+		})
+
+		By("deleting the IP Pool", func() {
+			_, cidr, _ := cnet.ParseCIDR("192.168.0.0/16")
+			err := c.Delete(&model.KVPair{
+				Key: model.IPPoolKey{
+					CIDR: *cidr,
+				},
+				Value: &model.IPPool{
+					CIDR:          *cidr,
+					IPIPInterface: "tunl0",
+					Masquerade:    true,
+					IPAM:          true,
+					Disabled:      true,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/lib/backend/k8s/resources/ippools.go
+++ b/lib/backend/k8s/resources/ippools.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	goerrors "errors"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/utils"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+
+	"k8s.io/client-go/kubernetes"
+	kerrors "k8s.io/client-go/pkg/api/errors"
+	kapiv1 "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/rest"
+)
+
+func NewIPPools(c *kubernetes.Clientset, r *rest.RESTClient) api.Client {
+	return &client{
+		clientSet: c,
+		tprClient: r,
+	}
+}
+
+// Implements the api.Client interface for pools.
+type client struct {
+	clientSet *kubernetes.Clientset
+	tprClient *rest.RESTClient
+}
+
+func (c *client) Create(kvp *model.KVPair) (*model.KVPair, error) {
+	tpr := IPPoolToThirdParty(kvp)
+	res := thirdparty.IpPool{}
+	req := c.tprClient.Post().
+		Resource("ippools").
+		Namespace("kube-system").
+		Body(tpr)
+	err := req.Do().Into(&res)
+	if err != nil {
+		return nil, utils.K8sErrorToCalico(err, kvp.Key)
+	}
+	kvp.Revision = res.Metadata.ResourceVersion
+	return kvp, nil
+}
+
+func (c *client) Update(kvp *model.KVPair) (*model.KVPair, error) {
+	tpr := IPPoolToThirdParty(kvp)
+	res := thirdparty.IpPool{}
+	req := c.tprClient.Put().
+		Resource("ippools").
+		Namespace("kube-system").
+		Body(tpr).
+		Name(tpr.Metadata.Name)
+	err := req.Do().Into(&res)
+	if err != nil {
+		return nil, utils.K8sErrorToCalico(err, kvp.Key)
+	}
+	kvp.Revision = tpr.Metadata.ResourceVersion
+	return kvp, nil
+}
+
+func (c *client) Apply(kvp *model.KVPair) (*model.KVPair, error) {
+	updated, err := c.Update(kvp)
+	if err != nil {
+		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
+			return nil, err
+		}
+
+		// It doesn't exist - create it.
+		updated, err = c.Create(kvp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return updated, nil
+}
+
+func (c *client) Delete(kvp *model.KVPair) error {
+	result := c.tprClient.Delete().
+		Resource("ippools").
+		Namespace("kube-system").
+		Name(tprName(kvp.Key.(model.IPPoolKey))).
+		Do()
+
+		// TODO: Error conversion
+	return utils.K8sErrorToCalico(result.Error(), kvp.Key)
+}
+
+func (c *client) Get(key model.Key) (*model.KVPair, error) {
+	tpr := thirdparty.IpPool{}
+	err := c.tprClient.Get().
+		Resource("ippools").
+		Namespace("kube-system").
+		Name(tprName(key.(model.IPPoolKey))).
+		Do().Into(&tpr)
+	if err != nil {
+		return nil, utils.K8sErrorToCalico(err, key)
+	}
+
+	return ThirdPartyToIPPool(&tpr), nil
+}
+
+func (c *client) List(list model.ListInterface) ([]*model.KVPair, error) {
+	kvps := []*model.KVPair{}
+	tprs := thirdparty.IpPoolList{}
+	l := list.(model.IPPoolListOptions)
+
+	// Build the request.
+	req := c.tprClient.Get().Resource("ippools").Namespace("kube-system")
+	if l.CIDR.IP != nil {
+		k := model.IPPoolKey{CIDR: l.CIDR}
+		req.Name(tprName(k))
+	}
+
+	// Perform the request.
+	err := req.Do().Into(&tprs)
+	if err != nil {
+		// Don't return errors for "not found".  This just
+		// means there are no IPPools, and we should return
+		// an empty list.
+		if !kerrors.IsNotFound(err) {
+			return nil, utils.K8sErrorToCalico(err, l)
+		}
+	}
+
+	// Convert them to KVPairs.
+	for _, tpr := range tprs.Items {
+		kvps = append(kvps, ThirdPartyToIPPool(&tpr))
+	}
+	return kvps, nil
+}
+
+func (c *client) EnsureInitialized() error {
+	log.Info("Ensuring IP Pool ThirdPartyResource exists")
+	tpr := extensions.ThirdPartyResource{
+		ObjectMeta: kapiv1.ObjectMeta{
+			Name:      "ip-pool.projectcalico.org",
+			Namespace: "kube-system",
+		},
+		Description: "Calico IP Pools",
+		Versions:    []extensions.APIVersion{{Name: "v1"}},
+	}
+	_, err := c.clientSet.Extensions().ThirdPartyResources().Create(&tpr)
+	if err != nil {
+		// Don't care if it already exists.
+		if !kerrors.IsAlreadyExists(err) {
+			return goerrors.New(fmt.Sprintf("failed to create ThirdPartyResource %s: %s", tpr.ObjectMeta.Name, err))
+		}
+	}
+	return nil
+}
+
+// Syncer is not implemented for ip pools.
+func (c *client) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	return fakeSyncer{}
+}
+
+type fakeSyncer struct{}
+
+func (f fakeSyncer) Start() {}

--- a/lib/backend/k8s/resources/ippools_conversion.go
+++ b/lib/backend/k8s/resources/ippools_conversion.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"encoding/json"
+	log "github.com/Sirupsen/logrus"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	kapi "k8s.io/client-go/pkg/api"
+)
+
+// ThirdPartyToIPPool takes a Kubrnetes ThirdPartyResource representation
+// of a Calico IP Pool and returns the equivalen IPPool object.
+func ThirdPartyToIPPool(t *thirdparty.IpPool) *model.KVPair {
+	v := model.IPPool{}
+	err := json.Unmarshal([]byte(t.Spec.Value), &v)
+	if err != nil {
+		panic(err)
+	}
+	return &model.KVPair{
+		Key:      model.IPPoolKey{CIDR: v.CIDR},
+		Value:    &v,
+		Revision: t.Metadata.ResourceVersion,
+	}
+}
+
+// IPPoolToThirdParty takes a Calico IP Pool and returns the equivalent
+// ThirdPartyResource representation.
+func IPPoolToThirdParty(kvp *model.KVPair) *thirdparty.IpPool {
+	v, err := json.Marshal(kvp.Value.(*model.IPPool))
+	if err != nil {
+		log.Fatalf("Error marshalling IPPool value: %s", err)
+	}
+
+	tpr := thirdparty.IpPool{
+		Metadata: kapi.ObjectMeta{
+			// Names in Kubernetes must be lower-case.
+			Name: tprName(kvp.Key.(model.IPPoolKey)),
+		},
+		Spec: thirdparty.IpPoolSpec{
+			Value: string(v),
+		},
+	}
+	if kvp.Revision != nil {
+		tpr.Metadata.ResourceVersion = kvp.Revision.(string)
+	}
+	return &tpr
+}
+
+// tprName converts the given IPPool key into a unique third party resource
+// name.
+func tprName(key model.IPPoolKey) string {
+	name := strings.Replace(key.CIDR.String(), ".", "-", 3)
+	name = strings.Replace(name, ":", "-", 7)
+	name = strings.Replace(name, "/", "-", 1)
+	return name
+}

--- a/lib/backend/k8s/resources/ippools_conversion.go
+++ b/lib/backend/k8s/resources/ippools_conversion.go
@@ -30,7 +30,7 @@ func ThirdPartyToIPPool(t *thirdparty.IpPool) *model.KVPair {
 	v := model.IPPool{}
 	err := json.Unmarshal([]byte(t.Spec.Value), &v)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Error unmarshalling IPPool value: %s", err)
 	}
 	return &model.KVPair{
 		Key:      model.IPPoolKey{CIDR: v.CIDR},

--- a/lib/backend/k8s/resources/util.go
+++ b/lib/backend/k8s/resources/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package resources
 
 import (
 	"github.com/projectcalico/libcalico-go/lib/errors"

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -15,6 +15,7 @@
 package k8s
 
 import (
+	"fmt"
 	"time"
 
 	"reflect"
@@ -22,6 +23,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/compat"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 
@@ -36,7 +38,7 @@ func newSyncer(kc KubeClient, callbacks api.SyncerCallbacks) *kubeSyncer {
 	syn := &kubeSyncer{
 		kc:         kc,
 		callbacks:  callbacks,
-		tracker:    map[model.Key]interface{}{},
+		tracker:    map[string]model.KVPair{},
 		labelCache: map[string]map[string]string{},
 	}
 	return syn
@@ -46,7 +48,7 @@ type kubeSyncer struct {
 	kc         KubeClient
 	callbacks  api.SyncerCallbacks
 	OneShot    bool
-	tracker    map[model.Key]interface{}
+	tracker    map[string]model.KVPair
 	labelCache map[string]map[string]string
 }
 
@@ -56,6 +58,7 @@ type resourceVersions struct {
 	namespaceVersion     string
 	networkPolicyVersion string
 	globalConfigVersion  string
+	poolVersion          string
 }
 
 func (syn *kubeSyncer) Start() {
@@ -80,7 +83,7 @@ func (syn *kubeSyncer) sendUpdates(kvps []model.KVPair) {
 func (syn *kubeSyncer) convertKVPairsToUpdates(kvps []model.KVPair) []api.Update {
 	updates := []api.Update{}
 	for _, kvp := range kvps {
-		if _, ok := syn.tracker[kvp.Key]; !ok && kvp.Value == nil {
+		if _, ok := syn.tracker[fmt.Sprintf("%s", kvp.Key)]; !ok && kvp.Value == nil {
 			// The given KVPair is not in the tracker, and is a delete, so no need to
 			// send a delete update.
 			continue
@@ -96,10 +99,10 @@ func (syn *kubeSyncer) updateTracker(updates []api.Update) {
 	for _, upd := range updates {
 		if upd.UpdateType == api.UpdateTypeKVDeleted {
 			log.Debugf("Delete from tracker: %+v", upd.KVPair.Key)
-			delete(syn.tracker, upd.KVPair.Key)
+			delete(syn.tracker, fmt.Sprintf("%s", upd.KVPair.Key))
 		} else {
 			log.Debugf("Update tracker: %+v: %+v", upd.KVPair.Key, upd.KVPair.Revision)
-			syn.tracker[upd.KVPair.Key] = upd.KVPair.Revision
+			syn.tracker[fmt.Sprintf("%s", upd.KVPair.Key)] = upd.KVPair
 		}
 	}
 }
@@ -111,7 +114,7 @@ func (syn *kubeSyncer) getUpdateType(kvp model.KVPair) api.UpdateType {
 	}
 
 	// Not a delete.
-	if _, ok := syn.tracker[kvp.Key]; !ok {
+	if _, ok := syn.tracker[fmt.Sprintf("%s", kvp.Key)]; !ok {
 		// If not a delete and it does not exist in the tracker, this is an add.
 		return api.UpdateTypeKVNew
 	} else {
@@ -127,7 +130,7 @@ func (syn *kubeSyncer) readFromKubernetesAPI() {
 	latestVersions := resourceVersions{}
 
 	// Other watcher vars.
-	var nsChan, poChan, npChan, gcChan <-chan watch.Event
+	var nsChan, poChan, npChan, gcChan, poolChan <-chan watch.Event
 	var event watch.Event
 	var kvp *model.KVPair
 	var opts k8sapi.ListOptions
@@ -187,14 +190,27 @@ func (syn *kubeSyncer) readFromKubernetesAPI() {
 			}
 
 			// Create watcher for Calico global config resources.
-			tprListWatcher := cache.NewListWatchFromClient(
+			globalConfigWatcher := cache.NewListWatchFromClient(
 				syn.kc.tprClient,
 				"globalconfigs",
 				"kube-system",
 				fields.Everything())
-			tprWatch, err := tprListWatcher.WatchFunc(opts)
+			globalConfigWatch, err := globalConfigWatcher.WatchFunc(opts)
 			if err != nil {
 				log.Warnf("Failed to watch GlobalConfig, retrying: %s", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			// Watcher for Calico IP Pool resources.
+			ipPoolWatcher := cache.NewListWatchFromClient(
+				syn.kc.tprClient,
+				"ippools",
+				"kube-system",
+				fields.Everything())
+			ipPoolWatch, err := ipPoolWatcher.WatchFunc(opts)
+			if err != nil {
+				log.Warnf("Failed to watch IPPools, retrying: %s", err)
 				time.Sleep(1 * time.Second)
 				continue
 			}
@@ -202,7 +218,8 @@ func (syn *kubeSyncer) readFromKubernetesAPI() {
 			nsChan = nsWatch.ResultChan()
 			poChan = poWatch.ResultChan()
 			npChan = npWatch.ResultChan()
-			gcChan = tprWatch.ResultChan()
+			gcChan = globalConfigWatch.ResultChan()
+			poolChan = ipPoolWatch.ResultChan()
 
 			// Success - reset the flag.
 			needsResync = false
@@ -267,20 +284,33 @@ func (syn *kubeSyncer) readFromKubernetesAPI() {
 			kvp = syn.parseGlobalConfigEvent(event)
 			latestVersions.globalConfigVersion = kvp.Revision.(string)
 			syn.sendUpdates([]model.KVPair{*kvp})
+		case event = <-poolChan:
+			log.Debugf("Incoming IPPool watch event. Type=%s", event.Type)
+			if needsResync = syn.eventTriggersResync(event); needsResync {
+				// We need to resync.  Break out into the sync loop.
+				log.Warn("Event triggered resync: %+v", event)
+				continue
+			}
+
+			// Event is OK - parse it and send it over the channel.
+			kvp = syn.parseIPPoolEvent(event)
+			latestVersions.poolVersion = kvp.Revision.(string)
+			syn.sendUpdates([]model.KVPair{*kvp})
+
 		}
 	}
 }
 
-func (syn *kubeSyncer) performSnapshotDeletes(exists map[model.Key]bool) {
+func (syn *kubeSyncer) performSnapshotDeletes(exists map[string]*model.KVPair) {
 	log.Info("Checking for any deletes for snapshot")
 	deletes := []model.KVPair{}
 	log.Debugf("Keys in snapshot: %+v", exists)
-	for cachedKey, _ := range syn.tracker {
+	for cachedKey, cachedKvp := range syn.tracker {
 		// Check each cached key to see if it exists in the snapshot.  If it doesn't,
 		// we need to send a delete for it.
 		if _, stillExists := exists[cachedKey]; !stillExists {
 			log.Debugf("Cached key not in snapshot: %+v", cachedKey)
-			deletes = append(deletes, model.KVPair{Key: cachedKey, Value: nil})
+			deletes = append(deletes, model.KVPair{Key: cachedKvp.Key, Value: nil})
 		}
 	}
 	log.Infof("Sending snapshot deletes: %+v", deletes)
@@ -291,17 +321,17 @@ func (syn *kubeSyncer) performSnapshotDeletes(exists map[model.Key]bool) {
 // a mapping of model.Key objects representing the objects which exist in the datastore, and
 // populates the provided resourceVersions with the latest k8s resource version
 // for each.
-func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[model.Key]bool, resourceVersions) {
+func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]*model.KVPair, resourceVersions) {
 	opts := k8sapi.ListOptions{}
 	versions := resourceVersions{}
 	var snap []model.KVPair
-	var keys map[model.Key]bool
+	var keys map[string]*model.KVPair
 
 	// Loop until we successfully are able to accesss the API.
 	for {
 		// Initialize the values to return.
 		snap = []model.KVPair{}
-		keys = map[model.Key]bool{}
+		keys = map[string]*model.KVPair{}
 
 		// Get Namespaces (Profiles)
 		log.Info("Syncing Namespaces")
@@ -325,9 +355,9 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[model.Key]bool, re
 			labels.Revision = profile.Revision
 
 			snap = append(snap, *rules, *tags, *labels)
-			keys[rules.Key] = true
-			keys[tags.Key] = true
-			keys[labels.Key] = true
+			keys[fmt.Sprintf("%s", rules.Key)] = rules
+			keys[fmt.Sprintf("%s", tags.Key)] = tags
+			keys[fmt.Sprintf("%s", labels.Key)] = labels
 		}
 
 		// Get NetworkPolicies (Policies)
@@ -348,7 +378,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[model.Key]bool, re
 		for _, np := range npList.Items {
 			pol, _ := syn.kc.converter.networkPolicyToPolicy(&np)
 			snap = append(snap, *pol)
-			keys[pol.Key] = true
+			keys[fmt.Sprintf("%s", pol.Key)] = pol
 		}
 
 		// Get Pods (WorkloadEndpoints)
@@ -365,7 +395,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[model.Key]bool, re
 			wep, _ := syn.kc.converter.podToWorkloadEndpoint(&po)
 			if wep != nil {
 				snap = append(snap, *wep)
-				keys[wep.Key] = true
+				keys[fmt.Sprintf("%s", wep.Key)] = wep
 			}
 		}
 
@@ -379,7 +409,20 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[model.Key]bool, re
 
 		for _, c := range confList {
 			snap = append(snap, *c)
-			keys[c.Key] = true
+			keys[fmt.Sprintf("%s", c.Key)] = c
+		}
+
+		// Sync IP Pools.
+		poolList, err := syn.kc.List(model.IPPoolListOptions{})
+		if err != nil {
+			log.Warnf("Error syncing IP Pools, retrying: %s", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		for _, p := range poolList {
+			snap = append(snap, *p)
+			keys[fmt.Sprintf("%s", p.Key)] = p
 		}
 
 		// Include ready state.
@@ -390,7 +433,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[model.Key]bool, re
 			continue
 		}
 		snap = append(snap, *ready)
-		keys[ready.Key] = true
+		keys[fmt.Sprintf("%s", ready.Key)] = ready
 
 		log.Infof("Snapshot resourceVersions: %+v", versions)
 		log.Debugf("Created snapshot: %+v", snap)
@@ -522,6 +565,24 @@ func (syn *kubeSyncer) parseGlobalConfigEvent(e watch.Event) *model.KVPair {
 
 	// Convert the received GlobalConfig into a KVPair.
 	kvp := syn.kc.converter.tprToGlobalConfig(gc)
+
+	// For deletes, we need to nil out the Value part of the KVPair
+	if e.Type == watch.Deleted {
+		kvp.Value = nil
+	}
+	return kvp
+}
+
+func (syn *kubeSyncer) parseIPPoolEvent(e watch.Event) *model.KVPair {
+	log.Debug("Parsing IPPool watch event")
+	// First, check the event type.
+	tpr, ok := e.Object.(*thirdparty.IpPool)
+	if !ok {
+		log.Panicf("Invalid IPPool event. Type: %s, Object: %+v", e.Type, e.Object)
+	}
+
+	// Convert the received IPPool into a KVPair.
+	kvp := resources.ThirdPartyToIPPool(tpr)
 
 	// For deletes, we need to nil out the Value part of the KVPair
 	if e.Type == watch.Deleted {

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -368,7 +368,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]bool, resou
 			Timeout(10 * time.Second).
 			Do().Into(&npList)
 		if err != nil {
-			log.Warnf("Error syncing NetworkPolicies, retrying: %s", err)
+			log.Warnf("Error querying NetworkPolicies during snapshot, retrying: %s", err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
@@ -384,7 +384,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]bool, resou
 		log.Info("Syncing Pods")
 		poList, err := syn.kc.clientSet.Pods("").List(opts)
 		if err != nil {
-			log.Warnf("Error syncing Pods, retrying: %s", err)
+			log.Warnf("Error querying Pods during snapshot, retrying: %s", err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
@@ -401,7 +401,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]bool, resou
 		// Sync GlobalConfig.
 		confList, err := syn.kc.listGlobalConfig(model.GlobalConfigListOptions{})
 		if err != nil {
-			log.Warnf("Error syncing GlobalConfig, retrying: %s", err)
+			log.Warnf("Error querying GlobalConfig during snapshot, retrying: %s", err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
@@ -414,7 +414,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]bool, resou
 		// Sync IP Pools.
 		poolList, err := syn.kc.List(model.IPPoolListOptions{})
 		if err != nil {
-			log.Warnf("Error syncing IP Pools, retrying: %s", err)
+			log.Warnf("Error querying IP Pools during snapshot, retrying: %s", err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
@@ -427,7 +427,7 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]bool, resou
 		// Include ready state.
 		ready, err := syn.kc.getReadyStatus(model.ReadyFlagKey{})
 		if err != nil {
-			log.Warnf("Error getting ready status, retrying: %s", err)
+			log.Warnf("Error querying ready status during snapshot, retrying: %s", err)
 			time.Sleep(1 * time.Second)
 			continue
 		}

--- a/lib/backend/k8s/thirdparty/ippool.go
+++ b/lib/backend/k8s/thirdparty/ippool.go
@@ -1,0 +1,77 @@
+package thirdparty
+
+import (
+	"encoding/json"
+
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/meta"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/runtime/schema"
+)
+
+type IpPoolSpec struct {
+	Value string `json:"value"`
+}
+
+type IpPool struct {
+	unversioned.TypeMeta `json:",inline"`
+	Metadata             api.ObjectMeta `json:"metadata"`
+
+	Spec IpPoolSpec `json:"spec"`
+}
+
+type IpPoolList struct {
+	unversioned.TypeMeta `json:",inline"`
+	Metadata             unversioned.ListMeta `json:"metadata"`
+
+	Items []IpPool `json:"items"`
+}
+
+// Required to satisfy Object interface
+func (e *IpPool) GetObjectKind() schema.ObjectKind {
+	return &e.TypeMeta
+}
+
+// Required to satisfy ObjectMetaAccessor interface
+func (e *IpPool) GetObjectMeta() meta.Object {
+	return &e.Metadata
+}
+
+// Required to satisfy Object interface
+func (el *IpPoolList) GetObjectKind() schema.ObjectKind {
+	return &el.TypeMeta
+}
+
+// Required to satisfy ListMetaAccessor interface
+func (el *IpPoolList) GetListMeta() unversioned.List {
+	return &el.Metadata
+}
+
+// The code below is used only to work around a known problem with third-party
+// resources and ugorji. If/when these issues are resolved, the code below
+// should no longer be required.
+
+type IpPoolListCopy IpPoolList
+type IpPoolCopy IpPool
+
+func (g *IpPool) UnmarshalJSON(data []byte) error {
+	tmp := IpPoolCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := IpPool(tmp)
+	*g = tmp2
+	return nil
+}
+
+func (l *IpPoolList) UnmarshalJSON(data []byte) error {
+	tmp := IpPoolListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := IpPoolList(tmp)
+	*l = tmp2
+	return nil
+}

--- a/lib/backend/k8s/thirdparty/ippool.go
+++ b/lib/backend/k8s/thirdparty/ippool.go
@@ -9,10 +9,14 @@ import (
 	"k8s.io/client-go/pkg/runtime/schema"
 )
 
+// IpPoolSpec is the specification of an IP Pool as represented in the Kubernetes
+// ThirdPartyResource API.
 type IpPoolSpec struct {
+	// Value is a json encoded string which can be unmarshalled into a model.IPPool struct.
 	Value string `json:"value"`
 }
 
+// IpPool is the ThirdPartyResource definition of an IPPool in the Kubernetes API.
 type IpPool struct {
 	unversioned.TypeMeta `json:",inline"`
 	Metadata             api.ObjectMeta `json:"metadata"`
@@ -20,6 +24,7 @@ type IpPool struct {
 	Spec IpPoolSpec `json:"spec"`
 }
 
+// IpPoolList is a list of IpPool resources.
 type IpPoolList struct {
 	unversioned.TypeMeta `json:",inline"`
 	Metadata             unversioned.ListMeta `json:"metadata"`
@@ -27,22 +32,22 @@ type IpPoolList struct {
 	Items []IpPool `json:"items"`
 }
 
-// Required to satisfy Object interface
+// GetObjectKind returns the kind of this object.  Required to satisfy Object interface
 func (e *IpPool) GetObjectKind() schema.ObjectKind {
 	return &e.TypeMeta
 }
 
-// Required to satisfy ObjectMetaAccessor interface
+// GetOjbectMeta returns the object metadata of this object. Required to satisfy ObjectMetaAccessor interface
 func (e *IpPool) GetObjectMeta() meta.Object {
 	return &e.Metadata
 }
 
-// Required to satisfy Object interface
+// GetObjectKind returns the kind of this object. Required to satisfy Object interface
 func (el *IpPoolList) GetObjectKind() schema.ObjectKind {
 	return &el.TypeMeta
 }
 
-// Required to satisfy ListMetaAccessor interface
+// GetListMeta returns the list metadata of this object. Required to satisfy ListMetaAccessor interface
 func (el *IpPoolList) GetListMeta() unversioned.List {
 	return &el.Metadata
 }

--- a/lib/backend/k8s/utils/util.go
+++ b/lib/backend/k8s/utils/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package utils
 
 import (
 	"github.com/projectcalico/libcalico-go/lib/errors"
@@ -20,9 +20,13 @@ import (
 	kerrors "k8s.io/client-go/pkg/api/errors"
 )
 
-// k8sErrorToCalico returns the equivalent libcalico error for the given
+// K8sErrorToCalico returns the equivalent libcalico error for the given
 // kubernetes error.
-func k8sErrorToCalico(ke error, id interface{}) error {
+func K8sErrorToCalico(ke error, id interface{}) error {
+	if ke == nil {
+		return nil
+	}
+
 	if kerrors.IsAlreadyExists(ke) {
 		return errors.ErrorResourceAlreadyExists{
 			Err:        ke,

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -59,6 +59,10 @@ type Key interface {
 
 	// valueType returns the object type associated with this key.
 	valueType() reflect.Type
+
+	// String returns a unique string representation of this key.  The string
+	// returned by this method must uniquely identify this Key.
+	String() string
 }
 
 // Interface used to perform datastore lookups.


### PR DESCRIPTION
Also investigating moving the various list/get/create/delete methods into their own packages so we don't end up with a giant k8s.go with a whole bunch of logic in it.

We can also move the "conversion" methods out into their own resource specific directories to break up that monolith as well.