### PR TITLE
Handle missing node better

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -192,7 +192,21 @@ func (c converter) globalConfigToTPR(kvp *model.KVPair) thirdparty.GlobalConfig 
 // isCalicoPod returns true if the pod should be shown as a workloadEndpoint
 // in the Calico API and false otherwise.
 func (c converter) isCalicoPod(pod *kapiv1.Pod) bool {
-	return !c.isHostNetworked(pod) && c.hasIPAddress(pod)
+	if c.isHostNetworked(pod) {
+		log.WithField("pod", pod.Name).Debug("Pod is host networked.")
+		return false
+	} else if !c.hasIPAddress(pod) {
+		log.WithField("pod", pod.Name).Debug("Pod does not have an IP address.")
+		return false
+	} else if !c.isScheduled(pod) {
+		log.WithField("pod", pod.Name).Debug("Pod is not scheduled.")
+		return false
+	}
+	return true
+}
+
+func (c converter) isScheduled(pod *kapiv1.Pod) bool {
+	return pod.Spec.NodeName != ""
 }
 
 func (c converter) isHostNetworked(pod *kapiv1.Pod) bool {
@@ -208,22 +222,18 @@ func (c converter) podToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 	profile := fmt.Sprintf("ns.projectcalico.org/%s", pod.ObjectMeta.Namespace)
 	workload := fmt.Sprintf("%s.%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 
-	// If the pod doesn't have an IP address yet, then it hasn't gone through CNI.
-	ipNets := []cnet.IPNet{}
-	if c.hasIPAddress(pod) {
-		// Parse the Pod's IP address.
-		_, ipNet, err := cnet.ParseCIDR(fmt.Sprintf("%s/32", pod.Status.PodIP))
-		if err != nil {
-			return nil, err
-		}
-		ipNets = []cnet.IPNet{*ipNet}
+	// If the pod isn't ready, we can't parse it.
+	if !c.isCalicoPod(pod) {
+		return nil, fmt.Errorf("Pod is not ready / valid. pod=%s", pod.Name)
 	}
 
-	// Check to see if the Pod has a Node.
-	if len(pod.Spec.NodeName) == 0 {
-		log.Warnf("%s - NodeName is empty. Spec: %+v Status: %+v", pod.Name, pod.Spec, pod.Status)
-		return nil, fmt.Errorf("Pod '%s' is missing a NodeName", pod.Name)
+	// Parse the Pod's IP address.
+	_, ipNet, err := cnet.ParseCIDR(fmt.Sprintf("%s/32", pod.Status.PodIP))
+	if err != nil {
+		log.WithFields(log.Fields{"ip": pod.Status.PodIP, "pod": pod.Name}).WithError(err).Error("Failed to parse pod IP")
+		return nil, err
 	}
+	ipNets := []cnet.IPNet{*ipNet}
 
 	// Generate the interface name and MAC based on workload.  This must match
 	// the host-side veth configured by the CNI plugin.

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(wep.Revision.(string)).To(Equal("1234"))
 	})
 
-	It("should parse a Pod without an IP to a WorkloadEndpoint", func() {
+	It("should fail to parse a Pod without an IP to a WorkloadEndpoint", func() {
 		pod := k8sapi.Pod{
 			ObjectMeta: k8sapi.ObjectMeta{
 				Name:      "podA",
@@ -147,21 +147,8 @@ var _ = Describe("Test Pod conversion", func() {
 			Status: k8sapi.PodStatus{},
 		}
 
-		wep, err := c.podToWorkloadEndpoint(&pod)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Assert key fields.
-		Expect(wep.Key.(model.WorkloadEndpointKey).WorkloadID).To(Equal("default.podA"))
-		Expect(wep.Key.(model.WorkloadEndpointKey).Hostname).To(Equal("nodeA"))
-		Expect(wep.Key.(model.WorkloadEndpointKey).EndpointID).To(Equal("eth0"))
-		Expect(wep.Key.(model.WorkloadEndpointKey).OrchestratorID).To(Equal("k8s"))
-
-		// Assert value fields.
-		Expect(len(wep.Value.(*model.WorkloadEndpoint).IPv6Nets)).To(Equal(0))
-		Expect(len(wep.Value.(*model.WorkloadEndpoint).IPv4Nets)).To(Equal(0))
-		Expect(wep.Value.(*model.WorkloadEndpoint).State).To(Equal("active"))
-		expectedLabels := map[string]string{"labelA": "valueA", "labelB": "valueB", "calico/k8s_ns": "default"}
-		Expect(wep.Value.(*model.WorkloadEndpoint).Labels).To(Equal(expectedLabels))
+		_, err := c.podToWorkloadEndpoint(&pod)
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should parse a Pod with no labels", func() {

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -34,7 +35,12 @@ import (
 // cb implements the callback interface required for the
 // backend Syncer API.
 type cb struct {
-	status api.SyncStatus
+	// Stores the current state for comparison by the tests.
+	State map[string]api.Update
+	Lock  *sync.Mutex
+
+	status     api.SyncStatus
+	updateChan chan api.Update
 }
 
 func (c cb) OnStatusUpdated(status api.SyncStatus) {
@@ -71,10 +77,48 @@ func (c cb) OnUpdates(updates []api.Update) {
 		case api.UpdateTypeKVUnknown:
 			panic(fmt.Sprintf("[TEST] Syncer received unkown update: %+v", u))
 		}
+
+		// Send the update to a goroutine which will process it.
+		c.updateChan <- u
 	}
 }
 
-func CreateClientAndStartSyncer() *KubeClient {
+func (c cb) ProcessUpdates() {
+	for u := range c.updateChan {
+		// Store off the update so it can be checked by the test.
+		// Use a mutex for safe cross-goroutine reads/writes.
+		c.Lock.Lock()
+		if u.UpdateType == api.UpdateTypeKVUnknown {
+			// We should never get this!
+			log.Panic("Received Unknown update type")
+		} else if u.UpdateType == api.UpdateTypeKVDeleted {
+			// Deleted.
+			delete(c.State, u.Key.String())
+			log.Infof("[TEST] Delete update %s", u.Key.String())
+		} else {
+			// Add or modified.
+			c.State[u.Key.String()] = u
+			log.Infof("[TEST] Stored update %s", u.Key.String())
+		}
+		c.Lock.Unlock()
+	}
+}
+
+func (c cb) ExpectUpdate(kvps []model.KVPair) {
+	for _, kvp := range kvps {
+		log.Infof("[TEST] Expecting key: %s", kvp.Key)
+
+		// Get the update.
+		c.Lock.Lock()
+		update, ok := c.State[kvp.Key.String()]
+		c.Lock.Unlock()
+
+		log.Infof("[TEST] Key exists? %t: %+v", ok, update)
+		Expect(ok).To(Equal(true), fmt.Sprintf("Expected key to exist: %s", kvp.Key))
+	}
+}
+
+func CreateClientAndSyncer() (*KubeClient, *cb, api.Syncer) {
 	// First create the client.
 	cfg := KubeConfig{
 		K8sAPIEndpoint: "http://localhost:8080",
@@ -91,19 +135,26 @@ func CreateClientAndStartSyncer() *KubeClient {
 	}
 
 	// Start the syncer.
+	updateChan := make(chan api.Update)
 	callback := cb{
-		status: api.WaitForDatastore,
+		State:      map[string]api.Update{},
+		status:     api.WaitForDatastore,
+		Lock:       &sync.Mutex{},
+		updateChan: updateChan,
 	}
 	syncer := c.Syncer(callback)
-	syncer.Start()
-	return c
+	return c, &callback, syncer
 }
 
 var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 	log.SetLevel(log.DebugLevel)
 
 	// Start the syncer.
-	c := CreateClientAndStartSyncer()
+	c, cb, syncer := CreateClientAndSyncer()
+	syncer.Start()
+
+	// Start processing updates.
+	go cb.ProcessUpdates()
 
 	It("should handle a Namespace with DefaultDeny", func() {
 		ns := k8sapi.Namespace{
@@ -139,6 +190,15 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		_, err = c.Get(model.PolicyKey{Name: fmt.Sprintf("ns.projectcalico.org/%s", ns.ObjectMeta.Name)})
 		Expect(err).NotTo(HaveOccurred())
 
+		// Expect corresponding Profile updates over the syncer for this Namespace.
+		expectedName := "ns.projectcalico.org/test-syncer-namespace-default-deny"
+		expectedKeys := []model.KVPair{
+			{Key: model.ProfileRulesKey{model.ProfileKey{Name: expectedName}}},
+			{Key: model.ProfileTagsKey{model.ProfileKey{Name: expectedName}}},
+			{Key: model.ProfileLabelsKey{model.ProfileKey{Name: expectedName}}},
+		}
+		time.Sleep(1 * time.Second)
+		cb.ExpectUpdate(expectedKeys)
 	})
 
 	It("should handle a Namespace without DefaultDeny", func() {
@@ -341,6 +401,34 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			_, err = c.Apply(wep)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		// The expected KVPair keys that should exist as a result of creating this Pod.
+		expectedKeys := []model.KVPair{
+			{Key: model.WorkloadEndpointKey{
+				Hostname:       "127.0.0.1",
+				OrchestratorID: "k8s",
+				WorkloadID:     fmt.Sprintf("default.%s", pod.ObjectMeta.Name),
+				EndpointID:     "eth0",
+			}},
+		}
+
+		By("Expecting an update on the Syncer API", func() {
+			// Expect corresponding updates over the syncer for this Pod.
+			time.Sleep(1 * time.Second)
+			cb.ExpectUpdate(expectedKeys)
+		})
+
+		By("Expecting a Syncer snapshot to include the update", func() {
+			// Create a new syncer / callback pair so that it performs a snapshot.
+			_, snapshotCallbacks, snapshotSyncer := CreateClientAndSyncer()
+			go snapshotCallbacks.ProcessUpdates()
+			snapshotSyncer.Start()
+
+			// Wait a bit for the snapshot to finish.
+			time.Sleep(2 * time.Second)
+			snapshotCallbacks.ExpectUpdate(expectedKeys)
+		})
+
 	})
 
 	// Add a defer to wait for all pods to clean up.


### PR DESCRIPTION
Fix #345 

We receive Pods with a missing NodeName when they are first created in the k8s API, but not yet scheduled.

This PR makes the syncer ignore any such updates, and updates the code to be consistent in using `isCalicoPod` for determining if a Pod should be shown through the Calico API as a workloadEndpoint.