### PR TITLE
k8s backend getHostConfig error

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -718,10 +718,7 @@ func (c *KubeClient) deleteGlobalConfig(k *model.KVPair) error {
 }
 
 func (c *KubeClient) getHostConfig(k model.HostConfigKey) (*model.KVPair, error) {
-	return &model.KVPair{
-		Key:   k,
-		Value: nil,
-	}, nil
+	return nil, errors.ErrorResourceDoesNotExist{Identifier: k}
 }
 
 func (c *KubeClient) listHostConfig(l model.HostConfigListOptions) ([]*model.KVPair, error) {


### PR DESCRIPTION
`KubeClient.getHostConfig()` should return an error not a KVPair struct with nil Value.

Fixes projectcalico/calicoctl#1498