### PR TITLE
Introduce Labels interface

### DIFF
--- a/lib/selector/selector.go
+++ b/lib/selector/selector.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import "github.com/projectcalico/libcalico-go/lib/selector/parser"
 
 type Selector interface {
 	Evaluate(labels map[string]string) bool
+	EvaluateLabels(labels parser.Labels) bool
 	String() string
 	UniqueId() string
 }


### PR DESCRIPTION
Allows for different implementations of labels rather than just `map[string]string`.  Allows for various occupancy improvements in Felix by calculating combined labels on-the-fly.

Existing interface is maintained and new `EvaluateLabels()` method added for back compatibility. 

Targeting 2.1.1 for occupancy improvements so this isn't needed for 2.1.0.