### PR TITLE
Improves Backend API Client tests

### DIFF
--- a/lib/backend/backend_suite_test.go
+++ b/lib/backend/backend_suite_test.go
@@ -1,4 +1,4 @@
-package backend
+package backend_test
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
This PR improves a bit the backend api client coverage by the missing methods. I did not add the `EnsureCalicoNodeInitialized` and `EnsureInitialized` because they are backend dependent, and the idea is after the Consul code gets merged, in different PR we could loop through it backend and run the same tests.

