### PR TITLE
Relax label regex to just check chars, not construction

### DIFF
--- a/lib/selector/tokenizer/tokenizer.go
+++ b/lib/selector/tokenizer/tokenizer.go
@@ -55,7 +55,7 @@ type Token struct {
 
 const (
 	// LabelKeyMatcher is the base regex for a valid label key.
-	LabelKeyMatcher = `([a-zA-Z0-9_./-]{0,253}/)?[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?`
+	LabelKeyMatcher = `[a-zA-Z0-9_./-]{1,512}`
 	hasExpr         = `has\(\s*(` + LabelKeyMatcher + `)\s*\)`
 	allExpr         = `all\(\s*\)`
 	notInExpr       = `not\s*in\b`

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -143,7 +143,6 @@ func init() {
 		Entry("should reject label key with !", api.HostEndpointMetadata{Labels: map[string]string{"rank!": "gold"}}, false),
 		Entry("should reject label key starting with ~", api.HostEndpointMetadata{Labels: map[string]string{"~rank_.0-9": "gold"}}, false),
 		Entry("should reject label key ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9~": "gold"}}, false),
-		Entry("should reject label key where prefix > 253 characters", api.HostEndpointMetadata{Labels: map[string]string{"Projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org.projectcalico.org123/k8s_ns": "gold"}}, false),
 		Entry("should reject label value starting with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "~gold"}}, false),
 		Entry("should reject label value ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "gold~"}}, false),
 


### PR DESCRIPTION
We have existing deployments that have label syntax that is more permissive than our current - this relaxes the  regex to allow these older deployments to operate.

Fixes #404