### PR TITLE
Add SNP to alpha domain

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientapi "k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
-	kapiv1 "k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -50,7 +49,8 @@ type KubeClient struct {
 	clientSet *kubernetes.Clientset
 
 	// Client for interacting with ThirdPartyResources.
-	tprClient *rest.RESTClient
+	tprClientV1      *rest.RESTClient
+	tprClientV1alpha *rest.RESTClient
 
 	disableNodePoll bool
 
@@ -112,20 +112,25 @@ func NewKubeClient(kc *capi.KubeConfig) (*KubeClient, error) {
 	}
 	log.Debugf("Created k8s clientSet: %+v", cs)
 
-	tprClient, err := buildTPRClient(config)
+	tprClientV1, err := buildTPRClientV1(*config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to build TPR client: %s", err)
+		return nil, fmt.Errorf("Failed to build V1 TPR client: %s", err)
+	}
+	tprClientV1alpha, err := buildTPRClientV1alpha(*config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to build V1alpha TPR client: %s", err)
 	}
 	kubeClient := &KubeClient{
-		clientSet:       cs,
-		tprClient:       tprClient,
-		disableNodePoll: kc.K8sDisableNodePoll,
+		clientSet:        cs,
+		tprClientV1:      tprClientV1,
+		tprClientV1alpha: tprClientV1alpha,
+		disableNodePoll:  kc.K8sDisableNodePoll,
 	}
 
 	// Create the Calico sub-clients.
-	kubeClient.ipPoolClient = resources.NewIPPools(cs, tprClient)
-	kubeClient.nodeClient = resources.NewNodeClient(cs, tprClient)
-	kubeClient.snpClient = resources.NewSystemNetworkPolicies(cs, tprClient)
+	kubeClient.ipPoolClient = resources.NewIPPools(cs, tprClientV1)
+	kubeClient.nodeClient = resources.NewNodeClient(cs, tprClientV1)
+	kubeClient.snpClient = resources.NewSystemNetworkPolicies(cs, tprClientV1alpha)
 
 	return kubeClient, nil
 }
@@ -242,10 +247,9 @@ func (c *KubeClient) ensureClusterType() (bool, error) {
 	return true, nil
 }
 
-// buildTPRClient builds a RESTClient configured to interact with Calico ThirdPartyResources
-func buildTPRClient(baseConfig *rest.Config) (*rest.RESTClient, error) {
+// buildTPRClientV1 builds a RESTClient configured to interact with Calico ThirdPartyResources
+func buildTPRClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 	// Generate config using the base config.
-	cfg := baseConfig
 	cfg.GroupVersion = &schema.GroupVersion{
 		Group:   "projectcalico.org",
 		Version: "v1",
@@ -254,7 +258,7 @@ func buildTPRClient(baseConfig *rest.Config) (*rest.RESTClient, error) {
 	cfg.ContentType = runtime.ContentTypeJSON
 	cfg.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: clientapi.Codecs}
 
-	cli, err := rest.RESTClientFor(cfg)
+	cli, err := rest.RESTClientFor(&cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -268,10 +272,37 @@ func buildTPRClient(baseConfig *rest.Config) (*rest.RESTClient, error) {
 				&thirdparty.GlobalConfigList{},
 				&thirdparty.IpPool{},
 				&thirdparty.IpPoolList{},
+			)
+			return nil
+		})
+	schemeBuilder.AddToScheme(clientapi.Scheme)
+
+	return cli, nil
+}
+
+// buildTPRClientV1alpha builds a RESTClient configured to interact with Calico ThirdPartyResources
+func buildTPRClientV1alpha(cfg rest.Config) (*rest.RESTClient, error) {
+	// Generate config using the base config.
+	cfg.GroupVersion = &schema.GroupVersion{
+		Group:   "alpha.projectcalico.org",
+		Version: "v1",
+	}
+	cfg.APIPath = "/apis"
+	cfg.ContentType = runtime.ContentTypeJSON
+	cfg.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: clientapi.Codecs}
+
+	cli, err := rest.RESTClientFor(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// We also need to register resources.
+	schemeBuilder := runtime.NewSchemeBuilder(
+		func(scheme *runtime.Scheme) error {
+			scheme.AddKnownTypes(
+				*cfg.GroupVersion,
 				&thirdparty.SystemNetworkPolicy{},
 				&thirdparty.SystemNetworkPolicyList{},
-				&kapiv1.ListOptions{},
-				&kapiv1.DeleteOptions{},
 			)
 			return nil
 		})
@@ -669,7 +700,7 @@ func (c *KubeClient) applyGlobalConfig(kvp *model.KVPair) (*model.KVPair, error)
 func (c *KubeClient) updateGlobalConfig(kvp *model.KVPair) (*model.KVPair, error) {
 	gcfg := c.converter.globalConfigToTPR(kvp)
 	res := thirdparty.GlobalConfig{}
-	req := c.tprClient.Put().
+	req := c.tprClientV1.Put().
 		Resource("globalconfigs").
 		Namespace("kube-system").
 		Body(&gcfg).
@@ -687,7 +718,7 @@ func (c *KubeClient) updateGlobalConfig(kvp *model.KVPair) (*model.KVPair, error
 func (c *KubeClient) createGlobalConfig(kvp *model.KVPair) (*model.KVPair, error) {
 	gcfg := c.converter.globalConfigToTPR(kvp)
 	res := thirdparty.GlobalConfig{}
-	req := c.tprClient.Post().
+	req := c.tprClientV1.Post().
 		Resource("globalconfigs").
 		Namespace("kube-system").
 		Body(&gcfg)
@@ -702,7 +733,7 @@ func (c *KubeClient) createGlobalConfig(kvp *model.KVPair) (*model.KVPair, error
 // getGlobalConfig gets a global config and returns an error if it doesn't exist.
 func (c *KubeClient) getGlobalConfig(k model.GlobalConfigKey) (*model.KVPair, error) {
 	cfg := thirdparty.GlobalConfig{}
-	err := c.tprClient.Get().
+	err := c.tprClientV1.Get().
 		Resource("globalconfigs").
 		Namespace("kube-system").
 		Name(strings.ToLower(k.Name)).
@@ -721,7 +752,7 @@ func (c *KubeClient) listGlobalConfig(l model.GlobalConfigListOptions) ([]*model
 	resourceVersion := ""
 
 	// Build the request.
-	req := c.tprClient.Get().Resource("globalconfigs").Namespace("kube-system")
+	req := c.tprClientV1.Get().Resource("globalconfigs").Namespace("kube-system")
 	if l.Name != "" {
 		req.Name(strings.ToLower(l.Name))
 	}
@@ -748,7 +779,7 @@ func (c *KubeClient) listGlobalConfig(l model.GlobalConfigListOptions) ([]*model
 
 // deleteGlobalConfig deletes the given global config.
 func (c *KubeClient) deleteGlobalConfig(k *model.KVPair) error {
-	result := c.tprClient.Delete().
+	result := c.tprClientV1.Delete().
 		Resource("globalconfigs").
 		Namespace("kube-system").
 		Name(strings.ToLower(k.Key.(model.GlobalConfigKey).Name)).

--- a/lib/backend/k8s/resources/systemnetworkpolicies.go
+++ b/lib/backend/k8s/resources/systemnetworkpolicies.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	SystemNetworkPolicyResourceName = "systemnetworkpolicies"
-	SystemNetworkPolicyTPRName      = "system-network-policy.projectcalico.org"
+	SystemNetworkPolicyTPRName      = "system-network-policy.alpha.projectcalico.org"
 	SystemNetworkPolicyNamePrefix   = "snp.projectcalico.org/"
 )
 

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -78,7 +78,7 @@ func (k *realKubeAPI) NetworkPolicyWatch(opts metav1.ListOptions) (watch watch.I
 
 func (k *realKubeAPI) GlobalConfigWatch(opts metav1.ListOptions) (watch watch.Interface, err error) {
 	globalConfigWatcher := cache.NewListWatchFromClient(
-		k.kc.tprClient,
+		k.kc.tprClientV1,
 		"globalconfigs",
 		"kube-system",
 		fields.Everything())
@@ -88,7 +88,7 @@ func (k *realKubeAPI) GlobalConfigWatch(opts metav1.ListOptions) (watch watch.In
 
 func (k *realKubeAPI) IPPoolWatch(opts metav1.ListOptions) (watch watch.Interface, err error) {
 	ipPoolWatcher := cache.NewListWatchFromClient(
-		k.kc.tprClient,
+		k.kc.tprClientV1,
 		"ippools",
 		"kube-system",
 		fields.Everything())
@@ -118,7 +118,7 @@ func (k *realKubeAPI) NetworkPolicyList() (list extensions.NetworkPolicyList, er
 
 func (k *realKubeAPI) SystemNetworkPolicyWatch(opts metav1.ListOptions) (watch.Interface, error) {
 	watcher := cache.NewListWatchFromClient(
-		k.kc.tprClient,
+		k.kc.tprClientV1alpha,
 		resources.SystemNetworkPolicyResourceName,
 		"kube-system",
 		fields.Everything())
@@ -128,7 +128,7 @@ func (k *realKubeAPI) SystemNetworkPolicyWatch(opts metav1.ListOptions) (watch.I
 func (k *realKubeAPI) SystemNetworkPolicyList() (*thirdparty.SystemNetworkPolicyList, error) {
 	// Perform the request.
 	tprs := &thirdparty.SystemNetworkPolicyList{}
-	err := k.kc.tprClient.Get().
+	err := k.kc.tprClientV1alpha.Get().
 		Resource(resources.SystemNetworkPolicyResourceName).
 		Namespace("kube-system").
 		Do().Into(tprs)
@@ -140,8 +140,7 @@ func (k *realKubeAPI) SystemNetworkPolicyList() (*thirdparty.SystemNetworkPolicy
 			return nil, err
 		}
 	}
-
-	return tprs, err
+	return tprs, nil
 }
 
 func (k *realKubeAPI) PodList(namespace string, opts metav1.ListOptions) (list *k8sapi.PodList, err error) {


### PR DESCRIPTION
Put the System Network Policy into the alpha.projectcalico.org domain to indicate an alpha resource.

