### PR TITLE
Indicate config file path when the file is malformed

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -152,7 +152,12 @@ func LoadClientConfig(filename string) (*api.CalicoAPIConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		return LoadClientConfigFromBytes(b)
+
+		c, err := LoadClientConfigFromBytes(b)
+		if err != nil {
+			return nil, fmt.Errorf("syntax error in %s: %s", filename, err)
+		}
+		return c, nil
 	} else {
 		return LoadClientConfigFromEnvironment()
 	}


### PR DESCRIPTION
Amend error string with the config file path:
- Bug fix: https://github.com/projectcalico/calicoctl/issues/1635
- ran ut's - failures look unrelated to this PR
- ran a range of manual tests, including w & w/o calicoctl.cfg, w & w/o syntax err in calicoctl.cfg

## Todos
- [X] Tests
