### PR TITLE
Align BGP Peer model with other per-host and global config types

### DIFF
--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -747,7 +747,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 	}()
 
 	It("should not error on unsupported List() calls", func() {
-		objs, err := c.List(model.BGPPeerListOptions{})
+		objs, err := c.List(model.NodeBGPPeerListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(objs)).To(Equal(0))
 	})

--- a/lib/client/bgppeer.go
+++ b/lib/client/bgppeer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
+	"github.com/projectcalico/libcalico-go/lib/scope"
 )
 
 // BGPPeerInterface has methods to work with BGPPeer resources.
@@ -32,12 +34,13 @@ type BGPPeerInterface interface {
 
 // bgpPeers implements BGPPeerInterface
 type bgpPeers struct {
+	converter.BGPPeerConverter
 	c *Client
 }
 
 // newBGPPeers returns a new BGPPeerInterface bound to the supplied client.
 func newBGPPeers(c *Client) BGPPeerInterface {
-	return &bgpPeers{c}
+	return &bgpPeers{c: c}
 }
 
 // Create creates a new BGP peer.
@@ -73,67 +76,62 @@ func (h *bgpPeers) Get(metadata api.BGPPeerMetadata) (*api.BGPPeer, error) {
 // that match the Metadata (wildcarding missing fields).
 func (h *bgpPeers) List(metadata api.BGPPeerMetadata) (*api.BGPPeerList, error) {
 	l := api.NewBGPPeerList()
-	err := h.c.list(metadata, h, l)
-	return l, err
+
+	// Global and host peers are listed separately.  Work out which we need
+	// to list.
+	listGlobal := metadata.Scope == scope.Global || (metadata.Scope == scope.Undefined && metadata.Node == "")
+	listNode := metadata.Scope == scope.Node || metadata.Scope == scope.Undefined
+
+	// Tweak the scope of the Metadata so that we are performing a list within
+	// a specific scope.
+	if listGlobal {
+		metadata.Scope = scope.Global
+		if err := h.c.list(metadata, h, l); err != nil {
+			return nil, err
+		}
+	}
+	if listNode {
+		metadata.Scope = scope.Node
+		if err := h.c.list(metadata, h, l); err != nil {
+			return nil, err
+		}
+	}
+
+	return l, nil
 }
 
 // convertMetadataToListInterface converts a BGPPeerMetadata to a BGPPeerListOptions.
 // This is part of the conversionHelper interface.
 func (h *bgpPeers) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	pm := m.(api.BGPPeerMetadata)
-	l := model.BGPPeerListOptions{
-		Scope:    pm.Scope,
-		PeerIP:   pm.PeerIP,
-		Hostname: pm.Node,
+	if pm.Scope == scope.Global {
+		return model.GlobalBGPPeerListOptions{
+			PeerIP: pm.PeerIP,
+		}, nil
+	} else {
+		return model.NodeBGPPeerListOptions{
+			PeerIP:   pm.PeerIP,
+			Hostname: pm.Node,
+		}, nil
 	}
-	return l, nil
 }
 
-// convertMetadataToKey converts a BGPPeerMetadata to a BGPPeerKey
+// convertMetadataToKey converts a BGPPeerMetadata to a HostBGPPeerKey/GlobalBGPPeerKey
 // This is part of the conversionHelper interface.
 func (h *bgpPeers) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
-	pm := m.(api.BGPPeerMetadata)
-	k := model.BGPPeerKey{
-		Scope:    pm.Scope,
-		PeerIP:   pm.PeerIP,
-		Hostname: pm.Node,
-	}
-	return k, nil
+	return h.ConvertMetadataToKey(m)
 }
 
 // convertAPIToKVPair converts an API BGPPeer structure to a KVPair containing a
-// backend BGPPeer and BGPPeerKey.
+// backend BGPPeer and HostBGPPeerKey/GlobalBGPPeerKey.
 // This is part of the conversionHelper interface.
 func (h *bgpPeers) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
-	ap := a.(api.BGPPeer)
-	k, err := h.convertMetadataToKey(ap.Metadata)
-	if err != nil {
-		return nil, err
-	}
-
-	d := model.KVPair{
-		Key: k,
-		Value: &model.BGPPeer{
-			PeerIP: ap.Metadata.PeerIP,
-			ASNum:  ap.Spec.ASNumber,
-		},
-	}
-
-	return &d, nil
+	return h.ConvertAPIToKVPair(a)
 }
 
-// convertKVPairToAPI converts a KVPair containing a backend BGPPeer and BGPPeerKey
+// convertKVPairToAPI converts a KVPair containing a backend BGPPeer and HostBGPPeerKey/GlobalBGPPeerKey
 // to an API BGPPeer structure.
 // This is part of the conversionHelper interface.
 func (h *bgpPeers) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
-	backendBGPPeer := d.Value.(*model.BGPPeer)
-	backendBGPPeerKey := d.Key.(model.BGPPeerKey)
-
-	apiBGPPeer := api.NewBGPPeer()
-	apiBGPPeer.Metadata.Scope = backendBGPPeerKey.Scope
-	apiBGPPeer.Metadata.PeerIP = backendBGPPeerKey.PeerIP
-	apiBGPPeer.Metadata.Node = backendBGPPeerKey.Hostname
-	apiBGPPeer.Spec.ASNumber = backendBGPPeer.ASNum
-
-	return apiBGPPeer, nil
+	return h.ConvertKVPairToAPI(d)
 }

--- a/lib/converter/bgppeer.go
+++ b/lib/converter/bgppeer.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/scope"
+)
+
+// BGPPeerConverter implements a set of functions used for converting between
+// API and backend representations of the BGPPeer resource.
+type BGPPeerConverter struct{}
+
+// ConvertMetadataToKey converts a BGPPeerMetadata to a GlobalBGPPeerKey or HostBGPPeerKey.
+func (p BGPPeerConverter) ConvertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
+	pm := m.(api.BGPPeerMetadata)
+
+	if pm.Scope == scope.Global {
+		return model.GlobalBGPPeerKey{
+			PeerIP: pm.PeerIP,
+		}, nil
+	} else if pm.Scope == scope.Node {
+		return model.NodeBGPPeerKey{
+			PeerIP:   pm.PeerIP,
+			Nodename: pm.Node,
+		}, nil
+	} else {
+		return nil, errors.ErrorInsufficientIdentifiers{
+			Name: "scope",
+		}
+	}
+}
+
+// ConvertAPIToKVPair converts an API Policy structure to a KVPair containing a
+// backend BGPPeer and GlobalBGPPeerKey/HostBGPPeerKey.
+func (p BGPPeerConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
+	ap := a.(api.BGPPeer)
+	k, err := p.ConvertMetadataToKey(ap.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	d := model.KVPair{
+		Key: k,
+		Value: &model.BGPPeer{
+			PeerIP: ap.Metadata.PeerIP,
+			ASNum:  ap.Spec.ASNumber,
+		},
+	}
+
+	return &d, nil
+}
+
+// ConvertKVPairToAPI converts a KVPair containing a backend BGPPeer and GlobalBGPPeerKey/HostBGPPeerKey
+// to an API BGPPeer structure.
+func (p BGPPeerConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
+	apiBGPPeer := api.NewBGPPeer()
+
+	switch k := d.Key.(type) {
+	case model.GlobalBGPPeerKey:
+		apiBGPPeer.Metadata.Scope = scope.Global
+		apiBGPPeer.Metadata.PeerIP = k.PeerIP
+		apiBGPPeer.Metadata.Node = ""
+	case model.NodeBGPPeerKey:
+		apiBGPPeer.Metadata.Scope = scope.Node
+		apiBGPPeer.Metadata.PeerIP = k.PeerIP
+		apiBGPPeer.Metadata.Node = k.Nodename
+	}
+
+	backendBGPPeer := d.Value.(*model.BGPPeer)
+	apiBGPPeer.Spec.ASNumber = backendBGPPeer.ASNum
+
+	return apiBGPPeer, nil
+}

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -111,6 +111,7 @@ func init() {
 	registerStructValidator(validateRule, api.Rule{})
 	registerStructValidator(validateBackendRule, model.Rule{})
 	registerStructValidator(validateNodeSpec, api.NodeSpec{})
+	registerStructValidator(validateBGPPeerMeta, api.BGPPeerMetadata{})
 }
 
 // reason returns the provided error reason prefixed with an identifier that
@@ -470,5 +471,14 @@ func validateNodeSpec(v *validator.Validate, structLevel *validator.StructLevel)
 			structLevel.ReportError(reflect.ValueOf(ns.BGP.IPv6Address),
 				"BGP.IPv6Address", "", reason("invalid IPv6 address and subnet specified"))
 		}
+	}
+}
+
+func validateBGPPeerMeta(v *validator.Validate, structLevel *validator.StructLevel) {
+	m := structLevel.CurrentStruct.Interface().(api.BGPPeerMetadata)
+
+	if m.Scope == scope.Global && m.Node != "" {
+		structLevel.ReportError(reflect.ValueOf(m.Node),
+			"Metadata.Node", "", reason("no BGP Peer node name should be specified when scope is global"))
 	}
 }


### PR DESCRIPTION
This PR aligns the BGP Peer backend model with other models that support per-node and global varieties (i.e. by having separate model types for each).

This was something that I wanted to change previously and ultimately limits the potential processing the backend has to implement.

Although not strictly required, it does align more nicely with our felix and bgp config model *and* for k8s simplifies the processing since they are handled differently, and for etcd allows a less permissive root to be used for the enumeration.  I think as we move to a more k8s idiomatic indexing, the per-Node model will effectively just be phased out, or converted to a different type (using a node selector)...

This also splits out the API->KVPair conversion so that k8s may use it when we construct a k8s resource that uses the same `api.BGPPeerSpec` (as we did previously for Network Policies)