### PR TITLE
Do not run containers in interactive mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ run-kubernetes-master: stop-kubernetes-master
 	# request on port 8080, before completing this Makefile
 	# target.
 	docker run \
-		-ti \
 		--rm \
 		--net=host \
 		tutum/curl \


### PR DESCRIPTION
Docker run options '-i' and '-t' are not needed for
fully automated operations (when user doesn't
interact with an application inside a container).
At the same time those options require valid TTY as
input device, which makes tests execution impossible
in closed virtual environment (e.g. Jenkins job).