### PR TITLE
Fix panic caused by Node IP being passed through as (*net.IP)(nil).

### DIFF
--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -912,8 +912,13 @@ func (syn *kubeSyncer) parseNodeEvent(e watch.Event) (*model.KVPair, *model.KVPa
 
 	kvpHostIp := &model.KVPair{
 		Key:      model.HostIPKey{Hostname: node.Name},
-		Value:    kvp.Value.(*model.Node).BGPIPv4Addr,
 		Revision: kvp.Revision,
+	}
+	caliNode := kvp.Value.(*model.Node)
+	if caliNode.BGPIPv4Addr != nil {
+		// Only set the value if it's non nil.  We want to avoid setting Value to
+		// an interface containing a nil value instead of a nil interface.
+		kvpHostIp.Value = caliNode.BGPIPv4Addr
 	}
 
 	kvpIPIPAddr, err := getTunIp(node)

--- a/lib/net/ip.go
+++ b/lib/net/ip.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,4 +74,11 @@ func (i *IP) Network() *IPNet {
 		n.Mask = net.CIDRMask(net.IPv6len*8, net.IPv6len*8)
 	}
 	return n
+}
+
+func (i *IP) String() string {
+	if i == nil {
+		return "<nil>"
+	}
+	return i.IP.String()
 }


### PR DESCRIPTION
- Fix that our IP object couldn't be stringified if it was nil.
- Fix the node conversion to convert to a nil interface.
