### PR TITLE
K8s host config

### DIFF
--- a/kubernetes-manifests/manifests-multi/master-multi.json
+++ b/kubernetes-manifests/manifests-multi/master-multi.json
@@ -19,6 +19,7 @@
         "--root-ca-file=/srv/kubernetes/ca.crt",
         "--min-resync-period=3m",
         "--leader-elect=true",
+        "--allocate-node-cidrs=true",
         "--cluster-cidr=10.1.0.0/16",
         "--v=2"
       ],

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -40,6 +40,8 @@ import (
 	"k8s.io/client-go/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 type KubeClient struct {
@@ -739,9 +741,79 @@ func (c *KubeClient) deleteGlobalConfig(k *model.KVPair) error {
 }
 
 func (c *KubeClient) getHostConfig(k model.HostConfigKey) (*model.KVPair, error) {
+	if k.Name == "IpInIpTunnelAddr" {
+		n, err := c.clientSet.Nodes().Get(k.Hostname, metav1.GetOptions{})
+		if err != nil {
+			return nil, resources.K8sErrorToCalico(err, k)
+		}
+
+		kvp, err := getTunIp(n)
+		if err != nil {
+			return nil, err
+		}
+
+		return kvp, nil
+	}
+
 	return nil, errors.ErrorResourceDoesNotExist{Identifier: k}
 }
 
 func (c *KubeClient) listHostConfig(l model.HostConfigListOptions) ([]*model.KVPair, error) {
-	return []*model.KVPair{}, nil
+	var kvps = []*model.KVPair{}
+
+	// Short circuit if they aren't asking for information we can provide.
+	if l.Name == "" || l.Name == "IpInIpTunnelAddr" {
+		// First see if we were handed a specific host, if not list all Nodes
+		if l.Hostname == "" {
+			nodes, err := c.clientSet.Nodes().List(v1.ListOptions{})
+			if err != nil {
+				return nil, resources.K8sErrorToCalico(err, l)
+			}
+
+			for _, node := range nodes.Items {
+				kvp, err := getTunIp(&node)
+				if err != nil {
+					log.Warnf("Invalid IP for HostConfig: %s, %s", node.Name, node.Spec.PodCIDR)
+					continue
+				}
+
+				kvps = append(kvps, kvp)
+			}
+		} else {
+			node, err := c.clientSet.Nodes().Get(l.Hostname, metav1.GetOptions{})
+			if err != nil {
+				return nil, resources.K8sErrorToCalico(err, l)
+			}
+
+			kvp, err := getTunIp(node)
+			if err != nil {
+				return []*model.KVPair{}, nil
+			}
+
+			kvps = append(kvps, kvp)
+		}
+	}
+
+	return kvps, nil
+}
+
+func getTunIp(n *v1.Node) (*model.KVPair, error) {
+	ip, _, err := net.ParseCIDR(n.Spec.PodCIDR)
+	if err != nil {
+		return nil, err
+	}
+	// We need to get the IP for the podCIDR and increment it to the
+	// first IP in the CIDR.
+	tunIp := ip.To4()
+	tunIp[3]++
+
+	kvp := &model.KVPair{
+		Key: model.HostConfigKey{
+			Hostname: n.Name,
+			Name: "IpInIpTunnelAddr",
+		},
+		Value: tunIp,
+	}
+
+	return kvp, nil
 }

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -819,7 +819,7 @@ func getTunIp(n *v1.Node) (*model.KVPair, error) {
 			Hostname: n.Name,
 			Name: "IpInIpTunnelAddr",
 		},
-		Value: tunIp,
+		Value: tunIp.String(),
 	}
 
 	return kvp, nil

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -736,4 +736,18 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(getNode.Value.(*model.Node).BGPASNumber).To(BeNil())
 		})
 	})
+
+	It("Should support Getting and Listing HostConfig", func() {
+		By("Listing all Nodes HostConfig", func() {
+			l, err := c.List(model.HostConfigListOptions{Hostname: ""})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(l[0].Value).NotTo(BeZero())
+		})
+
+		By("Getting a specific Nodes HostConfig", func() {
+			h, err := c.Get(model.HostConfigKey{Hostname: "127.0.0.1", Name: "IpInIpTunnelAddr"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(h.Value).NotTo(BeZero())
+		})
+	})
 })

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -576,7 +576,7 @@ func (syn *kubeSyncer) parseNodeEvent(e watch.Event) *model.KVPair {
 	}
 
 	kvpHostIp := &model.KVPair{
-		Key: model.HostConfigKey{Hostname: node.Name},
+		Key: model.HostIPKey{Hostname: node.Name},
 		Value: kvp.Value.(*model.Node).BGPIPv4Addr,
 		Revision: kvp.Revision,
 	}

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -451,6 +451,21 @@ func (syn *kubeSyncer) performSnapshot() ([]model.KVPair, map[string]bool, resou
 			keys[c.Key.String()] = true
 		}
 
+		// Sync Hostconfig.
+		log.Info("Syncing HostConfig")
+		hostConfList, err := syn.kc.listHostConfig(model.HostConfigListOptions{})
+		if err != nil {
+			log.Warnf("Error querying HostConfig during snapshot, retrying: %s", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		log.Info("Received HostConfig List() response")
+
+		for _, h := range hostConfList {
+			snap = append(snap, *h)
+			keys[h.Key.String()] = true
+		}
+
 		// Sync IP Pools.
 		log.Info("Syncing IP Pools")
 		poolList, err := syn.kc.List(model.IPPoolListOptions{})
@@ -556,16 +571,21 @@ func (syn *kubeSyncer) parseNodeEvent(e watch.Event) *model.KVPair {
 	}
 
 	kvp, err := resources.K8sNodeToCalico(node)
-
 	if err != nil {
 		log.Panicf("%s", err)
+	}
+
+	kvpHostIp := &model.KVPair{
+		Key: model.HostConfigKey{Hostname: node.Name},
+		Value: kvp.Value.(*model.Node).BGPIPv4Addr,
+		Revision: kvp.Revision,
 	}
 
 	if e.Type == watch.Deleted {
 		kvp.Value = nil
 	}
 
-	return kvp
+	return kvpHostIp
 }
 
 // parsePodEvent returns a KVPair for the given event.  If the event isn't


### PR DESCRIPTION
Fleshed out portion of the `HostConfig` object in KDD to return an IP address for an IPIP tunnel if requested.

As we are currently using `host-local` for the IPAM provider in KDD we can assume that the first two IPs are available for use, as `host-local` reserves those for use.  This change will query the Node for its pod CIDR and grab the first IP from it to return.

fixes projectcalico/calicoctl#1599