### PR TITLE
Support InsecureSkipTLSVerify

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -59,12 +59,13 @@ type KubeClient struct {
 }
 
 type KubeConfig struct {
-	Kubeconfig     string `json:"kubeconfig" envconfig:"KUBECONFIG" default:""`
-	K8sAPIEndpoint string `json:"k8sAPIEndpoint" envconfig:"K8S_API_ENDPOINT" default:""`
-	K8sKeyFile     string `json:"k8sKeyFile" envconfig:"K8S_KEY_FILE" default:""`
-	K8sCertFile    string `json:"k8sCertFile" envconfig:"K8S_CERT_FILE" default:""`
-	K8sCAFile      string `json:"k8sCAFile" envconfig:"K8S_CA_FILE" default:""`
-	K8sAPIToken    string `json:"k8sAPIToken" envconfig:"K8S_API_TOKEN" default:""`
+	Kubeconfig               string `json:"kubeconfig" envconfig:"KUBECONFIG" default:""`
+	K8sAPIEndpoint           string `json:"k8sAPIEndpoint" envconfig:"K8S_API_ENDPOINT" default:""`
+	K8sKeyFile               string `json:"k8sKeyFile" envconfig:"K8S_KEY_FILE" default:""`
+	K8sCertFile              string `json:"k8sCertFile" envconfig:"K8S_CERT_FILE" default:""`
+	K8sCAFile                string `json:"k8sCAFile" envconfig:"K8S_CA_FILE" default:""`
+	K8sAPIToken              string `json:"k8sAPIToken" envconfig:"K8S_API_TOKEN" default:""`
+	K8sInsecureSkipTLSVerify bool   `json:"k8sInsecureSkipTLSVerify" envconfig:"K8S_INSECURE_SKIP_TLS_VERIFY" default:""`
 }
 
 func NewKubeClient(kc *KubeConfig) (*KubeClient, error) {
@@ -94,6 +95,9 @@ func NewKubeClient(kc *KubeConfig) (*KubeClient, error) {
 		if override.value != "" {
 			*override.variable = override.value
 		}
+	}
+	if kc.K8sInsecureSkipTLSVerify {
+		configOverrides.ClusterInfo.InsecureSkipTLSVerify = true
 	}
 	log.Debugf("Config overrides: %+v", configOverrides)
 


### PR DESCRIPTION
Allow k8s datastore users to set an environmental
variable (K8S_INSECURE_SKIP_TLS_VERIFY) that means to skip verification
of the API server's TLS certificate.