### PR TITLE
Check for conflicting Source/Dest CIDR type

### DIFF
--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -364,6 +364,26 @@ func validateRule(v *validator.Validate, structLevel *validator.StructLevel) {
 				"Destination.NotPorts", "", reason("protocol does not support ports"))
 		}
 	}
+
+	// Check for mismatch in IP versions
+	if rule.Source.Net != nil && rule.IPVersion != nil {
+		if rule.Source.Net.Version() != *(rule.IPVersion) {
+			structLevel.ReportError(reflect.ValueOf(rule.Source.Net), "Source.Net",
+				"", reason("rule contains an IP version that does not match src CIDR version"))
+		}
+	}
+	if rule.Destination.Net != nil && rule.IPVersion != nil {
+		if rule.Destination.Net.Version() != *(rule.IPVersion) {
+			structLevel.ReportError(reflect.ValueOf(rule.Destination.Net), "Destination.Net",
+				"", reason("rule contains an IP version that does not match dst CIDR version"))
+		}
+	}
+	if rule.Source.Net != nil && rule.Destination.Net != nil {
+		if rule.Source.Net.Version() != rule.Destination.Net.Version() {
+			structLevel.ReportError(reflect.ValueOf(rule.Destination.Net), "Destination.Net",
+				"", reason("rule does not support mixing of IPv4/v6 CIDRs"))
+		}
+	}
 }
 
 func validateBackendRule(v *validator.Validate, structLevel *validator.StructLevel) {

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -473,6 +473,58 @@ func init() {
 					NotPorts: []numorstring.Port{numorstring.Port{MinPort: 0, MaxPort: 100}},
 				},
 			}, false),
+		Entry("should reject rule mixed IPv4 (src) and IPv6 (dest)",
+			api.Rule{
+				Action:   "allow",
+				Protocol: protocolFromString("tcp"),
+				Source: api.EntityRule{
+					Net: &netv4_3,
+				},
+				Destination: api.EntityRule{
+					Net: &netv6_3,
+				},
+			}, false),
+		Entry("should reject rule mixed IPv6 (src) and IPv4 (dest)",
+			api.Rule{
+				Action:   "allow",
+				Protocol: protocolFromString("tcp"),
+				Source: api.EntityRule{
+					Net: &netv6_2,
+				},
+				Destination: api.EntityRule{
+					Net: &netv4_2,
+				},
+			}, false),
+		Entry("should reject rule mixed IPv6 version and IPv4 Net",
+			api.Rule{
+				Action:    "allow",
+				Protocol:  protocolFromString("tcp"),
+				IPVersion: &V6,
+				Source: api.EntityRule{
+					Net: &netv4_4,
+				},
+				Destination: api.EntityRule{
+					Net: &netv4_2,
+				},
+			}, false),
+		Entry("should reject rule mixed IPVersion and Source Net IP version",
+			api.Rule{
+				Action:    "allow",
+				Protocol:  protocolFromString("tcp"),
+				IPVersion: &V6,
+				Source: api.EntityRule{
+					Net: &netv4_1,
+				},
+			}, false),
+		Entry("should reject rule mixed IPVersion and Dest Net IP version",
+			api.Rule{
+				Action:    "allow",
+				Protocol:  protocolFromString("tcp"),
+				IPVersion: &V4,
+				Destination: api.EntityRule{
+					Net: &netv6_1,
+				},
+			}, false),
 
 		// (API) NodeSpec
 		Entry("should accept node with IPv4 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: &netv4_1}}, true),


### PR DESCRIPTION
Shouldn't allow for creation of rules with mixed
IPv4/v6 source/dest types