### PR TITLE
Add Node calls to k8s backend

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -55,6 +55,7 @@ type KubeClient struct {
 
 	// Clients for interacting with Calico resources.
 	ipPoolClient api.Client
+	nodeClient api.Client
 }
 
 type KubeConfig struct {
@@ -122,6 +123,7 @@ func NewKubeClient(kc *KubeConfig) (*KubeClient, error) {
 
 	// Create the Calico sub-clients.
 	kubeClient.ipPoolClient = resources.NewIPPools(cs, tprClient)
+	kubeClient.nodeClient = resources.NewNodeClient(cs, tprClient)
 
 	return kubeClient, nil
 }
@@ -281,6 +283,8 @@ func (c *KubeClient) Create(d *model.KVPair) (*model.KVPair, error) {
 		return c.createGlobalConfig(d)
 	case model.IPPoolKey:
 		return c.ipPoolClient.Create(d)
+	case model.NodeKey:
+		return c.nodeClient.Create(d)
 	default:
 		log.Warn("Attempt to 'Create' using kubernetes backend is not supported.")
 		return nil, errors.ErrorOperationNotSupported{
@@ -298,6 +302,8 @@ func (c *KubeClient) Update(d *model.KVPair) (*model.KVPair, error) {
 		return c.updateGlobalConfig(d)
 	case model.IPPoolKey:
 		return c.ipPoolClient.Update(d)
+	case model.NodeKey:
+		return c.nodeClient.Update(d)
 	default:
 		// If the resource isn't supported, then this is a no-op.
 		log.Infof("'Update' for %+v is no-op", d.Key)
@@ -315,6 +321,8 @@ func (c *KubeClient) Apply(d *model.KVPair) (*model.KVPair, error) {
 		return c.applyGlobalConfig(d)
 	case model.IPPoolKey:
 		return c.ipPoolClient.Apply(d)
+	case model.NodeKey:
+		return c.nodeClient.Apply(d)
 	default:
 		log.Infof("'Apply' for %s is no-op", d.Key)
 		return d, nil
@@ -328,6 +336,8 @@ func (c *KubeClient) Delete(d *model.KVPair) error {
 		return c.deleteGlobalConfig(d)
 	case model.IPPoolKey:
 		return c.ipPoolClient.Delete(d)
+	case model.NodeKey:
+		return c.nodeClient.Delete(d)
 	default:
 		log.Warn("Attempt to 'Delete' using kubernetes backend is not supported.")
 		return nil
@@ -352,6 +362,8 @@ func (c *KubeClient) Get(k model.Key) (*model.KVPair, error) {
 		return c.getReadyStatus(k.(model.ReadyFlagKey))
 	case model.IPPoolKey:
 		return c.ipPoolClient.Get(k.(model.IPPoolKey))
+	case model.NodeKey:
+		return c.nodeClient.Get(k.(model.NodeKey))
 	default:
 		return nil, errors.ErrorOperationNotSupported{
 			Identifier: k,
@@ -377,6 +389,8 @@ func (c *KubeClient) List(l model.ListInterface) ([]*model.KVPair, error) {
 		return c.listHostConfig(l.(model.HostConfigListOptions))
 	case model.IPPoolListOptions:
 		return c.ipPoolClient.List(l.(model.IPPoolListOptions))
+	case model.NodeListOptions:
+		return c.nodeClient.List(l.(model.NodeListOptions))
 	default:
 		return []*model.KVPair{}, nil
 	}

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -475,4 +475,49 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	It("Should support getting, deleting, and listing Nodes", func() {
+		nodeHostname := ""
+		var kvp model.KVPair
+		By("Listing all Nodes", func() {
+			nodes, err := c.List(model.NodeListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			// Get the hostname so we can make a Get call
+			kvp = *nodes[0]
+			nodeHostname = kvp.Key.(model.NodeKey).Hostname
+		})
+
+		By("Getting a specific nodeHostname", func() {
+			n, err := c.Get(model.NodeKey{Hostname: nodeHostname})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check to see we have the right Node
+			Expect(nodeHostname).To(Equal(n.Key.(model.NodeKey).Hostname))
+		})
+
+		By("Creating a new Node", func() {
+			_, err := c.Create(&kvp)
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Getting non-existent Node", func() {
+			_, err := c.Get(model.NodeKey{Hostname: "Fake"})
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Deleting a Node", func() {
+			err := c.Delete(&kvp)
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Applying changes to a node", func() {
+			_, err := c.Apply(&kvp)
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Updating a Node", func() {
+			_, err := c.Update(&kvp)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+ 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+
+	"k8s.io/client-go/kubernetes"
+	kapiv1 "k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func NewNodeClient(c *kubernetes.Clientset, r *rest.RESTClient) api.Client {
+	return &nodeClient{
+		clientSet: c,
+	}
+}
+
+// Implements the api.Client interface for Nodes.
+type nodeClient struct{
+	clientSet *kubernetes.Clientset
+}
+
+func (c *nodeClient) Create(kvp *model.KVPair) (*model.KVPair, error){
+	log.Warn("Operation Create is not supported on Node type")
+	return nil, errors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation: "Create",
+	}
+}
+
+func (c *nodeClient) Update(kvp *model.KVPair) (*model.KVPair, error){
+	log.Warn("Operation Update is not supported on Node type")
+	return nil, errors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation: "Update",
+	}
+}
+
+func (c *nodeClient) Apply(kvp *model.KVPair) (*model.KVPair, error){
+	log.Warn("Operation Apply is not supported on Node type")
+	return nil, errors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation: "Apply",
+	}
+}
+
+func (c *nodeClient) Delete(kvp *model.KVPair) error {
+	log.Warn("Operation Delete is not supported on Node type")
+	return errors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation: "Delete",
+	}
+}
+
+func (c *nodeClient) Get(key model.Key) (*model.KVPair, error){
+	log.Debug("Received Get request on Node type")
+	node, err := c.clientSet.Nodes().Get(key.(model.NodeKey).Hostname, metav1.GetOptions{})
+	if err != nil {
+		return nil, K8sErrorToCalico(err, key)
+	}
+
+	kvp, err := K8sNodeToCalico(node)
+	if err != nil {
+		log.Panicf("%s", err)
+	}
+
+	return kvp, nil
+}
+
+func (c *nodeClient) List(list model.ListInterface) ([]*model.KVPair, error){
+	log.Debug("Received List request on Node type")
+	nodes, err := c.clientSet.Nodes().List(kapiv1.ListOptions{})
+	if err != nil {
+		K8sErrorToCalico(err, list)
+	}
+
+	kvps := []*model.KVPair{}
+
+	for _, node := range nodes.Items {
+		n, err := K8sNodeToCalico(&node)
+		if err != nil {
+			log.Panicf("%s", err)
+		}
+		kvps = append(kvps, n)
+	}
+
+	return kvps, nil
+}
+
+func (c *nodeClient) EnsureInitialized() error{
+	return nil
+}
+
+func (c *nodeClient) EnsureCalicoNodeInitialized(node string) error {
+	return nil
+}
+
+func (c *nodeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	return nodeFakeSyncer{}
+}
+
+type nodeFakeSyncer struct {}
+
+func (f nodeFakeSyncer) Start() {}

--- a/lib/backend/k8s/resources/node_conversion.go
+++ b/lib/backend/k8s/resources/node_conversion.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"errors"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	kapiv1 "k8s.io/client-go/pkg/api/v1"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/Sirupsen/logrus"
+)
+
+func K8sNodeToCalico(node *kapiv1.Node) (*model.KVPair, error) {
+	// Get the internal IP of the node, should be 1-1 with calico node IP
+	nodeIP := ""
+	for _, address := range node.Status.Addresses {
+		if address.Type == kapiv1.NodeInternalIP {
+			nodeIP = address.Address
+			log.Debugf("Found NodeInternalIP %s", nodeIP)
+			break
+		}
+	}
+
+	ip := net.ParseIP(nodeIP)
+	log.Debugf("Node IP is %s", ip)
+	if ip == nil {
+		return nil, errors.New("Invalid IP received from k8s for Node")
+	}
+	asn := numorstring.ASNumber(64512)
+	return &model.KVPair{
+		Key: model.NodeKey{
+			Hostname: node.Name,
+		},
+		Value: &model.Node{
+			FelixIPv4:   ip,
+			Labels:      node.Labels,
+			BGPIPv4Addr:     ip,
+			BGPIPv6Addr:     &net.IP{},
+			BGPASNumber: &asn,
+		},
+		Revision: node.ObjectMeta.ResourceVersion,
+	}, nil
+}

--- a/lib/net/ip.go
+++ b/lib/net/ip.go
@@ -42,6 +42,15 @@ func (i *IP) UnmarshalJSON(b []byte) error {
 	return i.UnmarshalText([]byte(s))
 }
 
+// ParseIP returns an IP from a string
+func ParseIP(ip string) *IP {
+	addr := net.ParseIP(ip)
+	if addr == nil {
+		return nil
+	}
+	return &IP{addr}
+}
+
 // Version returns the IP version for an IP, or 0 if the IP is not valid.
 func (i IP) Version() int {
 	if i.To4() != nil {


### PR DESCRIPTION
First go at getting Node related calls working in the k8s backend.

- Translates k8s Node to Calico Node
- Watches k8s API for Node changes
- Read only for Nodes (only supports list and get)