### PR TITLE
Update client-go, glide

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,11 @@
-hash: 6462492e10b3d1760697e32f01cb0fd82c5fb6ceb3c5c12313e6ab73986fa20d
-updated: 2017-05-18T20:27:25.167957Z
+hash: a35ac70c3f24336298e49395f16d469f35bc7105e3d9df129c3ba948eb74132f
+updated: 2017-06-04T10:01:10.429693073-07:00
 imports:
 - name: github.com/coreos/etcd
-  version: 0afc51c762da68571ad0623ebf3d462f4c2ddf18
+  version: 17ae440991da3bdb2df4309936dd2074f66ec394
   subpackages:
   - client
   - pkg/pathutil
-  - pkg/srv
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
@@ -36,7 +35,7 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: e51c28f07047ad90caff03f6450908720d337e0c
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
@@ -45,7 +44,7 @@ imports:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/howeyc/gopass
@@ -55,7 +54,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: b6fde1625d631a48340817849a547164f395d9eb
+  version: 8bf4bbfc795e2c7c8a5ea47b707453ed019e2ad4
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -63,7 +62,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/onsi/ginkgo
-  version: 18c43bbb99ffd9dc8bd38904654693ce75e3e685
+  version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
   subpackages:
   - config
   - extensions/table
@@ -96,7 +95,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
@@ -112,37 +111,23 @@ imports:
   - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
-  - html
-  - html/atom
-  - html/charset
   - http2
   - http2/hpack
   - idna
   - lex/httplex
 - name: golang.org/x/sys
-  version: e62c3de784db939836898e5c19ffd41bece347da
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text
   version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
   subpackages:
   - cases
-  - encoding
-  - encoding/charmap
-  - encoding/htmlindex
-  - encoding/internal
-  - encoding/internal/identifier
-  - encoding/japanese
-  - encoding/korean
-  - encoding/simplifiedchinese
-  - encoding/traditionalchinese
-  - encoding/unicode
   - internal
   - internal/tag
-  - internal/utf8internal
   - language
   - runes
   - secure/bidirule
@@ -160,9 +145,9 @@ imports:
   subpackages:
   - patricia
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery
-  version: 98c470feb44de033f26efb4af98a19f804ffffdc
+  version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
   subpackages:
   - pkg/api/errors
   - pkg/api/meta
@@ -204,7 +189,7 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 117378eef311e1a8ae898ddbde22c4df522079f0
+  version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
   subpackages:
   - discovery
   - kubernetes
@@ -298,7 +283,7 @@ imports:
   - util/integer
 testImports:
 - name: github.com/onsi/gomega
-  version: 00acfa9d92a386415bd235ab069c52063f925998
+  version: 9b8c753e8dfb382618ba8fa19b4197b5dcb0434c
   subpackages:
   - format
   - internal/assertion

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
 - package: golang.org/x/text
   version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 - package: k8s.io/client-go
-  version: release-3.0
+  version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
   subpackages:
   - kubernetes
   - pkg/api


### PR DESCRIPTION
### Description

Updates client-go to a pin from master which fixes a bug with InClusterConfig present in v0.3.0.

Specifically, we want this fix: https://github.com/kubernetes/kubernetes/pull/44221/files

### Testing

Built a manual felix and calico/node and ensure that it functions properly when deployed as a DaemonSet on a GCE based cluster. #