### PR TITLE
Don't use compat module for KDD datastore

### DIFF
--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -102,12 +102,6 @@ func (c *ModelAdaptor) Update(d *model.KVPair) (*model.KVPair, error) {
 			return d, nil
 		}
 	case model.NodeKey:
-		// Quick fix for k8s Node call.  The k8s Node.Update call requires a complete model.Node object,
-		// therefore we do not need to break down the node object.
-		node, err := c.client.Update(d); if err == nil {
-		         return node, nil
-		}
-
 		p, o := toNodeComponents(d)
 		if p, err = c.client.Update(p); err != nil {
 			return nil, err
@@ -150,12 +144,6 @@ func (c *ModelAdaptor) Apply(d *model.KVPair) (*model.KVPair, error) {
 			return d, nil
 		}
 	case model.NodeKey:
-		// Quick fix for k8s Node call.  The k8s Node.Apply call requires a complete model.Node object,
-		// therefore we do not need to break down the node object.  The etcd API will raise an error
-		// if we try to hand it the composite object, hence we then try to apply the separate components.
-		node, err := c.client.Apply(d); if err == nil {
-			return node, nil
-		}
 		p, o := toNodeComponents(d)
 		if p, err = c.client.Apply(p); err != nil {
 			return nil, err
@@ -278,12 +266,6 @@ func (c *ModelAdaptor) getBlock(k model.Key) (*model.KVPair, error) {
 func (c *ModelAdaptor) getNode(nk model.NodeKey) (*model.KVPair, error) {
 	var err error
 
-	// Quick fix for k8s Node call.  The k8s Node.Get call returns a complete model.Node object, therefore we do
-	// not need to find each piece individually.
-	node, err := c.client.Get(nk); if err == nil {
-		return node, nil
-	}
-
 	// Fill in the Metadata specific part of the node configuration.  At the
 	// moment, there is nothing to fill in.
 	if _, err = c.client.Get(model.HostMetadataKey{nk.Hostname}); err != nil {
@@ -314,15 +296,6 @@ func validateBlockValue(kvp *model.KVPair) error {
 // because of the way we do our list queries - we'll enumerate all endpoints on
 // host as well!
 func (c *ModelAdaptor) listNodes(l model.NodeListOptions) ([]*model.KVPair, error) {
-	// The k8s List returns the complete list and values we're interested in, so we make a
-	// call and check if the list has anything in it, returning if it does.
-	nodes, err := c.client.List(l)
-	if err != nil {
-		return nil, err
-	} else if len(nodes) > 0 {
-		return nodes, nil
-	}
-	
 	hml := model.HostMetadataListOptions{Hostname: l.Hostname}
 	hmr, err := c.client.List(hml)
 	if err != nil {

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -168,13 +168,6 @@ type ProfileRules struct {
 	OutboundRules []Rule `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
 }
 
-type client interface {
-	Create(object *KVPair) (*KVPair, error)
-	Update(object *KVPair) (*KVPair, error)
-	Apply(object *KVPair) (*KVPair, error)
-	Get(key Key) (*KVPair, error)
-}
-
 func (_ *ProfileListOptions) ListConvert(ds []*KVPair) []*KVPair {
 
 	profiles := make(map[string]*KVPair)


### PR DESCRIPTION
Fixes #399 

The handling of composite resource types in KDD was a bit wonky.  Basically for KDD we should be completely bypassing the compat module.

This PR removes the insertion of the compat module for KDD and removes the workaround code in compat.go to deal with KDD operations.