### PR TITLE
Add System Network Policy (Calico policy as a TPR)

### DIFF
--- a/lib/api/apiconfig.go
+++ b/lib/api/apiconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/api/apiconfig.go
+++ b/lib/api/apiconfig.go
@@ -14,11 +14,7 @@
 
 package api
 
-import (
-	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
-	"github.com/projectcalico/libcalico-go/lib/backend/etcd"
-	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
-)
+import "github.com/projectcalico/libcalico-go/lib/api/unversioned"
 
 type DatastoreType string
 
@@ -44,10 +40,32 @@ type CalicoAPIConfigSpec struct {
 	DatastoreType DatastoreType `json:"datastoreType" envconfig:"DATASTORE_TYPE" default:"etcdv2"`
 
 	// Inline the ectd config fields
-	etcd.EtcdConfig
+	EtcdConfig
 
 	// Inline the k8s config fields.
-	k8s.KubeConfig
+	KubeConfig
+}
+
+type EtcdConfig struct {
+	EtcdScheme     string `json:"etcdScheme" envconfig:"ETCD_SCHEME" default:"http"`
+	EtcdAuthority  string `json:"etcdAuthority" envconfig:"ETCD_AUTHORITY" default:"127.0.0.1:2379"`
+	EtcdEndpoints  string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
+	EtcdUsername   string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
+	EtcdPassword   string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
+	EtcdKeyFile    string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
+	EtcdCertFile   string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
+	EtcdCACertFile string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
+}
+
+type KubeConfig struct {
+	Kubeconfig               string `json:"kubeconfig" envconfig:"KUBECONFIG" default:""`
+	K8sAPIEndpoint           string `json:"k8sAPIEndpoint" envconfig:"K8S_API_ENDPOINT" default:""`
+	K8sKeyFile               string `json:"k8sKeyFile" envconfig:"K8S_KEY_FILE" default:""`
+	K8sCertFile              string `json:"k8sCertFile" envconfig:"K8S_CERT_FILE" default:""`
+	K8sCAFile                string `json:"k8sCAFile" envconfig:"K8S_CA_FILE" default:""`
+	K8sAPIToken              string `json:"k8sAPIToken" envconfig:"K8S_API_TOKEN" default:""`
+	K8sInsecureSkipTLSVerify bool   `json:"k8sInsecureSkipTLSVerify" envconfig:"K8S_INSECURE_SKIP_TLS_VERIFY" default:""`
+	K8sDisableNodePoll       bool   `json:"k8sDisableNodePoll" envconfig:"K8S_DISABLE_NODE_POLL" default:""`
 }
 
 // NewCalicoAPIConfig creates a new (zeroed) CalicoAPIConfig struct with the

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/pkg/transport"
+	capi "github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
@@ -40,23 +41,12 @@ var (
 	clientTimeout        = 30 * time.Second
 )
 
-type EtcdConfig struct {
-	EtcdScheme     string `json:"etcdScheme" envconfig:"ETCD_SCHEME" default:"http"`
-	EtcdAuthority  string `json:"etcdAuthority" envconfig:"ETCD_AUTHORITY" default:"127.0.0.1:2379"`
-	EtcdEndpoints  string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
-	EtcdUsername   string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
-	EtcdPassword   string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
-	EtcdKeyFile    string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
-	EtcdCertFile   string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
-	EtcdCACertFile string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
-}
-
 type EtcdClient struct {
 	etcdClient  etcd.Client
 	etcdKeysAPI etcd.KeysAPI
 }
 
-func NewEtcdClient(config *EtcdConfig) (*EtcdClient, error) {
+func NewEtcdClient(config *capi.EtcdConfig) (*EtcdClient, error) {
 	// Determine the location from the authority or the endpoints.  The endpoints
 	// takes precedence if both are specified.
 	etcdLocation := []string{}

--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -15,19 +15,18 @@
 package k8s
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
 	goerrors "errors"
 	"fmt"
 	"strings"
 
-	"crypto/sha1"
-	"encoding/hex"
-	"encoding/json"
-
 	log "github.com/Sirupsen/logrus"
-	kapiv1 "k8s.io/client-go/pkg/api/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	kapiv1 "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 
-	k8sapi "k8s.io/client-go/pkg/api/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sapi "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/libcalico-go/lib/net"

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -22,24 +22,25 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	capi "github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
-
 	"github.com/projectcalico/libcalico-go/lib/net"
-	"k8s.io/client-go/kubernetes"
-	clientapi "k8s.io/client-go/pkg/api"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/pkg/api/v1"
-	kapiv1 "k8s.io/client-go/pkg/api/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	clientapi "k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	kapiv1 "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -60,20 +61,10 @@ type KubeClient struct {
 	// Clients for interacting with Calico resources.
 	ipPoolClient api.Client
 	nodeClient   api.Client
+	snpClient    api.Client
 }
 
-type KubeConfig struct {
-	Kubeconfig               string `json:"kubeconfig" envconfig:"KUBECONFIG" default:""`
-	K8sAPIEndpoint           string `json:"k8sAPIEndpoint" envconfig:"K8S_API_ENDPOINT" default:""`
-	K8sKeyFile               string `json:"k8sKeyFile" envconfig:"K8S_KEY_FILE" default:""`
-	K8sCertFile              string `json:"k8sCertFile" envconfig:"K8S_CERT_FILE" default:""`
-	K8sCAFile                string `json:"k8sCAFile" envconfig:"K8S_CA_FILE" default:""`
-	K8sAPIToken              string `json:"k8sAPIToken" envconfig:"K8S_API_TOKEN" default:""`
-	K8sInsecureSkipTLSVerify bool   `json:"k8sInsecureSkipTLSVerify" envconfig:"K8S_INSECURE_SKIP_TLS_VERIFY" default:""`
-	K8sDisableNodePoll       bool   `json:"k8sDisableNodePoll" envconfig:"K8S_DISABLE_NODE_POLL" default""`
-}
-
-func NewKubeClient(kc *KubeConfig) (*KubeClient, error) {
+func NewKubeClient(kc *capi.KubeConfig) (*KubeClient, error) {
 	// Use the kubernetes client code to load the kubeconfig file and combine it with the overrides.
 	log.Debugf("Building client for config: %+v", kc)
 	configOverrides := &clientcmd.ConfigOverrides{}
@@ -134,6 +125,7 @@ func NewKubeClient(kc *KubeConfig) (*KubeClient, error) {
 	// Create the Calico sub-clients.
 	kubeClient.ipPoolClient = resources.NewIPPools(cs, tprClient)
 	kubeClient.nodeClient = resources.NewNodeClient(cs, tprClient)
+	kubeClient.snpClient = resources.NewSystemNetworkPolicies(cs, tprClient)
 
 	return kubeClient, nil
 }
@@ -194,8 +186,15 @@ func (c *KubeClient) createThirdPartyResources() error {
 		}
 	}
 
-	// Ensure the IP Pool TPR exists.
-	return c.ipPoolClient.EnsureInitialized()
+	// Ensure the IP Pool and System Network Policy TPRs exists.
+	if err := c.ipPoolClient.EnsureInitialized(); err != nil {
+		return err
+	}
+	if err := c.snpClient.EnsureInitialized(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // waitForClusterType polls until GlobalConfig is ready, or until 30 seconds have passed.
@@ -269,6 +268,8 @@ func buildTPRClient(baseConfig *rest.Config) (*rest.RESTClient, error) {
 				&thirdparty.GlobalConfigList{},
 				&thirdparty.IpPool{},
 				&thirdparty.IpPoolList{},
+				&thirdparty.SystemNetworkPolicy{},
+				&thirdparty.SystemNetworkPolicyList{},
 				&kapiv1.ListOptions{},
 				&kapiv1.DeleteOptions{},
 			)
@@ -606,6 +607,13 @@ func (c *KubeClient) listPolicies(l model.PolicyListOptions) ([]*model.KVPair, e
 		ret = append(ret, kvp)
 	}
 
+	// List all System Network Policies.
+	snps, err := c.snpClient.List(l)
+	if err != nil {
+		return nil, err
+	}
+	ret = append(ret, snps...)
+
 	return ret, nil
 }
 
@@ -648,6 +656,9 @@ func (c *KubeClient) getPolicy(k model.PolicyKey) (*model.KVPair, error) {
 			return nil, resources.K8sErrorToCalico(err, k)
 		}
 		return c.converter.namespaceToPolicy(ns)
+	} else if strings.HasPrefix(k.Name, resources.SystemNetworkPolicyNamePrefix) {
+		// This is backed by a System Network Policy TPR.
+		return c.snpClient.Get(k)
 	} else {
 		// Received a Get() for a Policy that doesn't exist.
 		return nil, errors.ErrorResourceDoesNotExist{Identifier: k}
@@ -742,7 +753,7 @@ func (c *KubeClient) listGlobalConfig(l model.GlobalConfigListOptions) ([]*model
 	err := req.Do().Into(&gcfg)
 	if err != nil {
 		// Don't return errors for "not found".  This just
-		// means thre are no GlobalConfigs, and we should return
+		// means there are no GlobalConfigs, and we should return
 		// an empty list.
 		if !kerrors.IsNotFound(err) {
 			return nil, resources.K8sErrorToCalico(err, l)

--- a/lib/backend/k8s/resources/ippools.go
+++ b/lib/backend/k8s/resources/ippools.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/backend/k8s/resources/ippools_conversion.go
+++ b/lib/backend/k8s/resources/ippools_conversion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/backend/k8s/resources/ippools_conversion.go
+++ b/lib/backend/k8s/resources/ippools_conversion.go
@@ -50,7 +50,7 @@ func IPPoolToThirdParty(kvp *model.KVPair) *thirdparty.IpPool {
 	tpr := thirdparty.IpPool{
 		Metadata: metav1.ObjectMeta{
 			// Names in Kubernetes must be lower-case.
-			Name: tprName(kvp.Key.(model.IPPoolKey)),
+			Name: ipPoolTprName(kvp.Key.(model.IPPoolKey)),
 		},
 		Spec: thirdparty.IpPoolSpec{
 			Value: string(v),
@@ -62,9 +62,9 @@ func IPPoolToThirdParty(kvp *model.KVPair) *thirdparty.IpPool {
 	return &tpr
 }
 
-// tprName converts the given IPPool key into a unique third party resource
+// ipPoolTprName converts the given IPPool key into a unique third party resource
 // name.
-func tprName(key model.IPPoolKey) string {
+func ipPoolTprName(key model.IPPoolKey) string {
 	name := strings.Replace(key.CIDR.String(), ".", "-", 3)
 	name = strings.Replace(name, ":", "-", 7)
 	name = strings.Replace(name, "/", "-", 1)

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -21,8 +21,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 
-	"k8s.io/client-go/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -138,9 +138,5 @@ func (c *nodeClient) EnsureCalicoNodeInitialized(node string) error {
 }
 
 func (c *nodeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
-	return nodeFakeSyncer{}
+	return nil
 }
-
-type nodeFakeSyncer struct{}
-
-func (f nodeFakeSyncer) Start() {}

--- a/lib/backend/k8s/resources/node_conversion.go
+++ b/lib/backend/k8s/resources/node_conversion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/backend/k8s/resources/node_conversion.go
+++ b/lib/backend/k8s/resources/node_conversion.go
@@ -16,6 +16,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"

--- a/lib/backend/k8s/resources/systemnetworkpolicies_conversion.go
+++ b/lib/backend/k8s/resources/systemnetworkpolicies_conversion.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ThirdPartyToSystemNetworkPolicy takes a Kubernetes ThirdPartyResource representation
+// of a Calico Policy and returns the equivalent SystemNetworkPolicy object.
+func ThirdPartyToSystemNetworkPolicy(t *thirdparty.SystemNetworkPolicy) *model.KVPair {
+
+	// Since we are using the Calico API Spec definition to store the Calico
+	// Policy, use the client conversion helper to convert between KV and API.
+	policyName := fmt.Sprintf("%s%s", SystemNetworkPolicyNamePrefix, t.Metadata.Name)
+	r := api.Policy{
+		Metadata: api.PolicyMetadata{
+			Name: policyName,
+		},
+		Spec: t.Spec,
+	}
+	kvp, _ := converter.PolicyConverter{}.ConvertAPIToKVPair(r)
+	kvp.Revision = t.Metadata.ResourceVersion
+
+	return kvp
+}
+
+// SystemNetworkPolicyToThirdParty takes a Calico Policy and returns the equivalent
+// ThirdPartyResource representation.
+func SystemNetworkPolicyToThirdParty(kvp *model.KVPair) *thirdparty.SystemNetworkPolicy {
+	r, _ := converter.PolicyConverter{}.ConvertKVPairToAPI(kvp)
+
+	tprName := systemNetworkPolicyTprName(kvp.Key)
+	tpr := thirdparty.SystemNetworkPolicy{
+		Metadata: metav1.ObjectMeta{
+			Name: tprName,
+		},
+		Spec: r.(*api.Policy).Spec,
+	}
+	if kvp.Revision != nil {
+		tpr.Metadata.ResourceVersion = kvp.Revision.(string)
+	}
+	return &tpr
+}
+
+// systemNetworkPolicyTprName converts a Policy (specifically a System Network Policy)
+// name to a TPR name.
+func systemNetworkPolicyTprName(key model.Key) string {
+	// The name should be policed before we get here.
+	pk := key.(model.PolicyKey)
+	if !strings.HasPrefix(pk.Name, SystemNetworkPolicyNamePrefix) {
+		panic("System Network Policy name is not correctly namespaced")
+	}
+	// Trim the namespace and ensure lowercase.
+	return strings.ToLower(strings.TrimPrefix(pk.Name, SystemNetworkPolicyNamePrefix))
+}

--- a/lib/backend/k8s/syncer_test.go
+++ b/lib/backend/k8s/syncer_test.go
@@ -21,11 +21,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	k8sapi "k8s.io/client-go/pkg/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/watch"
+	k8sapi "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 type testWatch struct {
@@ -157,6 +158,13 @@ func (tc *testClient) NodeList(opts metav1.ListOptions) (list *k8sapi.NodeList, 
 	err = nil
 	return
 }
+func (tc *testClient) SystemNetworkPolicyWatch(opts metav1.ListOptions) (watch.Interface, error) {
+	return tc.newWatch("system network policy", make(chan watch.Event)), nil
+}
+
+func (tc *testClient) SystemNetworkPolicyList() (*thirdparty.SystemNetworkPolicyList, error) {
+	return &thirdparty.SystemNetworkPolicyList{}, nil
+}
 
 func (tc *testClient) getReadyStatus(key model.ReadyFlagKey) (*model.KVPair, error) {
 	return &model.KVPair{Key: key, Value: true}, nil
@@ -234,9 +242,9 @@ var _ = Describe("Test Syncer", func() {
 			// Check that, after the resync, the old watchers are stopped.
 			tc.stateMutex.Lock()
 			defer tc.stateMutex.Unlock()
-			// We expect 6 old watchers and 6 new. If that changes, we'll assert here
+			// We expect 7 old watchers and 7 new. If that changes, we'll assert here
 			// so the maintainer can re-check the test still matches the logic.
-			Expect(tc.openWatchers).To(HaveLen(12))
+			Expect(tc.openWatchers).To(HaveLen(14))
 			for _, w := range tc.openWatchers[:len(tc.openWatchers)/2] {
 				w.stopMutex.Lock()
 				stopped := w.stopped

--- a/lib/backend/k8s/thirdparty/systemnetworkpolicy.go
+++ b/lib/backend/k8s/thirdparty/systemnetworkpolicy.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package thirdparty
 
 import (

--- a/lib/backend/k8s/thirdparty/systemnetworkpolicy.go
+++ b/lib/backend/k8s/thirdparty/systemnetworkpolicy.go
@@ -1,0 +1,73 @@
+package thirdparty
+
+import (
+	"encoding/json"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SystemNetworkPolicy is the ThirdPartyResource definition of a Calico Policy resource in
+// the Kubernetes API.
+type SystemNetworkPolicy struct {
+	metav1.TypeMeta `json:",inline"`
+	Metadata        metav1.ObjectMeta `json:"metadata"`
+	Spec            api.PolicySpec    `json:"spec"`
+}
+
+// SystemNetworkPolicyList is a list of SystemNetworkPolicy resources.
+type SystemNetworkPolicyList struct {
+	metav1.TypeMeta `json:",inline"`
+	Metadata        metav1.ListMeta       `json:"metadata"`
+	Items           []SystemNetworkPolicy `json:"items"`
+}
+
+// GetObjectKind returns the kind of this object.  Required to satisfy Object interface
+func (e *SystemNetworkPolicy) GetObjectKind() schema.ObjectKind {
+	return &e.TypeMeta
+}
+
+// GetOjbectMeta returns the object metadata of this object. Required to satisfy ObjectMetaAccessor interface
+func (e *SystemNetworkPolicy) GetObjectMeta() metav1.Object {
+	return &e.Metadata
+}
+
+// GetObjectKind returns the kind of this object. Required to satisfy Object interface
+func (el *SystemNetworkPolicyList) GetObjectKind() schema.ObjectKind {
+	return &el.TypeMeta
+}
+
+// GetListMeta returns the list metadata of this object. Required to satisfy ListMetaAccessor interface
+func (el *SystemNetworkPolicyList) GetListMeta() metav1.List {
+	return &el.Metadata
+}
+
+// The code below is used only to work around a known problem with third-party
+// resources and ugorji. If/when these issues are resolved, the code below
+// should no longer be required.
+
+type SystemNetworkPolicyListCopy SystemNetworkPolicyList
+type SystemNetworkPolicyCopy SystemNetworkPolicy
+
+func (g *SystemNetworkPolicy) UnmarshalJSON(data []byte) error {
+	tmp := SystemNetworkPolicyCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := SystemNetworkPolicy(tmp)
+	*g = tmp2
+	return nil
+}
+
+func (l *SystemNetworkPolicyList) UnmarshalJSON(data []byte) error {
+	tmp := SystemNetworkPolicyListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := SystemNetworkPolicyList(tmp)
+	*l = tmp2
+	return nil
+}

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -23,8 +23,6 @@ import (
 	"os"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
-	"github.com/projectcalico/libcalico-go/lib/backend/etcd"
-	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
 	"github.com/projectcalico/libcalico-go/lib/client"
 )
 
@@ -45,7 +43,7 @@ spec:
 	cfg1data := api.NewCalicoAPIConfig()
 	cfg1data.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
-		EtcdConfig: etcd.EtcdConfig{
+		EtcdConfig: api.EtcdConfig{
 			EtcdEndpoints:  "https://1.2.3.4:1234,https://10.20.30.40:1234",
 			EtcdUsername:   "bar",
 			EtcdPassword:   "baz",
@@ -71,7 +69,7 @@ spec:
 	cfg2data := api.NewCalicoAPIConfig()
 	cfg2data.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
-		KubeConfig: k8s.KubeConfig{
+		KubeConfig: api.KubeConfig{
 			Kubeconfig:     "filename",
 			K8sAPIEndpoint: "bar",
 			K8sCertFile:    "baz",
@@ -103,7 +101,7 @@ kind: notCalicoApiConfig
 	cfg1env := api.NewCalicoAPIConfig()
 	cfg1env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
-		EtcdConfig: etcd.EtcdConfig{
+		EtcdConfig: api.EtcdConfig{
 			EtcdScheme:     "http",
 			EtcdAuthority:  "127.0.0.1:2379",
 			EtcdEndpoints:  "https://1.2.3.4:1234,https://10.20.30.40:1234",
@@ -128,11 +126,11 @@ kind: notCalicoApiConfig
 	cfg2env := api.NewCalicoAPIConfig()
 	cfg2env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.Kubernetes,
-		EtcdConfig: etcd.EtcdConfig{
+		EtcdConfig: api.EtcdConfig{
 			EtcdScheme:    "http",
 			EtcdAuthority: "127.0.0.1:2379",
 		},
-		KubeConfig: k8s.KubeConfig{
+		KubeConfig: api.KubeConfig{
 			Kubeconfig:     "filename",
 			K8sAPIEndpoint: "bar1",
 			K8sCertFile:    "baz1",
@@ -151,7 +149,7 @@ kind: notCalicoApiConfig
 	cfg3env := api.NewCalicoAPIConfig()
 	cfg3env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
-		EtcdConfig: etcd.EtcdConfig{
+		EtcdConfig: api.EtcdConfig{
 			EtcdScheme:    "http",
 			EtcdAuthority: "123.123.123.123:2344",
 			EtcdUsername:  "userbar",
@@ -168,11 +166,11 @@ kind: notCalicoApiConfig
 	cfg4env := api.NewCalicoAPIConfig()
 	cfg4env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.Kubernetes,
-		EtcdConfig: etcd.EtcdConfig{
+		EtcdConfig: api.EtcdConfig{
 			EtcdScheme:    "http",
 			EtcdAuthority: "127.0.0.1:2379",
 		},
-		KubeConfig: k8s.KubeConfig{
+		KubeConfig: api.KubeConfig{
 			Kubeconfig: "filename-preferred",
 		},
 	}

--- a/lib/client/policy.go
+++ b/lib/client/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,21 +90,24 @@ func (h *policies) convertMetadataToListInterface(m unversioned.ResourceMetadata
 }
 
 // convertMetadataToKey converts a PolicyMetadata to a PolicyKey
-// This is part of the conversionHelper interface.
+// This is part of the conversionHelper interface.  Call through to the shared
+// converter (embedded in the policies struct).
 func (h *policies) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
-	return h.ConvertMetadataToKey(m)
+	return h.ConvertMetadataToKey(m), nil
 }
 
 // convertAPIToKVPair converts an API Policy structure to a KVPair containing a
 // backend Policy and PolicyKey.
-// This is part of the conversionHelper interface.
+// This is part of the conversionHelper interface.  Call through to the shared
+// converter (embedded in the policies struct).
 func (h *policies) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
-	return h.ConvertAPIToKVPair(a)
+	return h.ConvertAPIToKVPair(a), nil
 }
 
 // convertKVPairToAPI converts a KVPair containing a backend Policy and PolicyKey
 // to an API Policy structure.
-// This is part of the conversionHelper interface.
+// This is part of the conversionHelper interface.  Call through to the shared
+// converter (embedded in the policies struct).
 func (h *policies) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	return h.ConvertKVPairToAPI(d)
+	return h.ConvertKVPairToAPI(d), nil
 }

--- a/lib/client/policy.go
+++ b/lib/client/policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
 )
 
 // PolicyInterface has methods to work with Policy resources.
@@ -32,12 +33,13 @@ type PolicyInterface interface {
 
 // policies implements PolicyInterface
 type policies struct {
+	converter.PolicyConverter
 	c *Client
 }
 
 // newPolicies returns a new PolicyInterface bound to the supplied client.
 func newPolicies(c *Client) *policies {
-	return &policies{c}
+	return &policies{c: c}
 }
 
 // Create creates a new policy.
@@ -90,51 +92,19 @@ func (h *policies) convertMetadataToListInterface(m unversioned.ResourceMetadata
 // convertMetadataToKey converts a PolicyMetadata to a PolicyKey
 // This is part of the conversionHelper interface.
 func (h *policies) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
-	pm := m.(api.PolicyMetadata)
-	k := model.PolicyKey{
-		Name: pm.Name,
-	}
-	return k, nil
+	return h.ConvertMetadataToKey(m)
 }
 
 // convertAPIToKVPair converts an API Policy structure to a KVPair containing a
 // backend Policy and PolicyKey.
 // This is part of the conversionHelper interface.
 func (h *policies) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
-	ap := a.(api.Policy)
-	k, err := h.convertMetadataToKey(ap.Metadata)
-	if err != nil {
-		return nil, err
-	}
-
-	d := model.KVPair{
-		Key: k,
-		Value: &model.Policy{
-			Order:         ap.Spec.Order,
-			InboundRules:  rulesAPIToBackend(ap.Spec.IngressRules),
-			OutboundRules: rulesAPIToBackend(ap.Spec.EgressRules),
-			Selector:      ap.Spec.Selector,
-			DoNotTrack:    ap.Spec.DoNotTrack,
-		},
-	}
-
-	return &d, nil
+	return h.ConvertAPIToKVPair(a)
 }
 
 // convertKVPairToAPI converts a KVPair containing a backend Policy and PolicyKey
 // to an API Policy structure.
 // This is part of the conversionHelper interface.
 func (h *policies) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bp := d.Value.(*model.Policy)
-	bk := d.Key.(model.PolicyKey)
-
-	ap := api.NewPolicy()
-	ap.Metadata.Name = bk.Name
-	ap.Spec.Order = bp.Order
-	ap.Spec.IngressRules = rulesBackendToAPI(bp.InboundRules)
-	ap.Spec.EgressRules = rulesBackendToAPI(bp.OutboundRules)
-	ap.Spec.Selector = bp.Selector
-	ap.Spec.DoNotTrack = bp.DoNotTrack
-
-	return ap, nil
+	return h.ConvertKVPairToAPI(d)
 }

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -19,6 +19,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
 )
 
 // ProfileInterface has methods to work with Profile resources.
@@ -125,8 +126,8 @@ func (h *profiles) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 		Key: k,
 		Value: &model.Profile{
 			Rules: model.ProfileRules{
-				InboundRules:  rulesAPIToBackend(ap.Spec.IngressRules),
-				OutboundRules: rulesAPIToBackend(ap.Spec.EgressRules),
+				InboundRules:  converter.RulesAPIToBackend(ap.Spec.IngressRules),
+				OutboundRules: converter.RulesAPIToBackend(ap.Spec.EgressRules),
 			},
 			Tags:   tags,
 			Labels: labels,
@@ -151,8 +152,8 @@ func (h *profiles) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, er
 	} else {
 		ap.Metadata.Tags = bp.Tags
 	}
-	ap.Spec.IngressRules = rulesBackendToAPI(bp.Rules.InboundRules)
-	ap.Spec.EgressRules = rulesBackendToAPI(bp.Rules.OutboundRules)
+	ap.Spec.IngressRules = converter.RulesBackendToAPI(bp.Rules.InboundRules)
+	ap.Spec.EgressRules = converter.RulesBackendToAPI(bp.Rules.OutboundRules)
 
 	return ap, nil
 }

--- a/lib/converter/doc.go
+++ b/lib/converter/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/converter/doc.go
+++ b/lib/converter/doc.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package converter implements adaptors for for conversion between API and Backend
+models.
+*/
+package converter

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+// PolicyConverter implements a set of functions used for converting between
+// API and backend representations of the Policy resource.
+type PolicyConverter struct{}
+
+// ConvertMetadataToKey converts a PolicyMetadata to a PolicyKey
+func (p PolicyConverter) ConvertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
+	pm := m.(api.PolicyMetadata)
+	k := model.PolicyKey{
+		Name: pm.Name,
+	}
+	return k, nil
+}
+
+// ConvertAPIToKVPair converts an API Policy structure to a KVPair containing a
+// backend Policy and PolicyKey.
+func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
+	ap := a.(api.Policy)
+	k, err := p.ConvertMetadataToKey(ap.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	d := model.KVPair{
+		Key: k,
+		Value: &model.Policy{
+			Order:         ap.Spec.Order,
+			InboundRules:  RulesAPIToBackend(ap.Spec.IngressRules),
+			OutboundRules: RulesAPIToBackend(ap.Spec.EgressRules),
+			Selector:      ap.Spec.Selector,
+			DoNotTrack:    ap.Spec.DoNotTrack,
+		},
+	}
+
+	return &d, nil
+}
+
+// ConvertKVPairToAPI converts a KVPair containing a backend Policy and PolicyKey
+// to an API Policy structure.
+func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
+	bp := d.Value.(*model.Policy)
+	bk := d.Key.(model.PolicyKey)
+
+	ap := api.NewPolicy()
+	ap.Metadata.Name = bk.Name
+	ap.Spec.Order = bp.Order
+	ap.Spec.IngressRules = RulesBackendToAPI(bp.InboundRules)
+	ap.Spec.EgressRules = RulesBackendToAPI(bp.OutboundRules)
+	ap.Spec.Selector = bp.Selector
+	ap.Spec.DoNotTrack = bp.DoNotTrack
+
+	return ap, nil
+}

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,22 +25,19 @@ import (
 type PolicyConverter struct{}
 
 // ConvertMetadataToKey converts a PolicyMetadata to a PolicyKey
-func (p PolicyConverter) ConvertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
+func (p PolicyConverter) ConvertMetadataToKey(m unversioned.ResourceMetadata) model.Key {
 	pm := m.(api.PolicyMetadata)
 	k := model.PolicyKey{
 		Name: pm.Name,
 	}
-	return k, nil
+	return k
 }
 
 // ConvertAPIToKVPair converts an API Policy structure to a KVPair containing a
 // backend Policy and PolicyKey.
-func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
+func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) *model.KVPair {
 	ap := a.(api.Policy)
-	k, err := p.ConvertMetadataToKey(ap.Metadata)
-	if err != nil {
-		return nil, err
-	}
+	k := p.ConvertMetadataToKey(ap.Metadata)
 
 	d := model.KVPair{
 		Key: k,
@@ -53,12 +50,12 @@ func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPa
 		},
 	}
 
-	return &d, nil
+	return &d
 }
 
 // ConvertKVPairToAPI converts a KVPair containing a backend Policy and PolicyKey
 // to an API Policy structure.
-func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
+func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) unversioned.Resource {
 	bp := d.Value.(*model.Policy)
 	bk := d.Key.(model.PolicyKey)
 
@@ -70,5 +67,5 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 	ap.Spec.Selector = bp.Selector
 	ap.Spec.DoNotTrack = bp.DoNotTrack
 
-	return ap, nil
+	return ap
 }

--- a/lib/converter/rule.go
+++ b/lib/converter/rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/converter/rule.go
+++ b/lib/converter/rule.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package converter
 
 import (
 	"github.com/projectcalico/libcalico-go/lib/api"
@@ -20,24 +20,30 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
-// ruleActionAPIToBackend converts the rule action field value from the API
-// value to the equivalent backend value.
-func ruleActionAPIToBackend(action string) string {
-	if action == "pass" {
-		return "next-tier"
+// RulesAPIToBackend converts an API Rule structure slice to a Backend Rule structure slice.
+func RulesAPIToBackend(ars []api.Rule) []model.Rule {
+	if ars == nil {
+		return []model.Rule{}
 	}
-	return action
+
+	brs := make([]model.Rule, len(ars))
+	for idx, ar := range ars {
+		brs[idx] = ruleAPIToBackend(ar)
+	}
+	return brs
 }
 
-// ruleActionBackendToAPI converts the rule action field value from the backend
-// value to the equivalent API value.
-func ruleActionBackendToAPI(action string) string {
-	if action == "" {
-		return "allow"
-	} else if action == "next-tier" {
-		return "pass"
+// RulesBackendToAPI converts a Backend Rule structure slice to an API Rule structure slice.
+func RulesBackendToAPI(brs []model.Rule) []api.Rule {
+	if brs == nil {
+		return nil
 	}
-	return action
+
+	ars := make([]api.Rule, len(brs))
+	for idx, br := range brs {
+		ars[idx] = ruleBackendToAPI(br)
+	}
+	return ars
 }
 
 // ruleAPIToBackend converts an API Rule structure to a Backend Rule structure.
@@ -138,28 +144,22 @@ func ruleBackendToAPI(br model.Rule) api.Rule {
 	}
 }
 
-// rulesAPIToBackend converts an API Rule structure slice to a Backend Rule structure slice.
-func rulesAPIToBackend(ars []api.Rule) []model.Rule {
-	if ars == nil {
-		return []model.Rule{}
+// ruleActionAPIToBackend converts the rule action field value from the API
+// value to the equivalent backend value.
+func ruleActionAPIToBackend(action string) string {
+	if action == "pass" {
+		return "next-tier"
 	}
-
-	brs := make([]model.Rule, len(ars))
-	for idx, ar := range ars {
-		brs[idx] = ruleAPIToBackend(ar)
-	}
-	return brs
+	return action
 }
 
-// rulesBackendToAPI converts a Backend Rule structure slice to an API Rule structure slice.
-func rulesBackendToAPI(brs []model.Rule) []api.Rule {
-	if brs == nil {
-		return nil
+// ruleActionBackendToAPI converts the rule action field value from the backend
+// value to the equivalent API value.
+func ruleActionBackendToAPI(action string) string {
+	if action == "" {
+		return "allow"
+	} else if action == "next-tier" {
+		return "pass"
 	}
-
-	ars := make([]api.Rule, len(brs))
-	for idx, br := range brs {
-		ars[idx] = ruleBackendToAPI(br)
-	}
-	return ars
+	return action
 }

--- a/lib/testutils/client.go
+++ b/lib/testutils/client.go
@@ -26,9 +26,10 @@ import (
 
 	"errors"
 	"fmt"
-	"golang.org/x/net/context"
 	"os/exec"
 	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // CreateNewIPPool takes a client.Client with a poolSubnet CIDR (in "192.168.1.0/24" format) with

--- a/lib/testutils/e2e_describe.go
+++ b/lib/testutils/e2e_describe.go
@@ -17,8 +17,6 @@ import (
 	"fmt"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
-	"github.com/projectcalico/libcalico-go/lib/backend/etcd"
-	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -47,7 +45,7 @@ func E2eDatastoreDescribe(description string, datastores DatastoreType, body fun
 				body(api.CalicoAPIConfig{
 					Spec: api.CalicoAPIConfigSpec{
 						DatastoreType: api.EtcdV2,
-						EtcdConfig: etcd.EtcdConfig{
+						EtcdConfig: api.EtcdConfig{
 							EtcdEndpoints: "http://127.0.0.1:2379",
 						},
 					},
@@ -61,7 +59,7 @@ func E2eDatastoreDescribe(description string, datastores DatastoreType, body fun
 				body(api.CalicoAPIConfig{
 					Spec: api.CalicoAPIConfigSpec{
 						DatastoreType: api.Kubernetes,
-						KubeConfig: k8s.KubeConfig{
+						KubeConfig: api.KubeConfig{
 							K8sAPIEndpoint: "http://localhost:8080",
 						},
 					},


### PR DESCRIPTION
## Description

This PR adds a new TPR type, the system-network-policy.

It allow the user to create SNP TPR resources in the kube-system namespace that Felix will interpret as system-wide Calico policy.

The format of the TPR Spec is identical to the  spec of the Calico Policy Resource.

## Notes

-  To avoid circular references it was necessary to move the etcd and kube config into the API - which I think is actually the correct place for it anyway.
-  Some of the profile->backend manipulation was moved out of client into it's own directory (converter)
-  There are UTs that test the SNP CRUD operations and Syncer notifications.
-  Whilst the CRUD code is implemented it is not exposed through the libcalico-go client API - policy resources can still only be queried for KDD.

## TODO
Would be nice to add some TPRs via kubectl and check that they are correctly interpreted.