### PR TITLE
Restart single watches

### DIFF
--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -304,16 +304,16 @@ func (syn *kubeSyncer) readFromKubernetesAPI() {
 	needsResync := true
 
 	watchEventContinue := func(event watch.Event, key string) bool {
-		if event.Object == nil {
+		if event.Type == watch.Error {
+			log.Warnf("Event requires resync: %+v", event)
+			needsResync = true
+			return true
+		} else if event.Object == nil {
 			log.Warnf("Need new %v watch: %+v", key, event)
 			w := openWatchers[key]
 			log.WithField("watcher", w).Debug("Closing old watcher.")
 			w.Stop()
 			delete(openWatchers, key)
-			return true
-		} else if event.Type == watch.Error {
-			log.Warnf("Event requires resync: %+v", event)
-			needsResync = true
 			return true
 		}
 		return false

--- a/lib/backend/k8s/syncer_test.go
+++ b/lib/backend/k8s/syncer_test.go
@@ -55,6 +55,8 @@ type testClient struct {
 	podC         chan watch.Event
 	state        map[model.Key]interface{}
 	stateMutex   sync.Mutex
+	listCalls    int
+	watchCalls   int
 }
 
 func (tc *testClient) OnStatusUpdated(status api.SyncStatus) {
@@ -84,6 +86,7 @@ func (tc *testClient) newWatch(name string, c chan watch.Event) *testWatch {
 		c:    c,
 	}
 	tc.openWatchers = append(tc.openWatchers, w)
+	tc.watchCalls++
 	return w
 }
 
@@ -123,37 +126,50 @@ func (tc *testClient) NodeWatch(opts metav1.ListOptions) (w watch.Interface, err
 	return
 }
 
+func (tc *testClient) countList() {
+	tc.stateMutex.Lock()
+	defer tc.stateMutex.Unlock()
+	tc.listCalls++
+}
+
 func (tc *testClient) NamespaceList(opts metav1.ListOptions) (list *k8sapi.NamespaceList, err error) {
+	tc.countList()
 	list = &k8sapi.NamespaceList{}
 	err = nil
 	return
 }
 
 func (tc *testClient) NetworkPolicyList() (list extensions.NetworkPolicyList, err error) {
+	tc.countList()
 	list = extensions.NetworkPolicyList{}
 	err = nil
 	return
 }
 
 func (tc *testClient) PodList(namespace string, opts metav1.ListOptions) (list *k8sapi.PodList, err error) {
+	tc.countList()
 	list = &k8sapi.PodList{}
 	err = nil
 	return
 }
 
 func (tc *testClient) GlobalConfigList(l model.GlobalConfigListOptions) ([]*model.KVPair, error) {
+	tc.countList()
 	return []*model.KVPair{}, nil
 }
 
 func (tc *testClient) HostConfigList(l model.HostConfigListOptions) ([]*model.KVPair, error) {
+	tc.countList()
 	return []*model.KVPair{}, nil
 }
 
 func (tc *testClient) IPPoolList(l model.IPPoolListOptions) ([]*model.KVPair, error) {
+	tc.countList()
 	return []*model.KVPair{}, nil
 }
 
 func (tc *testClient) NodeList(opts metav1.ListOptions) (list *k8sapi.NodeList, err error) {
+	tc.countList()
 	list = &k8sapi.NodeList{}
 	err = nil
 	return
@@ -163,6 +179,7 @@ func (tc *testClient) SystemNetworkPolicyWatch(opts metav1.ListOptions) (watch.I
 }
 
 func (tc *testClient) SystemNetworkPolicyList() (*thirdparty.SystemNetworkPolicyList, error) {
+	tc.countList()
 	return &thirdparty.SystemNetworkPolicyList{}, nil
 }
 
@@ -196,6 +213,34 @@ var _ = Describe("Test Syncer", func() {
 
 		AfterEach(func() {
 			syn.Stop()
+		})
+
+		It("should not resync when one watch times out", func() {
+			getNumListCalls := func() interface{} {
+				tc.stateMutex.Lock()
+				defer tc.stateMutex.Unlock()
+				log.WithField("listCalls", tc.listCalls).Info("")
+				return tc.listCalls
+			}
+			getNumWatchCalls := func() interface{} {
+				tc.stateMutex.Lock()
+				defer tc.stateMutex.Unlock()
+				log.WithField("watchCalls", tc.watchCalls).Info("")
+				return tc.watchCalls
+			}
+			// Initial resync makes 8 list calls and 7 watch calls.
+			const (
+				LIST_CALLS  = 8
+				WATCH_CALLS = 7
+			)
+			Eventually(getNumListCalls).Should(BeNumerically("==", LIST_CALLS))
+			Eventually(getNumWatchCalls).Should(BeNumerically("==", WATCH_CALLS))
+			// Simulate timeout of the pod watch.
+			tc.podC <- watch.Event{Object: nil}
+			// Expect a new watch call.
+			Eventually(getNumWatchCalls).Should(BeNumerically("==", WATCH_CALLS+1))
+			// But no new list calls.
+			Expect(getNumListCalls()).To(BeNumerically("==", LIST_CALLS))
 		})
 
 		It("should correctly handle pod being deleted in resync", func() {


### PR DESCRIPTION
@caseydavenport This is where I've got to - as a basis for discussion whether it is worth keeping at all.

There are some changes here that I think turned out not to be required, so could be reverted:
- getting an initial ResourceVersion for GlobalConfig
- the 'open' arg, when reading from a watch channel; I thought it might be different from (obj != nil), but it appears always to be the same

There are other things that would need adding or finishing, for a complete PR:
- the `eventNeedsNewWatch` calls all need changing so that they do as the code now does for (obj == nil), but set `needResync`, as the code used to do, if the event indicates an error
- I think it would be good to add a fallback to the old behavior (full resync), if we restart a watch and then the next read gives (obj == nil) again - to make sure that we can't get into a tight loop there
- testing

Finally one query, in case you happen to know this.  According to ListOptions doc, I think we should be setting `Watch: true` in order to get changes since the specified version.  But we're not, and we are still only getting the new changes that we want.  So not sure why exactly why that is working.