### PR TITLE
Relax the label key validation

### DIFF
--- a/lib/selector/tokenizer/tokenizer.go
+++ b/lib/selector/tokenizer/tokenizer.go
@@ -54,15 +54,16 @@ type Token struct {
 }
 
 const (
-	identifierExpr = `([a-zA-Z0-9.-]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])*`
-	hasExpr        = `has\(\s*(` + identifierExpr + `)\s*\)`
-	allExpr        = `all\(\s*\)`
-	notInExpr      = `not\s*in\b`
-	inExpr         = `in\b`
+	// LabelKeyMatcher is the base regex for a valid label key.
+	LabelKeyMatcher = `([a-zA-Z0-9_.-/]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?`
+	hasExpr         = `has\(\s*(` + LabelKeyMatcher + `)\s*\)`
+	allExpr         = `all\(\s*\)`
+	notInExpr       = `not\s*in\b`
+	inExpr          = `in\b`
 )
 
 var (
-	identifierRegex = regexp.MustCompile("^" + identifierExpr)
+	identifierRegex = regexp.MustCompile("^" + LabelKeyMatcher)
 	hasRegex        = regexp.MustCompile("^" + hasExpr)
 	allRegex        = regexp.MustCompile("^" + allExpr)
 	notInRegex      = regexp.MustCompile("^" + notInExpr)

--- a/lib/selector/tokenizer/tokenizer_test.go
+++ b/lib/selector/tokenizer/tokenizer_test.go
@@ -59,6 +59,24 @@ var tokenTests = []struct {
 		{tokenizer.TokLabel, "c"},
 		{tokenizer.TokEof, nil},
 	}},
+	{`has(calico/k8s_ns)`, []tokenizer.Token{
+		{tokenizer.TokHas, "calico/k8s_ns"},
+		{tokenizer.TokEof, nil},
+	}},
+	{`has(calico/k8s_ns/role)`, []tokenizer.Token{
+		{tokenizer.TokHas, "calico/k8s_ns/role"},
+		{tokenizer.TokEof, nil},
+	}},
+	{`calico/k8s_ns == "kube-system" && k8s-app == "kube-dns"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "calico/k8s_ns"},
+		{tokenizer.TokEq, nil},
+		{tokenizer.TokStringLiteral, "kube-system"},
+		{tokenizer.TokAnd, nil},
+		{tokenizer.TokLabel, "k8s-app"},
+		{tokenizer.TokEq, nil},
+		{tokenizer.TokStringLiteral, "kube-dns"},
+		{tokenizer.TokEof, nil},
+	}},
 	{`a  not  in  "bar"  &&  ! has( foo )  ||  b  in  c `, []tokenizer.Token{
 		{tokenizer.TokLabel, "a"},
 		{tokenizer.TokNotIn, nil},

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -26,16 +26,18 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/scope"
 	"github.com/projectcalico/libcalico-go/lib/selector"
+	"github.com/projectcalico/libcalico-go/lib/selector/tokenizer"
+
 	"gopkg.in/go-playground/validator.v8"
 )
 
 var validate *validator.Validate
 
 var (
+	labelRegex         = regexp.MustCompile(`^` + tokenizer.LabelKeyMatcher + `$`)
+	labelValueRegex    = regexp.MustCompile("^[a-zA-Z0-9]?([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
 	nameRegex          = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
 	interfaceRegex     = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
-	labelRegex         = regexp.MustCompile("^([a-zA-Z0-9.-]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
-	labelValueRegex    = regexp.MustCompile("^[a-zA-Z0-9]?([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
 	actionRegex        = regexp.MustCompile("^(allow|deny|log|pass)$")
 	backendActionRegex = regexp.MustCompile("^(allow|deny|log|next-tier|)$")
 	protocolRegex      = regexp.MustCompile("^(tcp|udp|icmp|icmpv6|sctp|udplite)$")

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -101,6 +101,8 @@ func init() {
 		// (API) Selectors.  Selectors themselves are thorougly UT'd so only need to test simple
 		// accept and reject cases here.
 		Entry("should accept valid selector", api.EntityRule{Selector: "foo == \"bar\""}, true),
+		Entry("should accept valid selector with 'has' and a '/'", api.EntityRule{Selector: "has(calico/k8s_ns)"}, true),
+		Entry("should accept valid selector with 'has'and two '/'", api.EntityRule{Selector: "has(calico/k8s_ns/role)"}, true),
 		Entry("should reject invalid selector", api.EntityRule{Selector: "thing=hello &"}, false),
 
 		// (API) Tags.
@@ -113,14 +115,13 @@ func init() {
 		Entry("should accept label key starting with 0-9", api.HostEndpointMetadata{Labels: map[string]string{"2rank": "gold"}}, true),
 		Entry("should accept label value starting with 0-9", api.HostEndpointMetadata{Labels: map[string]string{"rank": "2gold"}}, true),
 		Entry("should accept label key with dns prefix", api.HostEndpointMetadata{Labels: map[string]string{"calico/k8s_ns": "kube-system"}}, true),
-		Entry("should accept label key where prefix is 253 characters", api.HostEndpointMetadata{Labels: map[string]string{"Projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org12/k8s_ns": "gold"}}, true),
-		Entry("should accept label key where name segment is 63 character", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org/gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._012": "gold"}}, true),
+		Entry("should accept label key where prefix is 253 characters", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.calico12345/k8s_ns": "gold"}}, true),
+		Entry("should accept label key where prefix begins with an uppercase character", api.HostEndpointMetadata{Labels: map[string]string{"Projectcalico.org12345/k8s_ns": "gold"}}, true),
+		Entry("should accept label key with multiple /", api.HostEndpointMetadata{Labels: map[string]string{"k8s_ns/label/role": "gold"}}, true),
 		Entry("should reject label key with !", api.HostEndpointMetadata{Labels: map[string]string{"rank!": "gold"}}, false),
 		Entry("should reject label key starting with ~", api.HostEndpointMetadata{Labels: map[string]string{"~rank_.0-9": "gold"}}, false),
 		Entry("should reject label key ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9~": "gold"}}, false),
-		Entry("should reject label key with multiple /", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org/a/b": "gold"}}, false),
 		Entry("should reject label key where prefix > 253 characters", api.HostEndpointMetadata{Labels: map[string]string{"Projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org123/k8s_ns": "gold"}}, false),
-		Entry("should reject label key where name segment > 63 character", api.HostEndpointMetadata{Labels: map[string]string{"projectcalico.org/gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._0-9gold._0123": "gold"}}, false),
 		Entry("should reject label value starting with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "~gold"}}, false),
 		Entry("should reject label value ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "gold~"}}, false),
 


### PR DESCRIPTION
- allows 0 to 253 chars
- alphanumeric, `-`, `_`, `/`, and `.`
- end with only alphanumeric char