### PR TITLE
Implements etcd v3 backend

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -6,12 +6,21 @@ imports:
   subpackages:
   - compute/metadata
   - internal
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/coreos/etcd
   version: d2716fc5ae7909a3b9651e31cfb0eba22b4920c3
   subpackages:
+  - auth/authpb
   - client
+  - clientv3
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - mvcc/mvccpb
   - pkg/fileutil
   - pkg/pathutil
   - pkg/tlsutil
@@ -81,6 +90,14 @@ imports:
   - proto
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+- name: github.com/grpc-ecosystem/go-grpc-prometheus
+  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+- name: github.com/grpc-ecosystem/grpc-gateway
+  version: 84398b94e188ee336f307779b57b3aa91af7063c
+  subpackages:
+  - runtime
+  - runtime/internal
+  - utilities
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
@@ -97,6 +114,10 @@ imports:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/onsi/ginkgo
   version: bb93381d543b0e5725244abe752214a110791d01
   subpackages:
@@ -127,6 +148,22 @@ imports:
   version: 955bc3e451ef0c9df8b9113bf2e341139cdafab2
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: dd2f054febf4a6c00f2343686efb775948a8bff4
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -156,6 +193,8 @@ imports:
   - http2/hpack
   - idna
   - lex/httplex
+  - internal/timeseries
+  - trace
 - name: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
   subpackages:
@@ -192,6 +231,17 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: google.golang.org/grpc
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 - name: gopkg.in/go-playground/validator.v8
   version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
 - name: gopkg.in/inf.v0

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,7 @@ import:
 - package: github.com/coreos/etcd
   subpackages:
   - client
+  - clientv3
   - pkg/transport
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/kelseyhightower/envconfig

--- a/lib/backend/backend_test.go
+++ b/lib/backend/backend_test.go
@@ -180,5 +180,4 @@ var _ = Describe("Backend tests", func() {
 		}
 
 	})
-
 })

--- a/lib/backend/etcd/etcd_suite_test.go
+++ b/lib/backend/etcd/etcd_suite_test.go
@@ -1,0 +1,13 @@
+package etcd_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestEtcd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Etcd Suite")
+}

--- a/lib/backend/etcd/etcdv3.go
+++ b/lib/backend/etcd/etcdv3.go
@@ -1,0 +1,452 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"context"
+	goerrors "errors"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	etcdv3 "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/coreos/etcd/pkg/transport"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+type EtcdV3Client struct {
+	etcdClient *etcdv3.Client
+}
+
+func NewEtcdV3Client(config *EtcdConfig) (*EtcdV3Client, error) {
+	// Determine the location from the authority or the endpoints.  The endpoints
+	// takes precedence if both are specified.
+	etcdLocation := []string{}
+	if config.EtcdAuthority != "" {
+		etcdLocation = []string{config.EtcdScheme + "://" + config.EtcdAuthority}
+	}
+	if config.EtcdEndpoints != "" {
+		etcdLocation = strings.Split(config.EtcdEndpoints, ",")
+	}
+
+	if len(etcdLocation) == 0 {
+		return nil, goerrors.New("no etcd authority or endpoints specified")
+	}
+
+	// Create the etcd client
+	tlsInfo := &transport.TLSInfo{
+		CAFile:   config.EtcdCACertFile,
+		CertFile: config.EtcdCertFile,
+		KeyFile:  config.EtcdKeyFile,
+	}
+	tls, _ := tlsInfo.ClientConfig()
+
+	cfg := etcdv3.Config{
+		Endpoints:   etcdLocation,
+		TLS:         tls,
+		DialTimeout: clientTimeout,
+	}
+
+	// Plumb through the username and password if both are configured.
+	if config.EtcdUsername != "" && config.EtcdPassword != "" {
+		cfg.Username = config.EtcdUsername
+		cfg.Password = config.EtcdPassword
+	}
+
+	client, err := etcdv3.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EtcdV3Client{etcdClient: client}, nil
+}
+
+// Get an entry from the datastore.  This errors if the entry does not exist.
+func (c *EtcdV3Client) Get(k model.Key) (*model.KVPair, error) {
+	key, err := model.KeyToDefaultPath(k)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Get Key: %s", key)
+	resp, err := c.etcdClient.Get(context.Background(), key)
+	if err != nil {
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	// Older deployments with etcd may not have the Host metadata, so in the
+	// event that the key does not exist, just do a get on the directory to
+	// check it exists, and if so return an empty Metadata.
+	if resp.Count == 0 {
+		if _, ok := k.(model.HostMetadataKey); ok {
+			return c.getHostMetadataFromDirectory(k)
+		}
+
+		return nil, errors.ErrorResourceDoesNotExist{Identifier: k}
+	}
+
+	kv := resp.Kvs[0]
+
+	v, err := model.ParseValue(k, []byte(kv.Value))
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.KVPair{Key: k, Value: v, Revision: kv.ModRevision}, nil
+}
+
+// Create an entry in the datastore.  This errors if the entry already exists.
+func (c *EtcdV3Client) Create(d *model.KVPair) (*model.KVPair, error) {
+	logCxt := log.WithFields(log.Fields{"key": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
+	return c.create(d, logCxt)
+}
+
+// Update an entry in the datastore.  This errors if the entry already exists.
+func (c *EtcdV3Client) Update(d *model.KVPair) (*model.KVPair, error) {
+	logCxt := log.WithFields(log.Fields{"key": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
+	return c.update(d, logCxt)
+}
+
+// Apply an existing entry in the datastore.  This ignores whether an entry already
+// exists.
+func (c *EtcdV3Client) Apply(d *model.KVPair) (*model.KVPair, error) {
+	logCxt := log.WithFields(log.Fields{"key": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
+	return c.apply(d, logCxt)
+}
+
+// Delete an entry in the datastore.  This errors if the entry does not exists.
+func (c *EtcdV3Client) Delete(d *model.KVPair) error {
+	key, err := model.KeyToDefaultDeletePath(d.Key)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Delete Key: %s", key)
+
+	conds := []etcdv3.Cmp{}
+	if d.Revision != nil {
+		conds = append(conds, etcdv3.Compare(etcdv3.ModRevision(key), "=", d.Revision.(int64)))
+	}
+
+	if err := c.deleteKey(key, conds); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *EtcdV3Client) deleteKey(key string, conds []etcdv3.Cmp) error {
+	txnResp, err := c.etcdClient.Txn(context.Background()).If(
+		conds...,
+	).Then(
+		etcdv3.OpDelete(key, etcdv3.WithPrefix()),
+	).Commit()
+	if err != nil {
+		return errors.ErrorDatastoreError{Err: err, Identifier: key}
+	}
+
+	if !txnResp.Succeeded {
+		return errors.ErrorResourceUpdateConflict{Identifier: key}
+	}
+
+	delResp := txnResp.Responses[0].GetResponseDeleteRange()
+
+	if delResp.Deleted == 0 {
+		return errors.ErrorResourceDoesNotExist{Identifier: key}
+	}
+
+	return nil
+}
+
+// List entries in the datastore.  This may return an empty list of there are
+// no entries matching the request in the ListInterface.
+func (c *EtcdV3Client) List(l model.ListInterface) ([]*model.KVPair, error) {
+	// We need to handle the listing of HostMetadata separately for two reasons:
+	// -  older deployments may not have a Metadata, and instead we need to enumerate
+	//    based on existence of the directory
+	// -  it is not sensible to enumerate all of the endpoints, so better to enumerate
+	//    the host directories and then attempt to get the metadata.
+	switch lt := l.(type) {
+	case model.HostMetadataListOptions:
+		return c.listHostMetadata(lt)
+	default:
+		return c.defaultList(l)
+	}
+}
+
+// EnsureInitialized makes sure that the etcd data is initialized for use by
+// Calico.
+func (c *EtcdV3Client) EnsureInitialized() error {
+	// Make sure the Ready flag is initialized in the datastore
+	kv := &model.KVPair{
+		Key:   model.ReadyFlagKey{},
+		Value: true,
+	}
+
+	if _, err := c.Create(kv); err != nil {
+		if _, ok := err.(errors.ErrorResourceAlreadyExists); !ok {
+			log.WithError(err).Warn("Failed to set ready flag")
+			return err
+		}
+	}
+
+	log.Info("Ready flag is already set")
+	return nil
+}
+
+func (c *EtcdV3Client) EnsureCalicoNodeInitialized(node string) error {
+	// No need to do anything here when using Etcd v3
+	log.WithField("Node", node).Info("Ensuring node is initialized")
+	return nil
+}
+
+func (c *EtcdV3Client) listHostMetadata(l model.HostMetadataListOptions) ([]*model.KVPair, error) {
+	// If the hostname is specified then just attempt to get the host,
+	// returning an empty string if it does not exist.
+	if l.Hostname != "" {
+		log.Debug("Listing host metadata with exact key")
+		hmk := model.HostMetadataKey{Hostname: l.Hostname}
+		kv, err := c.Get(hmk)
+		if err != nil {
+			switch err.(type) {
+			case errors.ErrorResourceDoesNotExist:
+				return []*model.KVPair{}, nil
+			default:
+				return nil, err
+			}
+		}
+
+		return []*model.KVPair{kv}, nil
+	}
+
+	// No hostname specified, so enumerate the directories directly under
+	// the host tree, return no entries if the host directory does not exist.
+	log.Debug("Listing all host metadatas")
+	key := "/calico/v1/host"
+	resp, err := c.etcdClient.Get(context.Background(), key, etcdv3.WithPrefix())
+	if err != nil {
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	// TODO:  Since the host metadata is currently empty, we don't need
+	// to perform an additional get here, but in the future when the metadata
+	// may contain fields, we would need to perform a get.
+	log.Debug("Parse host directories.")
+	kvs := []*model.KVPair{}
+	for _, n := range resp.Kvs {
+		k := l.KeyFromDefaultPath(string(n.Key))
+		if k != nil {
+			kvs = append(kvs, &model.KVPair{
+				Key:   k,
+				Value: &model.HostMetadata{},
+			})
+		}
+	}
+
+	return kvs, nil
+}
+
+// defaultList provides the default list processing.
+func (c *EtcdV3Client) defaultList(l model.ListInterface) ([]*model.KVPair, error) {
+	// To list entries, we enumerate from the common root based on the supplied
+	// IDs, and then filter the results.
+	key := model.ListOptionsToDefaultPathRoot(l)
+	log.Debugf("List Key: %s", key)
+	resp, err := c.etcdClient.Get(context.Background(), key, etcdv3.WithPrefix())
+	if err != nil {
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	list := filterEtcdV3List(resp.Kvs, l)
+
+	switch t := l.(type) {
+	case model.ProfileListOptions:
+		return t.ListConvert(list), nil
+	}
+
+	return list, nil
+}
+
+// Process a node returned from a list to filter results based on the List type and to
+// compile and return the required results.
+func filterEtcdV3List(pairs []*mvccpb.KeyValue, l model.ListInterface) []*model.KVPair {
+	kvs := []*model.KVPair{}
+	for _, p := range pairs {
+		if k := l.KeyFromDefaultPath(string(p.Key)); k != nil {
+			if v, err := model.ParseValue(k, p.Value); err == nil {
+				kv := &model.KVPair{Key: k, Value: v, Revision: p.ModRevision}
+				kvs = append(kvs, kv)
+			}
+		}
+	}
+
+	log.Debugf("Returning filtered list: %#v", kvs)
+	return kvs
+}
+
+func (c *EtcdV3Client) apply(d *model.KVPair, log *log.Entry) (*model.KVPair, error) {
+	key, value, err := getKeyValueStrings(d)
+	if err != nil {
+		log.WithError(err).Error("failed to get key or value strings")
+		return nil, err
+	}
+
+	resp, err := c.etcdClient.Put(context.Background(), key, value)
+	if err != nil {
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	d.Revision = resp.Header.Revision
+
+	return d, nil
+}
+
+func (c *EtcdV3Client) update(d *model.KVPair, log *log.Entry) (*model.KVPair, error) {
+	key, value, err := getKeyValueStrings(d)
+	if err != nil {
+		log.WithError(err).Error("failed to get key or value strings")
+		return nil, err
+	}
+
+	opts, err := c.getTTLOption(d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Checking key existence
+	if _, err := c.Get(d.Key); err != nil {
+		return nil, err
+	}
+
+	conds := []etcdv3.Cmp{}
+	if d.Revision != nil {
+		conds = append(conds, etcdv3.Compare(etcdv3.ModRevision(key), "=", d.Revision.(int64)))
+	}
+
+	txnResp, err := c.etcdClient.Txn(context.Background()).If(conds...).Then(
+		etcdv3.OpPut(key, value, opts...),
+	).Commit()
+
+	if err != nil {
+		log.WithError(err).Debug("Update failed")
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	// Etcd V3 does not return a error when compare condition fails
+	// we must verify the response Succeeded field instead
+	if !txnResp.Succeeded {
+		return nil, errors.ErrorResourceUpdateConflict{Identifier: d.Key}
+	}
+
+	d.Revision = txnResp.Header.Revision
+
+	return d, nil
+}
+
+func (c *EtcdV3Client) create(d *model.KVPair, log *log.Entry) (*model.KVPair, error) {
+	key, value, err := getKeyValueStrings(d)
+	if err != nil {
+		log.WithError(err).Error("failed to get key or value strings")
+		return nil, err
+	}
+
+	putOpts, err := c.getTTLOption(d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Checking for 0 version of the key, which means it doesn't exists yet
+	cond := etcdv3.Compare(etcdv3.Version(key), "=", 0)
+	req := etcdv3.OpPut(key, value, putOpts...)
+	resp, err := c.etcdClient.Txn(context.Background()).If(cond).Then(req).Commit()
+	if err != nil {
+		log.WithError(err).Debug("Create failed")
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	if !resp.Succeeded {
+		return nil, errors.ErrorResourceAlreadyExists{
+			Err:        goerrors.New("resource already exists"),
+			Identifier: d.Key,
+		}
+	}
+
+	d.Revision = resp.Header.Revision
+
+	return d, nil
+}
+
+func (c *EtcdV3Client) getTTLOption(d *model.KVPair) ([]etcdv3.OpOption, error) {
+	putOpts := []etcdv3.OpOption{}
+
+	if d.TTL != 0 {
+		resp, err := c.etcdClient.Lease.Grant(context.Background(), int64(d.TTL.Seconds()))
+		if err != nil {
+			log.WithError(err).Debug("Failed to grant a lease")
+			return nil, errors.ErrorDatastoreError{Err: err}
+		}
+
+		putOpts = append(putOpts, etcdv3.WithLease(resp.ID))
+	}
+
+	return putOpts, nil
+}
+
+func getKeyValueStrings(d *model.KVPair) (string, string, error) {
+	key, err := model.KeyToDefaultPath(d.Key)
+	if err != nil {
+		return "", "", err
+	}
+	bytes, err := model.SerializeValue(d)
+	if err != nil {
+		return "", "", err
+	}
+
+	value := string(bytes)
+
+	return key, value, nil
+}
+
+// getHostMetadataFromDirectory gets hosts that may not be configured with a host
+// metadata (older deployments or Openstack deployments).
+func (c *EtcdV3Client) getHostMetadataFromDirectory(k model.Key) (*model.KVPair, error) {
+	// The delete path of the host metadata includes the whole of the per-host
+	// felix tree, so check the existence of this tree and return and empty
+	// Metadata if it exists.
+	key, err := model.KeyToDefaultDeletePath(k)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.etcdClient.Get(context.Background(), key)
+	if err != nil {
+		return nil, errors.ErrorDatastoreError{Err: err}
+	}
+
+	if resp.Count == 0 {
+		return nil, errors.ErrorResourceDoesNotExist{Identifier: k}
+	}
+
+	// The node exists, so return an empty Metadata.
+	kv := &model.KVPair{
+		Key:   k,
+		Value: &model.HostMetadata{},
+	}
+	return kv, nil
+}
+
+func (c *EtcdV3Client) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	return newSyncerV3(c.etcdClient, callbacks)
+}

--- a/lib/backend/etcd/syncer_test.go
+++ b/lib/backend/etcd/syncer_test.go
@@ -1,0 +1,126 @@
+package etcd_test
+
+import (
+	"sort"
+	"time"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	. "github.com/projectcalico/libcalico-go/lib/backend/etcd"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Etcd Syncer", func() {
+	// Cleaning Etcd
+	testutils.CleanEtcd()
+
+	// Init Etcd
+	etcdClient, _ := NewEtcdClient(&EtcdConfig{
+		EtcdEndpoints: "http://127.0.0.1:2379",
+	})
+	etcdClient.EnsureInitialized()
+
+	It("creates a stream of updates", func() {
+		// Syncer init
+		notifyStatus := make(chan interface{})
+		notifyUpdate := make(chan interface{})
+		callback := NewSyncerCallbacks(notifyStatus, notifyUpdate)
+		syncer := etcdClient.Syncer(callback)
+		syncer.Start()
+
+		// Give some time to syncer start watching
+		time.Sleep(time.Second)
+
+		// Create pairs
+		host1 := model.KVPair{
+			Key:   model.HostEndpointKey{Hostname: "host1", EndpointID: "endpoint1"},
+			Value: model.HostEndpoint{Name: "host-name-1"},
+		}
+		host2 := model.KVPair{
+			Key:   model.HostEndpointKey{Hostname: "host2", EndpointID: "endpoint2"},
+			Value: model.HostEndpoint{Name: "host-name-2"},
+		}
+		host3 := model.KVPair{
+			Key:   model.HostEndpointKey{Hostname: "host3", EndpointID: "endpoint3"},
+			Value: model.HostEndpoint{Name: "host-name-3"},
+		}
+
+		etcdClient.Create(&host1)
+		etcdClient.Create(&host2)
+		etcdClient.Create(&host3)
+
+		etcdClient.Delete(&host1)
+
+		host2.Value = model.HostEndpoint{Name: "foooo"}
+		etcdClient.Apply(&host2)
+
+		updates := Updates{}
+		done := false
+		for {
+			select {
+			case _ = <-notifyStatus:
+			case update := <-notifyUpdate:
+				updates = append(updates, update.([]api.Update)...)
+			case <-time.After(time.Second):
+				done = true
+			}
+
+			if done {
+				break
+			}
+		}
+
+		// Sorting to make easy assertion
+		sort.Sort(updates)
+
+		Expect(updates[1].KVPair.Key).To(Equal(host1.Key))
+		Expect(updates[1].UpdateType).To(Equal(api.UpdateTypeKVNew))
+
+		Expect(updates[2].KVPair.Key).To(Equal(host2.Key))
+		Expect(updates[2].UpdateType).To(Equal(api.UpdateTypeKVNew))
+
+		Expect(updates[3].KVPair.Key).To(Equal(host3.Key))
+		Expect(updates[3].UpdateType).To(Equal(api.UpdateTypeKVNew))
+
+		Expect(updates[4].KVPair.Key).To(Equal(host1.Key))
+		Expect(updates[4].UpdateType).To(Equal(api.UpdateTypeKVDeleted))
+
+		Expect(updates[5].KVPair.Key).To(Equal(host2.Key))
+		Expect(updates[5].UpdateType).To(Equal(api.UpdateTypeKVUpdated))
+	})
+})
+
+func NewSyncerCallbacks(status chan interface{}, update chan interface{}) *SyncerCallbacks {
+	return &SyncerCallbacks{
+		NotifyStatus: status,
+		NotifyUpdate: update,
+	}
+}
+
+type SyncerCallbacks struct {
+	NotifyUpdate chan interface{}
+	NotifyStatus chan interface{}
+}
+
+func (a *SyncerCallbacks) OnStatusUpdated(status api.SyncStatus) {
+	a.NotifyStatus <- status
+}
+
+func (a *SyncerCallbacks) OnUpdates(updates []api.Update) {
+	a.NotifyUpdate <- updates
+}
+
+type Updates []api.Update
+
+func (u Updates) Len() int {
+	return len(u)
+}
+func (u Updates) Swap(i, j int) {
+	u[i], u[j] = u[j], u[i]
+}
+func (u Updates) Less(i, j int) bool {
+	return u[i].KVPair.Revision.(uint64) < u[j].KVPair.Revision.(uint64)
+}

--- a/lib/backend/etcd/syncerv3.go
+++ b/lib/backend/etcd/syncerv3.go
@@ -1,0 +1,516 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"net"
+	"time"
+
+	"math/rand"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd/client"
+	etcdv3 "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/hwm"
+	"golang.org/x/net/context"
+)
+
+func newSyncerV3(etcdClient *etcdv3.Client, callbacks api.SyncerCallbacks) *etcdSyncerV3 {
+	return &etcdSyncerV3{
+		etcdClient: etcdClient,
+		callbacks:  callbacks,
+	}
+}
+
+// etcdSyncerV3 loads snapshots from etcd and merges them with events from a
+// watch on our directory in etcd. It sends an "eventually consistent" stream of
+// events to its callback.
+//
+// Syncer architecture
+//
+// The syncer's processing is divided into four goroutines:
+//
+// The merge goroutine
+//
+// The merge goroutine receives updates about newly loaded snapshots (from the
+// snapshot reeading goroutine) and events (from the watcher goroutine) and
+// merges them into a consistent event stream.
+//
+// Since processing a snapshot takes some time and it happens concurrently with
+// polling for new events, the merge goroutine may be receiving updates from
+// a snapshot that occurred at etcd index 10, while the event stream is already
+// reporting updates at etcd index 11, 12, ...  The merge thread does the
+// bookkeeping to squash out-of-date snapshot updates in favour of newer
+// information from the watcher and to resolve deletions after losing sync.
+//
+// The merge goroutine also requests new snapshots when the watcher drops out
+// of sync.  While it's the watcher goroutine that detects the loss of sync,
+// sending the request via the merge goroutine makes for easier reasoning about
+// the thread safety.
+//
+// The snapshot reading goroutine
+//
+// When requested by the merge goroutine, the snapshot-reading goroutine
+// reads a consistent point-in-time snapshot from etcd and streams it to the
+// merge goroutine.  Then it waits for the next request.
+//
+// The watcher goroutine
+//
+// The watcher goroutine polls etcd for new events.  A typical use of the
+// etcd API would load a snapshot first, then start polling from the snapshot
+// index.  However, that approach doesn't work at high event throughput because
+// etcd's event buffer can be exhausted before the snapshot is received, leading
+// to a resync loop.  We avoid that scenario by having the watcher be free
+// running.  If it loses sync, it immediately starts polling again from the
+// current etcd index; then it triggers a snapshot read from the point it started
+// polling.
+//
+// The cluster ID poll goroutine
+//
+// This goroutine simply polls etcd for its cluster ID every few seconds and
+// kills the process if it changes.  This ensures that we recover if etcd is
+// blown away and rebuilt.  It's such a rare corner case that corrective action
+// isn't worth it (and would be likely to be buggy due to lack of exercise).
+type etcdSyncerV3 struct {
+	callbacks  api.SyncerCallbacks
+	etcdClient *etcdv3.Client
+	OneShot    bool
+}
+
+// Start starts the syncer's background threads.
+func (syn *etcdSyncerV3) Start() {
+	// Start a background thread to read events from etcd.  It will
+	// queue events onto the etcdEvents channel.  If it drops out of sync,
+	// it will signal on the resyncIndex channel.
+	log.Info("Starting etcd Syncer")
+
+	// Channel used to send updates from the watcher thread to the merge
+	// thread.  We give it a large buffer because we want the watcher thread
+	// to be free running and only block if we get really backed up.
+	watcherUpdateC := make(chan interface{}, 20000)
+	// Channel used to send updates from the snapshot thread to the merge
+	// thread.  No buffer: we want the snapshot to be slowed down if the
+	// merge thread is under load.
+	snapshotUpdateC := make(chan interface{})
+	// Channel used to signal from the merge thread to the snapshot thread
+	// that a new snapshot is required.  To avoid deadlock with the channel
+	// above, the merge only sends a new snapshot request once the old
+	// snapshot is finished.
+	snapshotRequestC := make(chan snapshotRequest)
+
+	if !syn.OneShot {
+		log.Info("Syncer not in one-shot mode, starting watcher thread")
+		go syn.watchEtcd(watcherUpdateC)
+		// In order to make sure that we eventually spot if the etcd
+		// cluster is rebuilt, start a thread to poll the etcd
+		// Cluster ID.  If we don't spot a cluster rebuild then our
+		// watcher will start silently failing.
+		go syn.pollClusterID(clusterIDPollInterval)
+	}
+	go syn.readSnapshotsFromEtcd(snapshotUpdateC, snapshotRequestC)
+	go syn.mergeUpdates(snapshotUpdateC, watcherUpdateC, snapshotRequestC)
+}
+
+// readSnapshotsFromEtcd is a goroutine that, when requested, reads a new
+// snapshot from etcd and send it to the merge thread.  A snapshot request
+// includes the required etcd index for the snapshot; in case of a read from a
+// stale replica, the snapshot thread retries until it reads a snapshot that is
+// new enough.
+func (syn *etcdSyncerV3) readSnapshotsFromEtcd(
+	snapshotUpdateC chan<- interface{},
+	snapshotRequestC <-chan snapshotRequest,
+) {
+	log.Info("Syncer snapshot-reading thread started")
+
+	var highestCompletedSnapshotIndex uint64
+	var minRequiredSnapshotIndex uint64
+
+	for {
+		// Wait to be told to get the snapshot
+		snapshotRequest := <-snapshotRequestC
+		minRequiredSnapshotIndex = snapshotRequest.minRequiredSnapshotIndex
+		log.WithField("newMinIndex", minRequiredSnapshotIndex).Info("Asked for new snapshot")
+
+		// In case of read from stale replica, loop until we read a
+		// new-enough snapshot.  We don't do a quorum read to avoid
+		// pinning the read load to the etcd master.
+		for highestCompletedSnapshotIndex < minRequiredSnapshotIndex {
+			log.WithFields(log.Fields{
+				"requiredIdx": minRequiredSnapshotIndex,
+				"currentIdx":  highestCompletedSnapshotIndex,
+			}).Info("Newest snapshot is too stale, loading a new one")
+			resp, err := syn.etcdClient.Get(context.Background(), "/calico/v1", etcdv3.WithPrefix())
+			if err != nil {
+				if syn.OneShot {
+					// One-shot mode is used to grab a snapshot and then
+					// stop.  We don't want to go into a retry loop.
+					log.Fatal("Failed to read snapshot from etcd: ", err)
+				}
+				log.Warning("Error getting snapshot, retrying...", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			index := uint64(resp.Header.Revision)
+			if index < minRequiredSnapshotIndex {
+				log.Info("Retrieved stale snapshot, rereading...")
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+
+			// If we get here, we should have a good snapshot.
+			// Send it to the merge thread.
+			snapshotUpdateC <- snapshotStarting{
+				snapshotIndex: index,
+			}
+			sendSnapshotResp(resp, snapshotUpdateC)
+			highestCompletedSnapshotIndex = index
+		}
+		// Defensive: just in case we somehow got called without needing
+		// to execute the loop, send the snapshotFinished from outside
+		// the loop. This ensures that we always pair a snapshot
+		// finished to every snapshotRequest.
+		snapshotUpdateC <- snapshotFinished{
+			snapshotIndex: highestCompletedSnapshotIndex,
+		}
+	}
+}
+
+// sendSnapshotResp sends the node and its children over the channel as events.
+func sendSnapshotResp(resp *etcdv3.GetResponse, snapshotUpdates chan<- interface{}) {
+	for _, kv := range resp.Kvs {
+		snapshotUpdates <- snapshotUpdate{
+			snapshotIndex: uint64(resp.Header.Revision),
+			kv: kvPair{
+				key:           string(kv.Key),
+				value:         string(kv.Value),
+				modifiedIndex: uint64(kv.ModRevision),
+			},
+		}
+	}
+}
+
+// watchEtcd is a goroutine that polls etcd for new events.  As described in the
+// comment for the etcdSyncerV3, the watcher goroutine is free-running; it always
+// tries to keep up with etcd but it emits events when it drops out of sync
+// so that the merge goroutine can trigger a new resync via snapshot.
+func (syn *etcdSyncerV3) watchEtcd(watcherUpdateC chan<- interface{}) {
+	log.Info("etcd watch thread started.")
+	// Each trip around the outer loop establishes the current etcd index
+	// of the cluster, triggers a new snapshot read from that index (via
+	// message to the merge goroutine) and starts watching from that index.
+	for {
+		// Do a non-recursive get on the Ready flag to find out the
+		// current etcd index.  We'll trigger a snapshot/start polling from that.
+		resp, err := syn.etcdClient.Get(context.Background(), "/calico/v1/Ready")
+		if err != nil || resp.Count == 0 {
+			log.WithError(err).Warn("Failed to get Ready key from etcd")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		initialClusterIndex := uint64(resp.Header.Revision)
+		log.WithField("index", initialClusterIndex).Info("Polled etcd for initial watch index.")
+
+		// We were previously out-of-sync, request a new snapshot at
+		// the current cluster index, which is also the index that we'll
+		// poll from.
+		watcherUpdateC <- watcherNeedsSnapshot{
+			minSnapshotIndex: initialClusterIndex,
+		}
+
+	watchLoop: // We'll stay in this poll loop unless we drop out of sync.
+		watcher := syn.etcdClient.Watch(context.Background(), "/calico/v1", etcdv3.WithPrefix(), etcdv3.WithRev(int64(initialClusterIndex)))
+		for wresp := range watcher {
+			if err := wresp.Err(); err != nil {
+				log.WithError(err).Warn("Unexpected error type from etcd")
+				goto watchLoop
+			}
+
+			for _, ev := range wresp.Events {
+				switch ev.Type {
+				case mvccpb.PUT:
+					watcherUpdateC <- watcherUpdate{kv: kvPair{
+						modifiedIndex: uint64(ev.Kv.ModRevision),
+						key:           string(ev.Kv.Key),
+						value:         string(ev.Kv.Value),
+					}}
+				case mvccpb.DELETE:
+					watcherUpdateC <- watcherDeletion{
+						modifiedIndex: uint64(ev.Kv.ModRevision),
+						key:           string(ev.Kv.Key),
+					}
+				default:
+					log.WithField("actionType", ev.Type).Panic("Unknown action type")
+				}
+			}
+		}
+	}
+}
+
+// retryableWatcherError returns true if the given etcd error is worth
+// retrying in the context of a watch.
+func retryableWatcherV3Error(err error) bool {
+	// Unpack any nested errors.
+	var errs []error
+	if clusterErr, ok := err.(*client.ClusterError); ok {
+		errs = clusterErr.Errors
+	} else {
+		errs = []error{err}
+	}
+	for _, err = range errs {
+		switch err := err.(type) {
+		case client.Error:
+			errCode := err.Code
+			if errCode == client.ErrorCodeWatcherCleared ||
+				errCode == client.ErrorCodeEventIndexCleared {
+				// This means that our watch has failed and needs
+				// to be restarted.
+				return false
+			}
+		case net.Error:
+			// We expect timeouts if there are no events from etcd
+			// so only log if we hit something unusual.
+			if !err.Timeout() {
+				log.WithError(err).Warn("Net error from etcd")
+			}
+		default:
+			log.WithError(err).Warn("Unexpected error type from etcd")
+		}
+	}
+	// Didn't find any non-retryable errors.
+	return true
+}
+
+// pollClusterID polls etcd for its current cluster ID.  If the cluster ID changes
+// it terminates the process.
+func (syn *etcdSyncerV3) pollClusterID(interval time.Duration) {
+	log.Info("Cluster ID poll thread started")
+	lastSeenClusterID := uint64(0)
+	for {
+		resp, err := syn.etcdClient.Get(context.Background(), "/calico/v1/Ready")
+		if err != nil {
+			log.WithError(err).Warn("Failed to poll etcd server cluster ID")
+			syn.sleepBeforeContinue(interval)
+			continue
+		}
+
+		clusterID := resp.Header.ClusterId
+		log.WithField("clusterID", clusterID).Debug("Polled etcd for cluster ID.")
+
+		if lastSeenClusterID == 0 {
+			log.WithField("clusterID", clusterID).Info("etcd cluster ID now known")
+			lastSeenClusterID = resp.Header.ClusterId
+		} else if lastSeenClusterID != clusterID {
+			// The Syncer doesn't currently support this (hopefully rare)
+			// scenario.  Terminate the process rather than carry on with
+			// possibly out-of-sync etcd index.
+			log.WithFields(log.Fields{
+				"oldID": lastSeenClusterID,
+				"newID": clusterID,
+			}).Fatal("etcd cluster ID changed; must exit.")
+		}
+
+		syn.sleepBeforeContinue(interval)
+	}
+}
+
+//sleepBeforeContinue Jitter by 10% of interval.
+func (syn *etcdSyncerV3) sleepBeforeContinue(interval time.Duration) {
+	time.Sleep(time.Duration(float64(interval) * (1 + (0.1 * rand.Float64()))))
+}
+
+// mergeUpdates is a goroutine that processes updates from the snapshot and wathcer threads,
+// merging them into an eventually-consistent stream of updates.
+//
+// The merging includes resolving deletions where the watcher may be ahead of the snapshot
+// and delete a key that later arrives in a snapshot.  The key would then be suppressed
+// and no update generated.
+//
+// It also handles deletions due to a resync by doing a mark and sweep of keys that are seen
+// in the snapshot.
+//
+// Thread safety:  mergeUpdates both sends to and receives from channels to the snapshot
+// reading thread.  Thread safety is ensured by tracking whether a snapshot is in progress
+// and waiting until it finishes (and hence the snapshot thread is no longer sending)
+// before sending it a request for a new snapshot.
+func (syn *etcdSyncerV3) mergeUpdates(
+	snapshotUpdateC <-chan interface{},
+	watcherUpdateC <-chan interface{},
+	snapshotRequestC chan<- snapshotRequest,
+) {
+	var minRequiredSnapshotIndex uint64
+	var highestCompletedSnapshotIndex uint64
+	snapshotInProgress := false
+	hwms := hwm.NewHighWatermarkTracker()
+
+	syn.callbacks.OnStatusUpdated(api.WaitForDatastore)
+	for {
+		var event interface{}
+		select {
+		case event = <-snapshotUpdateC:
+			log.WithField("event", event).Debug("Snapshot update")
+		case event = <-watcherUpdateC:
+			log.WithField("event", event).Debug("Watcher update")
+		}
+
+		switch event := event.(type) {
+		case update:
+			// Common update processing, shared between snapshot and watcher updates.
+			updatedLastSeenIndex := event.lastSeenIndex()
+			kv := event.kvPair()
+			log.WithFields(log.Fields{
+				"indexToStore": updatedLastSeenIndex,
+				"kv":           kv,
+			}).Debug("Snapshot/watcher update")
+			oldIdx := hwms.StoreUpdate(kv.key, updatedLastSeenIndex)
+			if oldIdx < kv.modifiedIndex {
+				// Event is newer than value for that key.
+				// Send the update.
+				var updateType api.UpdateType
+				if oldIdx > 0 {
+					log.WithField("oldIdx", oldIdx).Debug("Set updates known key")
+					updateType = api.UpdateTypeKVUpdated
+				} else {
+					log.WithField("oldIdx", oldIdx).Debug("Set is a new key")
+					updateType = api.UpdateTypeKVNew
+				}
+				syn.sendUpdate(kv.key, kv.value, kv.modifiedIndex, updateType)
+			}
+		case watcherDeletion:
+			deletedKeys := hwms.StoreDeletion(event.key, event.modifiedIndex)
+			log.WithFields(log.Fields{
+				"prefix":  event.key,
+				"numKeys": len(deletedKeys),
+			}).Debug("Prefix deleted")
+			syn.sendDeletions(deletedKeys, event.modifiedIndex)
+		case watcherNeedsSnapshot:
+			// Watcher has lost sync.  Record the snapshot index
+			// that we now require to bring us into sync.  We'll start
+			// a new snapshot below if we can.
+			log.Info("Watcher out-of-sync, starting to track deletions")
+			minRequiredSnapshotIndex = event.minSnapshotIndex
+		case snapshotStarting:
+			// Informational message from the snapshot thread.  Makes the logs clearer.
+			log.WithField("snapshotIndex", event.snapshotIndex).Info("Started receiving snapshot")
+		case snapshotFinished:
+			// Snapshot is ending, we need to check if this snapshot is still new enough to
+			// mean that we're really in sync (because the watcher may have fallen
+			// out of sync again after it requested the snapshot).
+			logCxt := log.WithFields(log.Fields{
+				"snapshotIndex":    event.snapshotIndex,
+				"minSnapshotIndex": minRequiredSnapshotIndex,
+			})
+			logCxt.Info("Finished receiving snapshot, cleaning up old keys.")
+			snapshotInProgress = false
+			hwms.StopTrackingDeletions()
+			deletedKeys := hwms.DeleteOldKeys(event.snapshotIndex)
+			logCxt.WithField("numDeletedKeys", len(deletedKeys)).Info(
+				"Deleted old keys that weren't seen in snapshot.")
+			syn.sendDeletions(deletedKeys, event.snapshotIndex)
+
+			if event.snapshotIndex > highestCompletedSnapshotIndex {
+				highestCompletedSnapshotIndex = event.snapshotIndex
+			}
+			if event.snapshotIndex >= minRequiredSnapshotIndex {
+				// Now in sync.
+				logCxt.Info("Snapshot brought us into sync.")
+				syn.callbacks.OnStatusUpdated(api.InSync)
+			} else {
+				// Watcher is already out-of-sync.  We'll restart the
+				// snapshot below.
+				logCxt.Warn("Snapshot was stale before it finished.")
+			}
+		default:
+			log.WithField("event", event).Panic("Unknown event type")
+		}
+
+		outOfSync := highestCompletedSnapshotIndex < minRequiredSnapshotIndex
+		if outOfSync && !snapshotInProgress {
+			log.Info("Watcher is out-of-sync but no snapshot in progress, starting one.")
+			snapshotRequestC <- snapshotRequest{
+				minRequiredSnapshotIndex: minRequiredSnapshotIndex,
+			}
+			// Track that the snapshot is in progress; it's not safe to start a
+			// new snapshot until the old one finishes (or we'll deadlock with the
+			// snapshot trying to send us updates).
+			snapshotInProgress = true
+			hwms.StartTrackingDeletions()
+			syn.callbacks.OnStatusUpdated(api.ResyncInProgress)
+		}
+	}
+}
+
+// sendUpdate parses and sends an update to the callback API.
+func (syn *etcdSyncerV3) sendUpdate(key string, value string, revision uint64, updateType api.UpdateType) {
+	log.Debugf("Parsing etcd key %#v", key)
+	parsedKey := model.KeyFromDefaultPath(key)
+	if parsedKey == nil {
+		log.Debugf("Failed to parse key %v", key)
+		if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {
+			cb.ParseFailed(key, value)
+		}
+		return
+	}
+	log.Debugf("Parsed etcd key: %v", parsedKey)
+
+	var parsedValue interface{}
+	var err error
+
+	parsedValue, err = model.ParseValue(parsedKey, []byte(value))
+	if err != nil {
+		log.Warningf("Failed to parse value for %v: %#v", key, value)
+	}
+	log.Debugf("Parsed value: %#v", parsedValue)
+
+	updates := []api.Update{
+		{
+			KVPair: model.KVPair{
+				Key:      parsedKey,
+				Value:    parsedValue,
+				Revision: revision,
+			},
+			UpdateType: updateType,
+		},
+	}
+	syn.callbacks.OnUpdates(updates)
+}
+
+// sendDeletions sends a series of deletions on the callback API.
+func (syn *etcdSyncerV3) sendDeletions(deletedKeys []string, revision uint64) {
+	updates := make([]api.Update, 0, len(deletedKeys))
+	for _, key := range deletedKeys {
+		parsedKey := model.KeyFromDefaultPath(key)
+		if parsedKey == nil {
+			log.Debugf("Failed to parse key %v", key)
+			if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {
+				cb.ParseFailed(key, "")
+			}
+			continue
+		}
+		updates = append(updates, api.Update{
+			KVPair: model.KVPair{
+				Key:      parsedKey,
+				Value:    nil,
+				Revision: revision,
+			},
+			UpdateType: api.UpdateTypeKVDeleted,
+		})
+	}
+	syn.callbacks.OnUpdates(updates)
+}


### PR DESCRIPTION
This PR implements the Etcd V3 backend.

I didn't implement anything related to run multiple backends because that is already done on Consul PR, but all tests are passing if you change it to use the v3.

Another concern I had was testing the Syncer, I could find any unit test to it, so I added one.

as discussed with @tomdee I chose to duplicate most of the code, instead of trying to share with v2 version, so I wouldn't have to touch a stable and critical code.