### PR TITLE
Add new NetworkSet datatype.

### DIFF
--- a/lib/api/networkset.go
+++ b/lib/api/networkset.go
@@ -54,7 +54,7 @@ type NetworkSetSpec struct {
 func NewNetworkSet() *NetworkSet {
 	return &NetworkSet{
 		TypeMetadata: unversioned.TypeMetadata{
-			Kind:       "NetworkSet",
+			Kind:       "networkSet",
 			APIVersion: unversioned.VersionCurrent,
 		},
 	}

--- a/lib/api/networkset.go
+++ b/lib/api/networkset.go
@@ -46,7 +46,7 @@ type NetworkSetMetadata struct {
 // NetworkSetSpec contains the specification for a NetworkSet resource.
 type NetworkSetSpec struct {
 	// The list of IP networks that belong to this set.
-	Nets []net.IPNet `json:"expectedIPs,omitempty" validate:"omitempty"`
+	Nets []net.IPNet `json:"nets,omitempty" validate:"omitempty"`
 }
 
 // NewNetworkSet creates a new (zeroed) NetworkSet struct with the TypeMetadata initialised to the current

--- a/lib/api/networkset.go
+++ b/lib/api/networkset.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// NetworkSet contains a set of arbitrary IP sub-networks/CIDRs that share labels to
+// allow rules to refer to them via selectors.  The labels of NetworkSets are in the same
+// "namespace" as those for endpoints.  NetworkSets are useful to refer to groups
+// of "external" non-Calico workloads/hosts.
+type NetworkSet struct {
+	unversioned.TypeMetadata
+	Metadata NetworkSetMetadata `json:"metadata,omitempty"`
+	Spec     NetworkSetSpec     `json:"spec,omitempty"`
+}
+
+// NetworkSetMetadata contains the Metadata for a NetworkSet resource.
+type NetworkSetMetadata struct {
+	unversioned.ObjectMetadata
+
+	// The name of the endpoint.
+	Name string `json:"name,omitempty" validate:"omitempty,namespacedname"`
+
+	// The labels applied to the group.  It is expected that many endpoints and CIDR groups
+	// share the same labels. For example, they could be used to label all “production”
+	// workloads with “deployment=prod” so that security policy can be applied to production
+	// workloads.
+	Labels map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
+}
+
+// NetworkSetSpec contains the specification for a NetworkSet resource.
+type NetworkSetSpec struct {
+	// The list of IP networks that belong to this set.
+	Nets []net.IPNet `json:"expectedIPs,omitempty" validate:"omitempty"`
+}
+
+// NewNetworkSet creates a new (zeroed) NetworkSet struct with the TypeMetadata initialised to the current
+// version.
+func NewNetworkSet() *NetworkSet {
+	return &NetworkSet{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "NetworkSet",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
+}
+
+// NetworkSetList contains a list of NetworkSet resources.  List types are returned from List()
+// enumerations in the client interface.
+type NetworkSetList struct {
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
+	Items    []NetworkSet             `json:"items" validate:"dive"`
+}
+
+// NewNetworkSet creates a new (zeroed) NetworkSetList struct with the TypeMetadata initialised to the current
+// version.
+func NewNetworkSetList() *NetworkSetList {
+	return &NetworkSetList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "NetworkSetList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
+}

--- a/lib/backend/model/networkset.go
+++ b/lib/backend/model/networkset.go
@@ -88,7 +88,6 @@ func (options NetworkSetListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type NetworkSet struct {
-	IPv4Nets []net.IPNet       `json:"ipv4_nets,omitempty" validate:"omitempty,dive,cidrv4"`
-	IPv6Nets []net.IPNet       `json:"ipv6_nets,omitempty" validate:"omitempty,dive,cidrv6"`
-	Labels   map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
+	Nets   []net.IPNet       `json:"nets,omitempty" validate:"omitempty,dive,cidr"`
+	Labels map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
 }

--- a/lib/backend/model/networkset.go
+++ b/lib/backend/model/networkset.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+
+	"regexp"
+
+	"reflect"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+var (
+	matchNetworkSet = regexp.MustCompile("^/?calico/v1/netset/([^/]+)$")
+	typeNetworkSet  = reflect.TypeOf(NetworkSet{})
+)
+
+type NetworkSetKey struct {
+	Name string `json:"-" validate:"required,namespacedName"`
+}
+
+func (key NetworkSetKey) defaultPath() (string, error) {
+	if key.Name == "" {
+		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
+	}
+	e := fmt.Sprintf("/calico/v1/netset/%s", escapeName(key.Name))
+	return e, nil
+}
+
+func (key NetworkSetKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
+}
+
+func (key NetworkSetKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
+func (key NetworkSetKey) valueType() reflect.Type {
+	return typeNetworkSet
+}
+
+func (key NetworkSetKey) String() string {
+	return fmt.Sprintf("NetworkSet(name=%s)", key.Name)
+}
+
+type NetworkSetListOptions struct {
+	Name string
+}
+
+func (options NetworkSetListOptions) defaultPathRoot() string {
+	k := "/calico/v1/netset"
+	if options.Name == "" {
+		return k
+	}
+	k = k + fmt.Sprintf("/%s", escapeName(options.Name))
+	return k
+}
+
+func (options NetworkSetListOptions) KeyFromDefaultPath(path string) Key {
+	log.Debugf("Get NetworkSet key from %s", path)
+	r := matchNetworkSet.FindAllStringSubmatch(path, -1)
+	if len(r) != 1 {
+		log.Debugf("Didn't match regex")
+		return nil
+	}
+	name := unescapeName(r[0][1])
+	if options.Name != "" && name != options.Name {
+		log.Debugf("Didn't match name %s != %s", options.Name, name)
+		return nil
+	}
+	return NetworkSetKey{Name: name}
+}
+
+type NetworkSet struct {
+	IPv4Nets []net.IPNet       `json:"ipv4_nets,omitempty" validate:"omitempty,dive,cidrv4"`
+	IPv6Nets []net.IPNet       `json:"ipv6_nets,omitempty" validate:"omitempty,dive,cidrv6"`
+	Labels   map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
+}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,6 +88,11 @@ func (c *Client) Profiles() ProfileInterface {
 // HostEndpoints returns an interface for managing host endpoint resources.
 func (c *Client) HostEndpoints() HostEndpointInterface {
 	return newHostEndpoints(c)
+}
+
+// NetworkSets returns an interface for managing host endpoint resources.
+func (c *Client) NetworkSets() NetworkSetInterface {
+	return newNetworkSets(c)
 }
 
 // WorkloadEndpoints returns an interface for managing workload endpoint resources.

--- a/lib/client/networkset.go
+++ b/lib/client/networkset.go
@@ -128,22 +128,11 @@ func (h *NetworkSets) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair,
 		return nil, err
 	}
 
-	var ipv4Nets []net.IPNet
-	var ipv6Nets []net.IPNet
-	for _, n := range ah.Spec.Nets {
-		if n.IP.To4() == nil {
-			ipv6Nets = append(ipv6Nets, n)
-		} else {
-			ipv4Nets = append(ipv4Nets, n)
-		}
-	}
-
 	d := model.KVPair{
 		Key: k,
 		Value: &model.NetworkSet{
-			Labels:   ah.Metadata.Labels,
-			IPv4Nets: ipv4Nets,
-			IPv6Nets: ipv6Nets,
+			Labels: ah.Metadata.Labels,
+			Nets:   ah.Spec.Nets,
 		},
 	}
 
@@ -154,17 +143,13 @@ func (h *NetworkSets) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair,
 // to an API NetworkSet structure.
 // This is part of the conversionHelper interface.
 func (h *NetworkSets) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	bh := d.Value.(*model.NetworkSet)
+	bn := d.Value.(*model.NetworkSet)
 	bk := d.Key.(model.NetworkSetKey)
-
-	nets := make([]net.IPNet, 0, len(bh.IPv4Nets)+len(bh.IPv6Nets))
-	nets = append(nets, bh.IPv4Nets...)
-	nets = append(nets, bh.IPv6Nets...)
 
 	ah := api.NewNetworkSet()
 	ah.Metadata.Name = bk.Name
-	ah.Metadata.Labels = bh.Labels
-	ah.Spec.Nets = nets
+	ah.Metadata.Labels = bn.Labels
+	ah.Spec.Nets = bn.Nets
 
 	return ah, nil
 }

--- a/lib/client/networkset.go
+++ b/lib/client/networkset.go
@@ -18,7 +18,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // NetworkSetInterface has methods to work with host endpoint resources.

--- a/lib/client/networkset.go
+++ b/lib/client/networkset.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// NetworkSetInterface has methods to work with host endpoint resources.
+type NetworkSetInterface interface {
+
+	// List enumerates host endpoint resources matching the supplied metadata and
+	// wildcarding missing identifiers.
+	List(api.NetworkSetMetadata) (*api.NetworkSetList, error)
+
+	// Get returns the host endpoint resource matching the supplied metadata.  The metadata
+	// should contain all identifiers to uniquely identify a single resource.  If the
+	// resource does not exist, a errors.ErrorResourceNotFound error is returned.
+	Get(api.NetworkSetMetadata) (*api.NetworkSet, error)
+
+	// Create will create a new host endpoint resource.  If the resource already exists,
+	// a errors.ErrorResourceAlreadyExists error is returned.
+	Create(*api.NetworkSet) (*api.NetworkSet, error)
+
+	// Update will update an existing host endpoint resource.  If the resource does not exist,
+	// a errors.ErrorResourceDoesNotExist error is returned.
+	Update(*api.NetworkSet) (*api.NetworkSet, error)
+
+	// Apply with update an existing host endpoint resource, or create a new one if it does
+	// not exist.
+	Apply(*api.NetworkSet) (*api.NetworkSet, error)
+
+	// Delete will delete a host endpoint resource.  The metadata should contain all identifiers
+	// to uniquely identify a single resource.  If the resource does not exist, a
+	// errors.ErrorResourceDoesNotExist error is returned.
+	Delete(api.NetworkSetMetadata) error
+}
+
+// NetworkSets implements NetworkSetInterface
+type NetworkSets struct {
+	c *Client
+}
+
+// newNetworkSets returns a NetworkSetInterface bound to the supplied client.
+func newNetworkSets(c *Client) NetworkSetInterface {
+	return &NetworkSets{c}
+}
+
+// Create creates a new host endpoint.
+func (h *NetworkSets) Create(a *api.NetworkSet) (*api.NetworkSet, error) {
+	return a, h.c.create(*a, h)
+}
+
+// Update updates an existing host endpoint.
+func (h *NetworkSets) Update(a *api.NetworkSet) (*api.NetworkSet, error) {
+	return a, h.c.update(*a, h)
+}
+
+// Apply updates a host endpoint if it exists, or creates a new host endpoint if it does not exist.
+func (h *NetworkSets) Apply(a *api.NetworkSet) (*api.NetworkSet, error) {
+	return a, h.c.apply(*a, h)
+}
+
+// Delete deletes an existing host endpoint.
+func (h *NetworkSets) Delete(metadata api.NetworkSetMetadata) error {
+	return h.c.delete(metadata, h)
+}
+
+// Get returns information about a particular host endpoint.
+func (h *NetworkSets) Get(metadata api.NetworkSetMetadata) (*api.NetworkSet, error) {
+	if a, err := h.c.get(metadata, h); err != nil {
+		return nil, err
+	} else {
+		return a.(*api.NetworkSet), nil
+	}
+}
+
+// List takes a Metadata, and returns a NetworkSetList that contains the list of host endpoints
+// that match the Metadata (wildcarding missing fields).
+func (h *NetworkSets) List(metadata api.NetworkSetMetadata) (*api.NetworkSetList, error) {
+	l := api.NewNetworkSetList()
+	err := h.c.list(metadata, h, l)
+	return l, err
+}
+
+// convertMetadataToListInterface converts a NetworkSetMetadata to a NetworkSetListOptions.
+// This is part of the conversionHelper interface.
+func (h *NetworkSets) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
+	hm := m.(api.NetworkSetMetadata)
+	l := model.NetworkSetListOptions{
+		Name: hm.Name,
+	}
+	return l, nil
+}
+
+// convertMetadataToKey converts a NetworkSetMetadata to a NetworkSetKey
+// This is part of the conversionHelper interface.
+func (h *NetworkSets) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
+	hm := m.(api.NetworkSetMetadata)
+	k := model.NetworkSetKey{
+		Name: hm.Name,
+	}
+	return k, nil
+}
+
+// convertAPIToKVPair converts an API NetworkSet structure to a KVPair containing a
+// backend NetworkSet and NetworkSetKey.
+// This is part of the conversionHelper interface.
+func (h *NetworkSets) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
+	ah := a.(api.NetworkSet)
+	k, err := h.convertMetadataToKey(ah.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	var ipv4Nets []net.IPNet
+	var ipv6Nets []net.IPNet
+	for _, n := range ah.Spec.Nets {
+		if n.IP.To4() == nil {
+			ipv6Nets = append(ipv6Nets, n)
+		} else {
+			ipv4Nets = append(ipv4Nets, n)
+		}
+	}
+
+	d := model.KVPair{
+		Key: k,
+		Value: &model.NetworkSet{
+			Labels:   ah.Metadata.Labels,
+			IPv4Nets: ipv4Nets,
+			IPv6Nets: ipv6Nets,
+		},
+	}
+
+	return &d, nil
+}
+
+// convertKVPairToAPI converts a KVPair containing a backend NetworkSet and NetworkSetKey
+// to an API NetworkSet structure.
+// This is part of the conversionHelper interface.
+func (h *NetworkSets) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
+	bh := d.Value.(*model.NetworkSet)
+	bk := d.Key.(model.NetworkSetKey)
+
+	nets := make([]net.IPNet, 0, len(bh.IPv4Nets)+len(bh.IPv6Nets))
+	nets = append(nets, bh.IPv4Nets...)
+	nets = append(nets, bh.IPv6Nets...)
+
+	ah := api.NewNetworkSet()
+	ah.Metadata.Name = bk.Name
+	ah.Metadata.Labels = bh.Labels
+	ah.Spec.Nets = nets
+
+	return ah, nil
+}

--- a/lib/client/networkset_e2e_test.go
+++ b/lib/client/networkset_e2e_test.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test cases (NetworkSet object e2e):
+// Test 1: Pass two fully populated NetworkSetSpecs and expect the series of operations to succeed.
+// Test 2: Pass one partially populated NetworkSetSpec and another fully populated NetworkSetSpec and expect the series of operations to succeed.
+// Test 3: Pass one fully populated NetworkSetSpec and another empty NetworkSetSpec and expect the series of operations to succeed.
+// Test 4: Pass two fully populated NetworkSetSpecs with two NetworkSetMetadata (one IPv4 and another IPv6) and expect the series of operations to succeed.
+
+// Series of operations each test goes through:
+// Update meta1 - check for failure (because it doesn't exist).
+// Create meta1 with spec1.
+// Apply meta2 with spec2.
+// Get meta1 and meta2, compare spec1 and spec2.
+// Update meta1 with spec2.
+// Get meta1 compare spec2.
+// List (empty Meta) ... Get meta1 and meta2.
+// List (using Meta1) ... Get meta1.
+// Delete meta1.
+// Get meta1 ... fail.
+// Delete meta2.
+// List (empty Meta) ... Get no entries (should not error).
+
+package client_test
+
+import (
+	"errors"
+	"log"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("NetworkSet tests", testutils.DatastoreEtcdV2, func(config api.CalicoAPIConfig) {
+
+	DescribeTable("NetworkSet e2e tests",
+		func(meta1, meta2 api.NetworkSetMetadata, spec1, spec2 api.NetworkSetSpec) {
+			// Create a new client.
+			c := testutils.CreateCleanClient(config)
+			By("Updating the NetworkSet before it is created")
+			_, outError := c.NetworkSets().Update(&api.NetworkSet{Metadata: meta1, Spec: spec1})
+
+			// Should return an error.
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: NetworkSet(name=netset1)").Error()))
+
+			By("Create, Apply, Get and compare")
+
+			// Create a NetworkSet with meta1 and spec1.
+			_, outError = c.NetworkSets().Create(&api.NetworkSet{Metadata: meta1, Spec: spec1})
+			Expect(outError).NotTo(HaveOccurred())
+
+			// Apply a NetworkSet with meta2 and spec2.
+			_, outError = c.NetworkSets().Apply(&api.NetworkSet{Metadata: meta2, Spec: spec2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			// Get NetworkSet with meta1.
+			outNetworkSet1, outError1 := c.NetworkSets().Get(meta1)
+			log.Println("Out NetworkSet object: ", outNetworkSet1)
+
+			// Get NetworkSet with meta2.
+			outNetworkSet2, outError2 := c.NetworkSets().Get(meta2)
+			log.Println("Out NetworkSet object: ", outNetworkSet2)
+
+			// Should match spec1 & outNetworkSet1 and outNetworkSet2 & spec2 and errors to be nil.
+			Expect(outError1).NotTo(HaveOccurred())
+			Expect(outError2).NotTo(HaveOccurred())
+			Expect(outNetworkSet1.Spec).To(Equal(spec1))
+			Expect(outNetworkSet2.Spec).To(Equal(spec2))
+
+			By("Update, Get and compare")
+
+			// Update meta1 NetworkSet with spec2.
+			_, outError = c.NetworkSets().Update(&api.NetworkSet{Metadata: meta1, Spec: spec2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			// Get NetworkSet with meta1.
+			outNetworkSet1, outError1 = c.NetworkSets().Get(meta1)
+
+			// Assert the Spec for NetworkSet with meta1 matches spec2 and no error.
+			Expect(outError1).NotTo(HaveOccurred())
+			Expect(outNetworkSet1.Spec).To(Equal(spec2))
+
+			By("List all the NetworkSets and compare")
+
+			// Get a list of NetworkSets.
+			NetworkSetList, outError := c.NetworkSets().List(api.NetworkSetMetadata{})
+			Expect(outError).NotTo(HaveOccurred())
+
+			log.Println("Get NetworkSet list returns: ", NetworkSetList.Items)
+			metas := []api.NetworkSetMetadata{meta1, meta2}
+			expectedNetworkSets := []api.NetworkSet{}
+			// Go through meta list and append them to expectedNetworkSets.
+			for _, v := range metas {
+				p, outError := c.NetworkSets().Get(v)
+				Expect(outError).NotTo(HaveOccurred())
+				expectedNetworkSets = append(expectedNetworkSets, *p)
+			}
+
+			// Assert the returned NetworkSetList is has the meta1 and meta2 NetworkSets.
+			Expect(NetworkSetList.Items).To(Equal(expectedNetworkSets))
+
+			By("List a specific NetworkSet and compare")
+
+			// Get a NetworkSet list with meta1.
+			NetworkSetList, outError = c.NetworkSets().List(meta1)
+			Expect(outError).NotTo(HaveOccurred())
+			log.Println("Get NetworkSet list returns: ", NetworkSetList.Items)
+
+			// Get a NetworkSet with meta1.
+			outNetworkSet1, outError1 = c.NetworkSets().Get(meta1)
+
+			// Assert they are equal and no errors.
+			Expect(outError1).NotTo(HaveOccurred())
+			Expect(NetworkSetList.Items[0].Spec).To(Equal(outNetworkSet1.Spec))
+
+			By("Delete, Get and assert error")
+
+			// Delete a NetworkSet with meta1.
+			outError1 = c.NetworkSets().Delete(meta1)
+			Expect(outError1).NotTo(HaveOccurred())
+
+			// Get a NetworkSet with meta1.
+			_, outError = c.NetworkSets().Get(meta1)
+
+			// Expect an error since the NetworkSet was deleted.
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: NetworkSet(name=netset1)").Error()))
+
+			// Delete the second NetworkSet with meta2.
+			outError1 = c.NetworkSets().Delete(meta2)
+			Expect(outError1).NotTo(HaveOccurred())
+
+			By("Delete all the NetworkSets, Get NetworkSet list and expect empty NetworkSet list")
+
+			// Both NetworkSets are deleted in the calls above.
+			// Get the list of all the NetworkSets.
+			NetworkSetList, outError = c.NetworkSets().List(api.NetworkSetMetadata{})
+			Expect(outError).NotTo(HaveOccurred())
+			log.Println("Get NetworkSet list returns: ", NetworkSetList.Items)
+
+			// Create an empty NetworkSet list.
+			// Note: you can't use make([]api.NetworkSet, 0) because it creates an empty underlying struct,
+			// whereas new([]api.NetworkSet) just returns a pointer without creating an empty struct.
+			emptyNetworkSetList := new([]api.NetworkSet)
+
+			// Expect returned NetworkSetList to contain empty NetworkSetList.
+			Expect(NetworkSetList.Items).To(Equal(*emptyNetworkSetList))
+
+		},
+
+		// Test 1: Pass two fully populated NetworkSetSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated NetworkSetSpecs",
+			api.NetworkSetMetadata{
+				Name: "netset1",
+				Labels: map[string]string{
+					"app":  "app-abc",
+					"prod": "no",
+				}},
+			api.NetworkSetMetadata{
+				Name: "netset1/with_foo",
+				Labels: map[string]string{
+					"app":  "app-xyz",
+					"prod": "yes",
+				}},
+			api.NetworkSetSpec{
+				Nets: []cnet.IPNet{testutils.MustParseNetwork("10.0.0.0/16"), testutils.MustParseNetwork("20.0.0.0/16")},
+			},
+			api.NetworkSetSpec{
+				Nets: []cnet.IPNet{testutils.MustParseNetwork("192.168.0.0/16"), testutils.MustParseNetwork("192.168.1.1/32")},
+			}),
+
+		// Test 2: Pass one partially populated NetworkSetSpec and another fully populated NetworkSetSpec and expect the series of operations to succeed.
+		Entry("One partially populated NetworkSetSpec and another fully populated NetworkSetSpec",
+			api.NetworkSetMetadata{
+				Name: "netset1",
+				Labels: map[string]string{
+					"app":  "app-abc",
+					"prod": "no",
+				}},
+			api.NetworkSetMetadata{
+				Name: "netset1/with.foo",
+				Labels: map[string]string{
+					"app":  "app-xyz",
+					"prod": "yes",
+				}},
+			api.NetworkSetSpec{},
+			api.NetworkSetSpec{
+				Nets: []cnet.IPNet{testutils.MustParseNetwork("192.168.0.0/16"), testutils.MustParseNetwork("192.168.1.1/32")},
+			}),
+
+		// Test 3: Pass one fully populated NetworkSetSpec and another empty NetworkSetSpec and expect the series of operations to succeed.
+		Entry("One fully populated NetworkSetSpec and another (almost) empty NetworkSetSpec",
+			api.NetworkSetMetadata{
+				Name: "netset1",
+				Labels: map[string]string{
+					"app":  "app-abc",
+					"prod": "no",
+				}},
+			api.NetworkSetMetadata{
+				Name: "netset1/with.foo/and.bar",
+				Labels: map[string]string{
+					"app":  "app-xyz",
+					"prod": "yes",
+				}},
+			api.NetworkSetSpec{
+				Nets: []cnet.IPNet{testutils.MustParseNetwork("10.0.0.0/16"), testutils.MustParseNetwork("20.0.0.0/16")},
+			},
+			api.NetworkSetSpec{}),
+
+		// Test 4: Pass two fully populated NetworkSetSpecs with two NetworkSetMetadata (one IPv4 and another IPv6) and expect the series of operations to succeed.
+		Entry("Two fully populated NetworkSetSpecs with two NetworkSetMetadata (one IPv4 and another IPv6)",
+			api.NetworkSetMetadata{
+				Name: "netset1",
+				Labels: map[string]string{
+					"app":  "app-abc",
+					"prod": "no",
+				}},
+			api.NetworkSetMetadata{
+				Name: "netset2",
+				Labels: map[string]string{
+					"app":  "app-xyz",
+					"prod": "yes",
+				}},
+			api.NetworkSetSpec{
+				Nets: []cnet.IPNet{testutils.MustParseNetwork("10.0.0.0/16"), testutils.MustParseNetwork("192.168.1.1/32")},
+			},
+			api.NetworkSetSpec{
+				Nets: []cnet.IPNet{testutils.MustParseNetwork("fe80::00/96"), testutils.MustParseNetwork("fe80::33/128")},
+			}),
+	)
+
+})


### PR DESCRIPTION
## Description
Add a "Network set" datatype to front-end and back-end models.  A network set is a labelled set of CIDRs, with the intention being that Felix would be updated to add the CIDRs from matching network sets into the IP sets that it builds and puts int he dataplane.

Why "Network set"?  We seem to fairly consistently use the work "net" for CIDRs in the datamodel and this is a set of networks.  (My first thought was "CIDR group" or similar but that'd be inconsistent.)

## Todos
- [x] Agree datamodel
- [x] Tests
- [x] [Resource documentation](https://github.com/projectcalico/calico/pull/862)
- [ ] Verify impact on RBAC with @shatrugna 
- [ ] Implement support in Felix

