### PR TITLE
[WiP] Add support for multiple CIDRS in the Net fields.

### DIFF
--- a/lib/api/rule.go
+++ b/lib/api/rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package api
 
 import (
-	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
@@ -84,7 +84,7 @@ type EntityRule struct {
 
 	// Net is an optional field that restricts the rule to only apply to traffic that
 	// originates from (or terminates at) IP addresses in the given subnet.
-	Net *net.IPNet `json:"net,omitempty" validate:"omitempty"`
+	Net model.IPNets `json:"net,omitempty" validate:"omitempty"`
 
 	// Selector is an optional field that contains a selector expression (see Policy for
 	// sample syntax).  Only traffic that originates from (terminates at) endpoints matching
@@ -116,7 +116,7 @@ type EntityRule struct {
 	NotTag string `json:"notTag,omitempty" validate:"omitempty,tag"`
 
 	// NotNet is the negated version of the Net field.
-	NotNet *net.IPNet `json:"notNet,omitempty" validate:"omitempty"`
+	NotNet model.IPNets `json:"notNet,omitempty" validate:"omitempty"`
 
 	// NotSelector is the negated version of the Selector field.  See Selector field for
 	// subtleties with negated selectors.

--- a/lib/converter/rule.go
+++ b/lib/converter/rule.go
@@ -17,7 +17,6 @@ package converter
 import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // RulesAPIToBackend converts an API Rule structure slice to a Backend Rule structure slice.
@@ -91,11 +90,15 @@ func ruleAPIToBackend(ar api.Rule) model.Rule {
 
 // normalizeIPNet converts an IPNet to a network by ensuring the IP address
 // is correctly masked.
-func normalizeIPNet(n *net.IPNet) *net.IPNet {
-	if n == nil {
-		return nil
+func normalizeIPNet(ns model.IPNets) model.IPNets {
+	var normal model.IPNets
+	for _, n := range ns {
+		if n == nil {
+			continue
+		}
+		normal = append(normal, n.Network())
 	}
-	return n.Network()
+	return normal
 }
 
 // ruleBackendToAPI convert a Backend Rule structure to an API Rule structure.

--- a/lib/testutils/createRule.go
+++ b/lib/testutils/createRule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
@@ -48,9 +49,9 @@ func CreateRule(ipv, icmpType, icmpCode int, proto, cidrStr, tag, selector, inAc
 
 	src := api.EntityRule{
 		Tag: tag,
-		Net: &cnet.IPNet{
+		Net: model.IPNets{&cnet.IPNet{
 			*cidr,
-		},
+		}},
 		Selector: selector,
 	}
 

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -17,6 +17,7 @@ package testutils
 import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
@@ -46,7 +47,7 @@ var InRule1 = api.Rule{
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
 		Tag:      "tag1",
-		Net:      &cidr1,
+		Net:      model.IPNets{&cidr1},
 		Selector: "label1 == 'value1'",
 	},
 }
@@ -58,7 +59,7 @@ var InRule2 = api.Rule{
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
 		Tag:      "tag2",
-		Net:      &cidrv61,
+		Net:      model.IPNets{&cidrv61},
 		Selector: "has(label2)",
 	},
 }
@@ -70,7 +71,7 @@ var EgressRule1 = api.Rule{
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
 		Tag:      "tag3",
-		Net:      &cidr2,
+		Net:      model.IPNets{&cidr2},
 		Selector: "all()",
 	},
 }
@@ -82,7 +83,7 @@ var EgressRule2 = api.Rule{
 	ICMP:      &icmp1,
 	Source: api.EntityRule{
 		Tag:      "tag4",
-		Net:      &cidrv62,
+		Net:      model.IPNets{&cidrv62},
 		Selector: "label2 == '1234'",
 	},
 }

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -482,10 +482,10 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Source: api.EntityRule{
-					Net: &netv4_3,
+					Net: model.IPNets{&netv4_3},
 				},
 				Destination: api.EntityRule{
-					Net: &netv6_3,
+					Net: model.IPNets{&netv6_3},
 				},
 			}, false),
 		Entry("should reject rule mixed IPv6 (src) and IPv4 (dest)",
@@ -493,10 +493,10 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Source: api.EntityRule{
-					Net: &netv6_2,
+					Net: model.IPNets{&netv6_2},
 				},
 				Destination: api.EntityRule{
-					Net: &netv4_2,
+					Net: model.IPNets{&netv4_2},
 				},
 			}, false),
 		Entry("should reject rule mixed IPv6 version and IPv4 Net",
@@ -505,10 +505,10 @@ func init() {
 				Protocol:  protocolFromString("tcp"),
 				IPVersion: &V6,
 				Source: api.EntityRule{
-					Net: &netv4_4,
+					Net: model.IPNets{&netv4_4},
 				},
 				Destination: api.EntityRule{
-					Net: &netv4_2,
+					Net: model.IPNets{&netv4_2},
 				},
 			}, false),
 		Entry("should reject rule mixed IPVersion and Source Net IP version",
@@ -517,7 +517,7 @@ func init() {
 				Protocol:  protocolFromString("tcp"),
 				IPVersion: &V6,
 				Source: api.EntityRule{
-					Net: &netv4_1,
+					Net: model.IPNets{&netv4_1},
 				},
 			}, false),
 		Entry("should reject rule mixed IPVersion and Dest Net IP version",
@@ -526,7 +526,7 @@ func init() {
 				Protocol:  protocolFromString("tcp"),
 				IPVersion: &V4,
 				Destination: api.EntityRule{
-					Net: &netv6_1,
+					Net: model.IPNets{&netv6_1},
 				},
 			}, false),
 


### PR DESCRIPTION
@robbrockbank what do you think to this approach to adding multiple CIDRs into rules?  The good is that it's back-compatible; the bad is that the field is called `Net` but it can now be a string or a list.

