### PR TITLE
Add SRV discovery to etcd backend

### DIFF
--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -48,14 +48,15 @@ type CalicoAPIConfigSpec struct {
 }
 
 type EtcdConfig struct {
-	EtcdScheme     string `json:"etcdScheme" envconfig:"ETCD_SCHEME" default:"http"`
-	EtcdAuthority  string `json:"etcdAuthority" envconfig:"ETCD_AUTHORITY" default:"127.0.0.1:2379"`
-	EtcdEndpoints  string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
-	EtcdUsername   string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
-	EtcdPassword   string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
-	EtcdKeyFile    string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
-	EtcdCertFile   string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
-	EtcdCACertFile string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
+	EtcdScheme       string `json:"etcdScheme" envconfig:"ETCD_SCHEME" default:"http"`
+	EtcdAuthority    string `json:"etcdAuthority" envconfig:"ETCD_AUTHORITY" default:"127.0.0.1:2379"`
+	EtcdEndpoints    string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
+	EtcdDiscoverySrv string `json:"etcdDiscoverySrv" envconfig:"ETCD_DISCOVERY_SRV"`
+	EtcdUsername     string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
+	EtcdPassword     string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
+	EtcdKeyFile      string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
+	EtcdCertFile     string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
+	EtcdCACertFile   string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
 }
 
 type KubeConfig struct {

--- a/lib/apis/v1/apiconfig.go
+++ b/lib/apis/v1/apiconfig.go
@@ -47,14 +47,15 @@ type CalicoAPIConfigSpec struct {
 }
 
 type EtcdConfig struct {
-	EtcdScheme     string `json:"etcdScheme" envconfig:"ETCD_SCHEME" default:"http"`
-	EtcdAuthority  string `json:"etcdAuthority" envconfig:"ETCD_AUTHORITY" default:"127.0.0.1:2379"`
-	EtcdEndpoints  string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
-	EtcdUsername   string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
-	EtcdPassword   string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
-	EtcdKeyFile    string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
-	EtcdCertFile   string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
-	EtcdCACertFile string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
+	EtcdScheme       string `json:"etcdScheme" envconfig:"ETCD_SCHEME" default:"http"`
+	EtcdAuthority    string `json:"etcdAuthority" envconfig:"ETCD_AUTHORITY" default:"127.0.0.1:2379"`
+	EtcdEndpoints    string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
+	EtcdDiscoverySrv string `json:"etcdDiscoverySrv" envconfig:"ETCD_DISCOVERY_SRV"`
+	EtcdUsername     string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
+	EtcdPassword     string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
+	EtcdKeyFile      string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
+	EtcdCertFile     string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
+	EtcdCACertFile   string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
 }
 
 type KubeConfig struct {

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -29,7 +29,7 @@ import (
 var _ = Describe("Client config tests", func() {
 
 	// Data to test ETCD parameters
-	data1 := `
+	etcdStatic := `
 apiVersion: v1
 kind: calicoApiConfig
 spec:
@@ -40,8 +40,8 @@ spec:
   etcdCertFile: foobar
   etcdCACertFile: foobarbaz
 `
-	cfg1data := api.NewCalicoAPIConfig()
-	cfg1data.Spec = api.CalicoAPIConfigSpec{
+	etcdStaticCfg := api.NewCalicoAPIConfig()
+	etcdStaticCfg.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
 		EtcdConfig: api.EtcdConfig{
 			EtcdEndpoints:  "https://1.2.3.4:1234,https://10.20.30.40:1234",
@@ -50,6 +50,30 @@ spec:
 			EtcdKeyFile:    "foo",
 			EtcdCertFile:   "foobar",
 			EtcdCACertFile: "foobarbaz",
+		},
+	}
+
+	etcdSrv := `
+apiVersion: v1
+kind: calicoApiConfig
+spec:
+  etcdDiscoverySrv: example.com
+  etcdUsername: bar
+  etcdPassword: baz
+  etcdKeyFile: foo
+  etcdCertFile: foobar
+  etcdCACertFile: foobarbaz
+`
+	etcdSrvConfig := api.NewCalicoAPIConfig()
+	etcdSrvConfig.Spec = api.CalicoAPIConfigSpec{
+		DatastoreType: api.EtcdV2,
+		EtcdConfig: api.EtcdConfig{
+			EtcdDiscoverySrv: "example.com",
+			EtcdUsername:     "bar",
+			EtcdPassword:     "baz",
+			EtcdKeyFile:      "foo",
+			EtcdCertFile:     "foobar",
+			EtcdCACertFile:   "foobarbaz",
 		},
 	}
 
@@ -188,7 +212,8 @@ kind: notCalicoApiConfig
 			}
 		},
 
-		Entry("valid etcd configuration", data1, cfg1data, nil),
+		Entry("valid etcd static endpoint configuration", etcdStatic, etcdStaticCfg, nil),
+		Entry("valid etcd discovery SRV configuration", etcdSrv, etcdSrvConfig, nil),
 		Entry("valid k8s configuration", data2, cfg2data, nil),
 		Entry("invalid version", data3, nil, errors.New("invalid config file: unknown APIVersion 'v2'")),
 		Entry("invalid kind", data4, nil, errors.New("invalid config file: expected kind 'calicoApiConfig', got 'notCalicoApiConfig'")),


### PR DESCRIPTION
Adds a new JSON option `etcdDiscoverySrv` and env var `ETCD_DISCOVERY_SRV` to allow specifying a domain name with which the etcd client will perform DNS discovery. See https://coreos.com/etcd/docs/latest/op-guide/clustering.html#dns-discovery

Possibly related to an old issue https://github.com/projectcalico/calicoctl/issues/933.