### PR TITLE
Allow slash in certain names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 *.coverprofile
 vendor
 .idea
+.go-pkg-cache

--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -32,7 +32,7 @@ type HostEndpointMetadata struct {
 	unversioned.ObjectMetadata
 
 	// The name of the endpoint.
-	Name string `json:"name,omitempty" validate:"omitempty,name"`
+	Name string `json:"name,omitempty" validate:"omitempty,namespacedname"`
 
 	// The node name identifying the Calico node instance.
 	Node string `json:"node,omitempty" validate:"omitempty,name"`
@@ -64,7 +64,7 @@ type HostEndpointSpec struct {
 	// A list of identifiers of security Profile objects that apply to this endpoint. Each
 	// profile is applied in the order that they appear in this list.  Profile rules are applied
 	// after the selector-based security policy.
-	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,name"`
+	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,namespacedname"`
 }
 
 // NewHostEndpoint creates a new (zeroed) HostEndpoint struct with the TypeMetadata initialised to the current

--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -47,7 +47,7 @@ type PolicyMetadata struct {
 	unversioned.ObjectMetadata
 
 	// The name of the selector-based security policy.
-	Name string `json:"name,omitempty" validate:"omitempty,name"`
+	Name string `json:"name,omitempty" validate:"omitempty,namespacedname"`
 }
 
 // PolicySpec contains the specification for a selector-based security Policy resource.

--- a/lib/api/profile.go
+++ b/lib/api/profile.go
@@ -34,7 +34,7 @@ type ProfileMetadata struct {
 	unversioned.ObjectMetadata
 
 	// The name of the endpoint.
-	Name string `json:"name,omitempty" validate:"omitempty,name"`
+	Name string `json:"name,omitempty" validate:"omitempty,namespacedname"`
 
 	// A list of tags that are applied to each endpoint that references this profile.
 	Tags []string `json:"tags,omitempty" validate:"omitempty,dive,tag"`

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -33,13 +33,13 @@ type WorkloadEndpointMetadata struct {
 
 	// The name of the endpoint.  This may be omitted on a create, in which case an endpoint
 	// ID will be automatically created, and the endpoint ID will be included in the response.
-	Name string `json:"name,omitempty" validate:"omitempty,name"`
+	Name string `json:"name,omitempty" validate:"omitempty,namespacedname"`
 
 	// The name of the workload.
-	Workload string `json:"workload,omitempty" valid:"omitempty,name"`
+	Workload string `json:"workload,omitempty" valid:"omitempty,namespacedname"`
 
 	// The name of the orchestrator.
-	Orchestrator string `json:"orchestrator,omitempty" valid:"omitempty,name"`
+	Orchestrator string `json:"orchestrator,omitempty" valid:"omitempty,namespacedname"`
 
 	// The node name identifying the Calico node instance.
 	Node string `json:"node,omitempty" valid:"omitempty,name"`
@@ -74,7 +74,7 @@ type WorkloadEndpointSpec struct {
 	// A list of security Profile resources that apply to this endpoint. Each profile is
 	// applied in the order that they appear in this list.  Profile rules are applied
 	// after the selector-based security policy.
-	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,name"`
+	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,namespacedname"`
 
 	// InterfaceName the name of the Linux interface on the host: for example, tap80.
 	InterfaceName string `json:"interfaceName,omitempty" validate:"interface"`

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -33,7 +33,7 @@ var (
 
 type HostEndpointKey struct {
 	Hostname   string `json:"-" validate:"required,hostname"`
-	EndpointID string `json:"-" validate:"required,hostname"`
+	EndpointID string `json:"-" validate:"required,namespacedName"`
 }
 
 func (key HostEndpointKey) defaultPath() (string, error) {
@@ -44,7 +44,7 @@ func (key HostEndpointKey) defaultPath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/v1/host/%s/endpoint/%s",
-		key.Hostname, key.EndpointID)
+		key.Hostname, escapeName(key.EndpointID))
 	return e, nil
 }
 
@@ -78,7 +78,7 @@ func (options HostEndpointListOptions) defaultPathRoot() string {
 	if options.EndpointID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.EndpointID)
+	k = k + fmt.Sprintf("/%s", escapeName(options.EndpointID))
 	return k
 }
 
@@ -90,7 +90,7 @@ func (options HostEndpointListOptions) KeyFromDefaultPath(path string) Key {
 		return nil
 	}
 	hostname := r[0][1]
-	endpointID := r[0][2]
+	endpointID := unescapeName(r[0][2])
 	if options.Hostname != "" && hostname != options.Hostname {
 		log.Debugf("Didn't match hostname %s != %s", options.Hostname, hostname)
 		return nil

--- a/lib/backend/model/hostendpointstatus.go
+++ b/lib/backend/model/hostendpointstatus.go
@@ -32,7 +32,7 @@ var (
 
 type HostEndpointStatusKey struct {
 	Hostname   string `json:"-" validate:"required,hostname"`
-	EndpointID string `json:"-" validate:"required,hostname"`
+	EndpointID string `json:"-" validate:"required,namespacedName"`
 }
 
 func (key HostEndpointStatusKey) defaultPath() (string, error) {
@@ -43,7 +43,7 @@ func (key HostEndpointStatusKey) defaultPath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/felix/v1/host/%s/endpoint/%s",
-		key.Hostname, key.EndpointID)
+		key.Hostname, escapeName(key.EndpointID))
 	return e, nil
 }
 
@@ -77,7 +77,7 @@ func (options HostEndpointStatusListOptions) defaultPathRoot() string {
 	if options.EndpointID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.EndpointID)
+	k = k + fmt.Sprintf("/%s", escapeName(options.EndpointID))
 	return k
 }
 
@@ -89,7 +89,7 @@ func (options HostEndpointStatusListOptions) KeyFromDefaultPath(ekey string) Key
 		return nil
 	}
 	hostname := r[0][1]
-	endpointID := r[0][2]
+	endpointID := unescapeName(r[0][2])
 	if options.Hostname != "" && hostname != options.Hostname {
 		log.Debugf("Didn't match hostname %s != %s", options.Hostname, hostname)
 		return nil

--- a/lib/backend/model/name.go
+++ b/lib/backend/model/name.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import "strings"
+
+// escapeName removes any "/" from the name and URL encodes it to %2f,
+// and necessarily removes % and encodes to %25.
+func escapeName(name string) string {
+	name = strings.Replace(name, "%", "%25", -1)
+	return strings.Replace(name, "/", "%2f", -1)
+}
+
+// unescapeName replaces %2f and %25 in the name back to be a / and %.
+func unescapeName(name string) string {
+	name = strings.Replace(name, "%2f", "/", -1)
+	return strings.Replace(name, "%25", "%", -1)
+}

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -40,7 +40,7 @@ func (key PolicyKey) defaultPath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/v1/policy/tier/default/policy/%s",
-		key.Name)
+		escapeName(key.Name))
 	return e, nil
 }
 
@@ -69,7 +69,7 @@ func (options PolicyListOptions) defaultPathRoot() string {
 	if options.Name == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.Name)
+	k = k + fmt.Sprintf("/%s", escapeName(options.Name))
 	return k
 }
 
@@ -80,7 +80,7 @@ func (options PolicyListOptions) KeyFromDefaultPath(path string) Key {
 		log.Debugf("Didn't match regex")
 		return nil
 	}
-	name := r[0][2]
+	name := unescapeName(r[0][2])
 	if options.Name != "" && name != options.Name {
 		log.Debugf("Didn't match name %s != %s", options.Name, name)
 		return nil

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -42,7 +42,7 @@ func (key ProfileKey) defaultPath() (string, error) {
 	if key.Name == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
-	e := fmt.Sprintf("/calico/v1/policy/profile/%s", key.Name)
+	e := fmt.Sprintf("/calico/v1/policy/profile/%s", escapeName(key.Name))
 	return e, nil
 }
 
@@ -125,7 +125,7 @@ func (options ProfileListOptions) defaultPathRoot() string {
 	if options.Name == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.Name)
+	k = k + fmt.Sprintf("/%s", escapeName(options.Name))
 	return k
 }
 
@@ -136,7 +136,7 @@ func (options ProfileListOptions) KeyFromDefaultPath(path string) Key {
 		log.Debugf("Didn't match regex")
 		return nil
 	}
-	name := r[0][1]
+	name := unescapeName(r[0][1])
 	kind := r[0][2]
 	if options.Name != "" && name != options.Name {
 		log.Debugf("Didn't match name %s != %s", options.Name, name)

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -51,7 +51,7 @@ func (key WorkloadEndpointKey) defaultPath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	return fmt.Sprintf("/calico/v1/host/%s/workload/%s/%s/endpoint/%s",
-		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID), nil
+		key.Hostname, escapeName(key.OrchestratorID), escapeName(key.WorkloadID), escapeName(key.EndpointID)), nil
 }
 
 func (key WorkloadEndpointKey) defaultDeletePath() (string, error) {
@@ -69,7 +69,7 @@ func (key WorkloadEndpointKey) defaultDeleteParentPaths() ([]string, error) {
 		return nil, errors.ErrorInsufficientIdentifiers{Name: "workload"}
 	}
 	workload := fmt.Sprintf("/calico/v1/host/%s/workload/%s/%s",
-		key.Hostname, key.OrchestratorID, key.WorkloadID)
+		key.Hostname, escapeName(key.OrchestratorID), escapeName(key.WorkloadID))
 	endpoints := workload + "/endpoint"
 	return []string{endpoints, workload}, nil
 }
@@ -99,15 +99,15 @@ func (options WorkloadEndpointListOptions) defaultPathRoot() string {
 	if options.OrchestratorID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.OrchestratorID)
+	k = k + fmt.Sprintf("/%s", escapeName(options.OrchestratorID))
 	if options.WorkloadID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s/endpoint", options.WorkloadID)
+	k = k + fmt.Sprintf("/%s/endpoint", escapeName(options.WorkloadID))
 	if options.EndpointID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.EndpointID)
+	k = k + fmt.Sprintf("/%s", escapeName(options.EndpointID))
 	return k
 }
 
@@ -119,9 +119,9 @@ func (options WorkloadEndpointListOptions) KeyFromDefaultPath(path string) Key {
 		return nil
 	}
 	hostname := r[0][1]
-	orch := r[0][2]
-	workload := r[0][3]
-	endpointID := r[0][4]
+	orch := unescapeName(r[0][2])
+	workload := unescapeName(r[0][3])
+	endpointID := unescapeName(r[0][4])
 	if options.Hostname != "" && hostname != options.Hostname {
 		log.Debugf("Didn't match hostname %s != %s", options.Hostname, hostname)
 		return nil

--- a/lib/backend/model/workloadendpointstatus.go
+++ b/lib/backend/model/workloadendpointstatus.go
@@ -50,7 +50,7 @@ func (key WorkloadEndpointStatusKey) defaultPath() (string, error) {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "endpoint"}
 	}
 	return fmt.Sprintf("/calico/felix/v1/host/%s/workload/%s/%s/endpoint/%s",
-		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID), nil
+		key.Hostname, escapeName(key.OrchestratorID), escapeName(key.WorkloadID), escapeName(key.EndpointID)), nil
 }
 
 func (key WorkloadEndpointStatusKey) defaultDeletePath() (string, error) {
@@ -68,7 +68,7 @@ func (key WorkloadEndpointStatusKey) defaultDeleteParentPaths() ([]string, error
 		return nil, errors.ErrorInsufficientIdentifiers{Name: "workload"}
 	}
 	workload := fmt.Sprintf("/calico/felix/v1/host/%s/workload/%s/%s",
-		key.Hostname, key.OrchestratorID, key.WorkloadID)
+		key.Hostname, escapeName(key.OrchestratorID), escapeName(key.WorkloadID))
 	endpoints := workload + "/endpoint"
 	return []string{endpoints, workload}, nil
 }
@@ -98,15 +98,15 @@ func (options WorkloadEndpointStatusListOptions) defaultPathRoot() string {
 	if options.OrchestratorID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.OrchestratorID)
+	k = k + fmt.Sprintf("/%s", escapeName(options.OrchestratorID))
 	if options.WorkloadID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s/endpoint", options.WorkloadID)
+	k = k + fmt.Sprintf("/%s/endpoint", escapeName(options.WorkloadID))
 	if options.EndpointID == "" {
 		return k
 	}
-	k = k + fmt.Sprintf("/%s", options.EndpointID)
+	k = k + fmt.Sprintf("/%s", escapeName(options.EndpointID))
 	return k
 }
 
@@ -118,9 +118,9 @@ func (options WorkloadEndpointStatusListOptions) KeyFromDefaultPath(ekey string)
 		return nil
 	}
 	hostname := r[0][1]
-	orchID := r[0][2]
-	workloadID := r[0][3]
-	endpointID := r[0][4]
+	orchID := unescapeName(r[0][2])
+	workloadID := unescapeName(r[0][3])
+	endpointID := unescapeName(r[0][4])
 	if options.Hostname != "" && hostname != options.Hostname {
 		log.Debugf("Didn't match hostname %s != %s", options.Hostname, hostname)
 		return nil

--- a/lib/client/hostendpoint_e2e_test.go
+++ b/lib/client/hostendpoint_e2e_test.go
@@ -58,7 +58,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			_, outError := c.HostEndpoints().Update(&api.HostEndpoint{Metadata: meta1, Spec: spec1})
 
 			// Should return an error.
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: HostEndpoint(node=node1, name=host1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: HostEndpoint(node=node1, name=ep1)").Error()))
 
 			By("Create, Apply, Get and compare")
 
@@ -140,7 +140,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			_, outError = c.HostEndpoints().Get(meta1)
 
 			// Expect an error since the HostEndpoint was deleted.
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: HostEndpoint(node=node1, name=host1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: HostEndpoint(node=node1, name=ep1)").Error()))
 
 			// Delete the second HostEndpoint with meta2.
 			outError1 = c.HostEndpoints().Delete(meta2)
@@ -167,15 +167,15 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 		// Test 1: Pass two fully populated HostEndpointSpecs and expect the series of operations to succeed.
 		Entry("Two fully populated HostEndpointSpecs",
 			api.HostEndpointMetadata{
-				Name: "host1",
+				Name: "ep1",
 				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-abc",
 					"prod": "no",
 				}},
 			api.HostEndpointMetadata{
-				Name: "host2",
-				Node: "node2",
+				Name: "ep1/with_foo",
+				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "yes",
@@ -194,15 +194,15 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 		// Test 2: Pass one partially populated HostEndpointSpec and another fully populated HostEndpointSpec and expect the series of operations to succeed.
 		Entry("One partially populated HostEndpointSpec and another fully populated HostEndpointSpec",
 			api.HostEndpointMetadata{
-				Name: "host1",
+				Name: "ep1",
 				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-abc",
 					"prod": "no",
 				}},
 			api.HostEndpointMetadata{
-				Name: "host2",
-				Node: "node2",
+				Name: "ep1/with.foo",
+				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "yes",
@@ -219,15 +219,15 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 		// Test 3: Pass one fully populated HostEndpointSpec and another empty HostEndpointSpec and expect the series of operations to succeed.
 		Entry("One fully populated HostEndpointSpec and another (almost) empty HostEndpointSpec",
 			api.HostEndpointMetadata{
-				Name: "host1",
+				Name: "ep1",
 				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-abc",
 					"prod": "no",
 				}},
 			api.HostEndpointMetadata{
-				Name: "host2",
-				Node: "node2",
+				Name: "ep1/with.foo/and.bar",
+				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "yes",
@@ -244,14 +244,14 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 		// Test 4: Pass two fully populated HostEndpointSpecs with two HostEndpointMetadata (one IPv4 and another IPv6) and expect the series of operations to succeed.
 		Entry("Two fully populated HostEndpointSpecs with two HostEndpointMetadata (one IPv4 and another IPv6)",
 			api.HostEndpointMetadata{
-				Name: "host1",
+				Name: "ep1",
 				Node: "node1",
 				Labels: map[string]string{
 					"app":  "app-abc",
 					"prod": "no",
 				}},
 			api.HostEndpointMetadata{
-				Name: "host2",
+				Name: "ep2",
 				Node: "node2",
 				Labels: map[string]string{
 					"app":  "app-xyz",

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -72,7 +72,7 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			_, outError := c.Policies().Update(&api.Policy{Metadata: meta1, Spec: spec1})
 
 			// Should return an error.
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: Policy(name=policy1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: Policy(name=policy-1/with.foo)").Error()))
 
 			By("Create, Apply, Get and compare")
 
@@ -153,7 +153,7 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			_, outError = c.Policies().Get(meta1)
 
 			// Expect an error since the policy was deleted.
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: Policy(name=policy1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: Policy(name=policy-1/with.foo)").Error()))
 
 			// Delete the second policy with meta2.
 			outError1 = c.Policies().Delete(meta2)
@@ -179,26 +179,26 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 
 		// Test 1: Pass two fully populated PolicySpecs and expect the series of operations to succeed.
 		Entry("Two fully populated PolicySpecs",
-			api.PolicyMetadata{Name: "policy1"},
-			api.PolicyMetadata{Name: "policy2"},
+			api.PolicyMetadata{Name: "policy-1/with.foo"},
+			api.PolicyMetadata{Name: "policy.1"},
 			policySpec1,
 			policySpec2,
 		),
 
 		// Test 2: Pass one fully populated PolicySpec and another empty PolicySpec and expect the series of operations to succeed.
 		Entry("One fully populated PolicySpec and another empty PolicySpec",
-			api.PolicyMetadata{Name: "policy1"},
-			api.PolicyMetadata{Name: "policy2"},
+			api.PolicyMetadata{Name: "policy-1/with.foo"},
+			api.PolicyMetadata{Name: "policy.1"},
 			policySpec1,
 			api.PolicySpec{},
 		),
 
 		// Test 3: Pass one partially populated PolicySpec and another fully populated PolicySpec and expect the series of operations to succeed.
 		Entry("One partially populated PolicySpec and another fully populated PolicySpec",
-			api.PolicyMetadata{Name: "policy1"},
-			api.PolicyMetadata{Name: "policy2"},
+			api.PolicyMetadata{Name: "policy-1/with.foo"},
+			api.PolicyMetadata{Name: "policy_1/with.foo/with_bar"},
 			api.PolicySpec{
-				Selector: "has(myLabel888)",
+				Selector: "has(myLabel-8.9/88-._9)",
 			},
 			policySpec2,
 		),

--- a/lib/client/profile_e2e_test.go
+++ b/lib/client/profile_e2e_test.go
@@ -183,7 +183,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 				Tags: tags1,
 			},
 			api.ProfileMetadata{
-				Name: "profile2",
+				Name: "profile1/with_foo",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "no",
@@ -205,7 +205,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 				Tags: tags2,
 			},
 			api.ProfileMetadata{
-				Name: "profile2",
+				Name: "profile1/with_foo",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "no",
@@ -225,7 +225,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 				},
 			},
 			api.ProfileMetadata{
-				Name: "profile2",
+				Name: "profile1/with.foo",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "no",

--- a/lib/client/workloadendpoint_e2e_test.go
+++ b/lib/client/workloadendpoint_e2e_test.go
@@ -66,7 +66,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			_, outError := c.WorkloadEndpoints().Update(&api.WorkloadEndpoint{Metadata: meta1, Spec: spec1})
 
 			// Should return an error.
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: WorkloadEndpoint(node=node1, orchestrator=kubernetes, workload=workload1, name=host1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: WorkloadEndpoint(node=node1, orchestrator=kubernetes, workload=workload1, name=ep1)").Error()))
 
 			By("Create, Apply, Get and compare")
 
@@ -147,7 +147,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			_, outError = c.WorkloadEndpoints().Get(meta1)
 
 			// Expect an error since the WorkloadEndpoint was deleted.
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: WorkloadEndpoint(node=node1, orchestrator=kubernetes, workload=workload1, name=host1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: WorkloadEndpoint(node=node1, orchestrator=kubernetes, workload=workload1, name=ep1)").Error()))
 
 			// Delete the second WorkloadEndpoint with meta2.
 			outError1 = c.WorkloadEndpoints().Delete(meta2)
@@ -172,9 +172,10 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 		},
 
 		// Test 1: Pass two fully populated WorkloadEndpointSpecs and expect the series of operations to succeed.
+		// This also tests two endpoints in the same workload.
 		Entry("Two fully populated WorkloadEndpointSpecs",
 			api.WorkloadEndpointMetadata{
-				Name:         "host1",
+				Name:         "ep1",
 				Workload:     "workload1",
 				Orchestrator: "kubernetes",
 				Node:         "node1",
@@ -183,8 +184,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 					"prod": "no",
 				}},
 			api.WorkloadEndpointMetadata{
-				Name:         "host2",
-				Workload:     "workload2",
+				Name:         "ep1/with_foo",
+				Workload:     "workload1",
 				Orchestrator: "mesos",
 				Node:         "node2",
 				Labels: map[string]string{
@@ -225,7 +226,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 		// Test 2: Pass one partially populated WorkloadEndpointSpec and another fully populated WorkloadEndpointSpec and expect the series of operations to succeed.
 		Entry("One partially populated WorkloadEndpointSpec and another fully populated WorkloadEndpointSpec",
 			api.WorkloadEndpointMetadata{
-				Name:         "host1",
+				Name:         "ep1",
 				Workload:     "workload1",
 				Orchestrator: "kubernetes",
 				Node:         "node1",
@@ -234,9 +235,9 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 					"prod": "no",
 				}},
 			api.WorkloadEndpointMetadata{
-				Name:         "host2",
-				Workload:     "workload2",
-				Orchestrator: "mesos",
+				Name:         "ep1",
+				Workload:     "workload2/with_foo",
+				Orchestrator: "kubernetes",
 				Node:         "node2",
 				Labels: map[string]string{
 					"app":  "app-xyz",
@@ -272,7 +273,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 		// Test 3: Pass one fully populated WorkloadEndpointSpec and another empty WorkloadEndpointSpec and expect the series of operations to succeed.
 		Entry("One fully populated WorkloadEndpointSpec and a (nearly) empty WorkloadEndpointSpec",
 			api.WorkloadEndpointMetadata{
-				Name:         "host1",
+				Name:         "ep1",
 				Workload:     "workload1",
 				Orchestrator: "kubernetes",
 				Node:         "node1",
@@ -281,10 +282,10 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 					"prod": "no",
 				}},
 			api.WorkloadEndpointMetadata{
-				Name:         "host2",
+				Name:         "ep2",
 				Workload:     "workload2",
-				Orchestrator: "mesos",
-				Node:         "node2",
+				Orchestrator: "kubernetes/v2.0.0",
+				Node:         "node1",
 				Labels: map[string]string{
 					"app":  "app-xyz",
 					"prod": "yes",

--- a/lib/selector/tokenizer/tokenizer.go
+++ b/lib/selector/tokenizer/tokenizer.go
@@ -55,7 +55,7 @@ type Token struct {
 
 const (
 	// LabelKeyMatcher is the base regex for a valid label key.
-	LabelKeyMatcher = `([a-zA-Z0-9_.\-/]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?`
+	LabelKeyMatcher = `([a-zA-Z0-9_./-]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?`
 	hasExpr         = `has\(\s*(` + LabelKeyMatcher + `)\s*\)`
 	allExpr         = `all\(\s*\)`
 	notInExpr       = `not\s*in\b`

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -38,6 +38,7 @@ var (
 	labelRegex          = regexp.MustCompile(`^` + tokenizer.LabelKeyMatcher + `$`)
 	labelValueRegex     = regexp.MustCompile("^[a-zA-Z0-9]?([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
 	nameRegex           = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
+	namespacedNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_./-]{1,128}$`)
 	interfaceRegex      = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
 	actionRegex         = regexp.MustCompile("^(allow|deny|log|pass)$")
 	backendActionRegex  = regexp.MustCompile("^(allow|deny|log|next-tier|)$")
@@ -90,6 +91,7 @@ func init() {
 	registerFieldValidator("interface", validateInterface)
 	registerFieldValidator("backendaction", validateBackendAction)
 	registerFieldValidator("name", validateName)
+	registerFieldValidator("namespacedname", validateNamespacedName)
 	registerFieldValidator("selector", validateSelector)
 	registerFieldValidator("tag", validateTag)
 	registerFieldValidator("labels", validateLabels)
@@ -156,6 +158,12 @@ func validateName(v *validator.Validate, topStruct reflect.Value, currentStructO
 	s := field.String()
 	log.Debugf("Validate name: %s", s)
 	return nameRegex.MatchString(s)
+}
+
+func validateNamespacedName(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
+	s := field.String()
+	log.Debugf("Validate namespacedname: %s", s)
+	return namespacedNameRegex.MatchString(s)
 }
 
 func validateIPVersion(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {


### PR DESCRIPTION
Fixes #392 

Rather than fix up every single resource that have have namespaced names (due to k8s object construction), I've focussed on the subset of objects that were affected by the original problem (you couldn't use calicoctl to view k8s KDD policy).  When we refactor libcalico-go it will be significantly easier to escape and unescape all name segments for etcd and other kv backends.