### PR TITLE
Add multiple clients for e2e testing

### DIFF
--- a/lib/backend/k8s/resources/ippools.go
+++ b/lib/backend/k8s/resources/ippools.go
@@ -116,9 +116,9 @@ func (c *client) List(list model.ListInterface) ([]*model.KVPair, error) {
 	kvps := []*model.KVPair{}
 	l := list.(model.IPPoolListOptions)
 
-	// If the CIDR is specified, the Get() will return a single resource
-	// rather than a list - in this case just use our Get processing to
-	// return the data.
+	// If the CIDR is specified, k8s will return a single resource
+	// rather than a list, so handle this case separately, using our
+	// Get method to return the single result.
 	if l.CIDR.IP != nil {
 		log.Info("Performing IP pool List with name")
 		if kvp, err := c.Get(model.IPPoolKey{CIDR: l.CIDR}); err == nil {

--- a/lib/client/ippool_e2e_test.go
+++ b/lib/client/ippool_e2e_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-var _ = testutils.E2eDescribe("IPPool e2e tests", testutils.ClientEtcdV2|testutils.ClientK8s, func(apiConfig api.CalicoAPIConfig) {
+var _ = testutils.E2eDatastoreDescribe("IPPool e2e tests", testutils.DatastoreEtcdV2 |testutils.DatastoreK8s, func(apiConfig api.CalicoAPIConfig) {
 
 	DescribeTable("IPPool e2e tests",
 		func(meta1, meta2 api.IPPoolMetadata, spec1, spec2 api.IPPoolSpec) {

--- a/lib/testutils/client.go
+++ b/lib/testutils/client.go
@@ -82,12 +82,13 @@ func CreateNewIPPool(c client.Client, poolSubnet string, ipip, natOut, ipam bool
 
 // CleanIPPools removes all IP pool configuration from the datastore.
 func CleanIPPools(c *client.Client) {
-	// Delete IP Pools from the datastore
-	pools, err := c.IPPools().List(api.IPPoolMetadata{})
-	if err != nil {
+	if pools, err := c.IPPools().List(api.IPPoolMetadata{}); err == nil {
+		for _, pool := range pools.Items {
+			if err := c.IPPools().Delete(pool.Metadata); err != nil {
+				panic(err)
+			}
+		}
+	} else {
 		panic(err)
-	}
-	for _, pool := range pools.Items {
-		c.IPPools().Delete(pool.Metadata)
 	}
 }

--- a/lib/testutils/client.go
+++ b/lib/testutils/client.go
@@ -79,3 +79,15 @@ func CreateNewIPPool(c client.Client, poolSubnet string, ipip, natOut, ipam bool
 	}
 
 }
+
+// CleanIPPools removes all IP pool configuration from the datastore.
+func CleanIPPools(c *client.Client) {
+	// Delete IP Pools from the datastore
+	pools, err := c.IPPools().List(api.IPPoolMetadata{})
+	if err != nil {
+		panic(err)
+	}
+	for _, pool := range pools.Items {
+		c.IPPools().Delete(pool.Metadata)
+	}
+}

--- a/lib/testutils/e2e_describe.go
+++ b/lib/testutils/e2e_describe.go
@@ -11,20 +11,21 @@ import (
 )
 
 const (
-	ClientEtcdV2 = 1 << iota
-	ClientK8s
+	DatastoreEtcdV2 = 1 << iota
+	DatastoreK8s
 )
 
-// E2eDescribe is a replacement for ginkgo.Describe which invoke Describe
-// multiple times for one or more different backend clients - passing in the
+// E2eDatastoreDescribe is a replacement for ginkgo.Describe which invokes Describe
+// multiple times for one or more different datastore drivers - passing in the
 // Calico API configuration as a parameter to the test function.  This allows
-// easy construction of end-to-end tests covering multiple different backends.
+// easy construction of end-to-end tests covering multiple different datastore
+// drivers.
 //
-// The *clients* parameter is a bit-wise OR of the required client/backend
-// types that will be tested.
-func E2eDescribe(description string, clients int, body func(config api.CalicoAPIConfig)) bool {
+// The *datastores* parameter is a bit-wise OR of the required datastore drivers
+// that will be tested.
+func E2eDatastoreDescribe(description string, datastores int, body func(config api.CalicoAPIConfig)) bool {
 
-	if clients&ClientEtcdV2 != 0 {
+	if datastores & DatastoreEtcdV2 != 0 {
 		Describe(fmt.Sprintf("%s (etcdv2 backend)", description),
 			func() {
 				body(api.CalicoAPIConfig{
@@ -38,7 +39,7 @@ func E2eDescribe(description string, clients int, body func(config api.CalicoAPI
 			})
 	}
 
-	if clients&ClientK8s != 0 {
+	if datastores & DatastoreK8s != 0 {
 		Describe(fmt.Sprintf("%s (kubernetes backend)", description),
 			func() {
 				body(api.CalicoAPIConfig{

--- a/lib/testutils/e2e_describe.go
+++ b/lib/testutils/e2e_describe.go
@@ -1,0 +1,56 @@
+package testutils
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/etcd"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
+
+	. "github.com/onsi/ginkgo"
+)
+
+const (
+	ClientEtcdV2 = 1 << iota
+	ClientK8s
+)
+
+// E2eDescribe is a replacement for ginkgo.Describe which invoke Describe
+// multiple times for one or more different backend clients - passing in the
+// Calico API configuration as a parameter to the test function.  This allows
+// easy construction of end-to-end tests covering multiple different backends.
+//
+// The *clients* parameter is a bit-wise OR of the required client/backend
+// types that will be tested.
+func E2eDescribe(description string, clients int, body func(config api.CalicoAPIConfig)) bool {
+
+	if clients&ClientEtcdV2 != 0 {
+		Describe(fmt.Sprintf("%s (etcdv2 backend)", description),
+			func() {
+				body(api.CalicoAPIConfig{
+					Spec: api.CalicoAPIConfigSpec{
+						DatastoreType: api.EtcdV2,
+						EtcdConfig: etcd.EtcdConfig{
+							EtcdEndpoints: "http://127.0.0.1:2379",
+						},
+					},
+				})
+			})
+	}
+
+	if clients&ClientK8s != 0 {
+		Describe(fmt.Sprintf("%s (kubernetes backend)", description),
+			func() {
+				body(api.CalicoAPIConfig{
+					Spec: api.CalicoAPIConfigSpec{
+						DatastoreType: api.Kubernetes,
+						KubeConfig: k8s.KubeConfig{
+							K8sAPIEndpoint: "http://localhost:8080",
+						},
+					},
+				})
+			})
+	}
+
+	return true
+}


### PR DESCRIPTION
Add test infrastructure for running e2e tests using different client backends.

This PR also fixes a bug in the k8s IP pools List processing that was preventing IP pools from being Listed when the CIDR was specified in the request.