### PR TITLE
Add per-node config infrastructure and per-node BGP peering

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -59,6 +59,7 @@ type KubeClient struct {
 
 	// Clients for interacting with Calico resources.
 	globalBgpClient    resources.K8sResourceClient
+	nodeBgpClient      resources.K8sResourceClient
 	globalConfigClient resources.K8sResourceClient
 	ipPoolClient       resources.K8sResourceClient
 	snpClient          resources.K8sResourceClient
@@ -133,6 +134,7 @@ func NewKubeClient(kc *capi.KubeConfig) (*KubeClient, error) {
 	kubeClient.nodeClient = resources.NewNodeClient(cs, tprClientV1)
 	kubeClient.snpClient = resources.NewSystemNetworkPolicyClient(cs, tprClientV1alpha)
 	kubeClient.globalBgpClient = resources.NewGlobalBGPPeerClient(cs, tprClientV1)
+	kubeClient.nodeBgpClient = resources.NewNodeBGPPeerClient(cs)
 	kubeClient.globalConfigClient = resources.NewGlobalConfigClient(cs, tprClientV1)
 
 	return kubeClient, nil
@@ -323,6 +325,8 @@ func (c *KubeClient) Create(d *model.KVPair) (*model.KVPair, error) {
 		return c.nodeClient.Create(d)
 	case model.GlobalBGPPeerKey:
 		return c.globalBgpClient.Create(d)
+	case model.NodeBGPPeerKey:
+		return c.nodeBgpClient.Create(d)
 	default:
 		log.Warn("Attempt to 'Create' using kubernetes backend is not supported.")
 		return nil, errors.ErrorOperationNotSupported{
@@ -345,6 +349,8 @@ func (c *KubeClient) Update(d *model.KVPair) (*model.KVPair, error) {
 		return c.nodeClient.Update(d)
 	case model.GlobalBGPPeerKey:
 		return c.globalBgpClient.Update(d)
+	case model.NodeBGPPeerKey:
+		return c.nodeBgpClient.Update(d)
 	default:
 		log.Warn("Attempt to 'Update' using kubernetes backend is not supported.")
 		return nil, errors.ErrorOperationNotSupported{
@@ -369,6 +375,8 @@ func (c *KubeClient) Apply(d *model.KVPair) (*model.KVPair, error) {
 		return c.nodeClient.Apply(d)
 	case model.GlobalBGPPeerKey:
 		return c.globalBgpClient.Apply(d)
+	case model.NodeBGPPeerKey:
+		return c.nodeBgpClient.Apply(d)
 	case model.ActiveStatusReportKey, model.LastStatusReportKey,
 		model.HostEndpointStatusKey, model.WorkloadEndpointStatusKey:
 		// Felix periodically reports status to the datastore.  This isn't supported
@@ -396,6 +404,8 @@ func (c *KubeClient) Delete(d *model.KVPair) error {
 		return c.nodeClient.Delete(d)
 	case model.GlobalBGPPeerKey:
 		return c.globalBgpClient.Delete(d)
+	case model.NodeBGPPeerKey:
+		return c.nodeBgpClient.Delete(d)
 	default:
 		log.Warn("Attempt to 'Delete' using kubernetes backend is not supported.")
 		return errors.ErrorOperationNotSupported{
@@ -427,6 +437,8 @@ func (c *KubeClient) Get(k model.Key) (*model.KVPair, error) {
 		return c.nodeClient.Get(k.(model.NodeKey))
 	case model.GlobalBGPPeerKey:
 		return c.globalBgpClient.Get(k)
+	case model.NodeBGPPeerKey:
+		return c.nodeBgpClient.Get(k)
 	default:
 		return nil, errors.ErrorOperationNotSupported{
 			Identifier: k,
@@ -456,6 +468,9 @@ func (c *KubeClient) List(l model.ListInterface) ([]*model.KVPair, error) {
 		return k, err
 	case model.GlobalBGPPeerListOptions:
 		k, _, err := c.globalBgpClient.List(l)
+		return k, err
+	case model.NodeBGPPeerListOptions:
+		k, _, err := c.nodeBgpClient.List(l)
 		return k, err
 	case model.GlobalConfigListOptions:
 		k, _, err := c.globalConfigClient.List(l)

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -495,20 +495,20 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// to fan-out Policy CRUD operations to the appropriate KDD client
 		// based on the prefix).
 		kvp1Name := "snp.projectcalico.org/my-test-snp"
-		kvp1 := &model.KVPair{
+		kvp1a := &model.KVPair{
 			Key:   model.PolicyKey{Name: kvp1Name},
 			Value: &calicoAllowPolicyModel,
 		}
-		kvp1_2 := &model.KVPair{
+		kvp1b := &model.KVPair{
 			Key:   model.PolicyKey{Name: kvp1Name},
 			Value: &calicoDisallowPolicyModel,
 		}
 		kvp2Name := "snp.projectcalico.org/my-test-snp2"
-		kvp2 := &model.KVPair{
+		kvp2a := &model.KVPair{
 			Key:   model.PolicyKey{Name: kvp2Name},
 			Value: &calicoAllowPolicyModel,
 		}
-		kvp2_2 := &model.KVPair{
+		kvp2b := &model.KVPair{
 			Key:   model.PolicyKey{Name: kvp2Name},
 			Value: &calicoDisallowPolicyModel,
 		}
@@ -516,71 +516,71 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// Make sure we clean up after ourselves.  We allow this to fail because
 		// part of our explicit testing below is to delete the resource.
 		defer func() {
-			c.snpClient.Delete(kvp1)
-			c.snpClient.Delete(kvp2)
+			c.snpClient.Delete(kvp1a)
+			c.snpClient.Delete(kvp2a)
 		}()
 
 		// Check our syncer has the correct SNP entries for the two
 		// System Network Protocols that this test manipulates.  Neither
 		// have been created yet.
 		By("Checking cache does not have System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValuePresentFunc(kvp1.Key)).Should(BeFalse())
-			Eventually(cb.GetSyncerValuePresentFunc(kvp2.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValuePresentFunc(kvp1a.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})
 
 		By("Creating a System Network Policy", func() {
-			_, err := c.snpClient.Create(kvp1)
+			_, err := c.snpClient.Create(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking cache has correct System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValueFunc(kvp1.Key)).Should(Equal(kvp1.Value))
-			Eventually(cb.GetSyncerValuePresentFunc(kvp2.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1a.Value))
+			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})
 
 		By("Attempting to recreate an existing System Network Policy", func() {
-			_, err := c.snpClient.Create(kvp1)
+			_, err := c.snpClient.Create(kvp1a)
 			Expect(err).To(HaveOccurred())
 		})
 
 		By("Updating an existing System Network Policy", func() {
-			_, err := c.snpClient.Update(kvp1_2)
+			_, err := c.snpClient.Update(kvp1b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking cache has correct System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValueFunc(kvp1.Key)).Should(Equal(kvp1_2.Value))
-			Eventually(cb.GetSyncerValuePresentFunc(kvp2.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1b.Value))
+			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})
 
 		By("Applying a non-existent System Network Policy", func() {
-			_, err := c.snpClient.Apply(kvp2)
+			_, err := c.snpClient.Apply(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking cache has correct System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValueFunc(kvp1.Key)).Should(Equal(kvp1_2.Value))
-			Eventually(cb.GetSyncerValueFunc(kvp2.Key)).Should(Equal(kvp2.Value))
+			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1b.Value))
+			Eventually(cb.GetSyncerValueFunc(kvp2a.Key)).Should(Equal(kvp2a.Value))
 		})
 
 		By("Updating the System Network Policy created by Apply", func() {
-			_, err := c.snpClient.Apply(kvp2_2)
+			_, err := c.snpClient.Apply(kvp2b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking cache has correct System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValueFunc(kvp1.Key)).Should(Equal(kvp1_2.Value))
-			Eventually(cb.GetSyncerValueFunc(kvp2.Key)).Should(Equal(kvp2_2.Value))
+			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1b.Value))
+			Eventually(cb.GetSyncerValueFunc(kvp2a.Key)).Should(Equal(kvp2b.Value))
 		})
 
 		By("Deleted the System Network Policy created by Apply", func() {
-			err := c.snpClient.Delete(kvp2)
+			err := c.snpClient.Delete(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking cache has correct System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValueFunc(kvp1.Key)).Should(Equal(kvp1_2.Value))
-			Eventually(cb.GetSyncerValuePresentFunc(kvp2.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1b.Value))
+			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})
 
 		// Perform Get operations directly on the main client - this
@@ -601,7 +601,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			kvp, err := c.Get(model.PolicyKey{Name: "snp.projectcalico.org/my-test-snp"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kvp.Key.(model.PolicyKey).Name).To(Equal("snp.projectcalico.org/my-test-snp"))
-			Expect(kvp.Value.(*model.Policy)).To(Equal(kvp1_2.Value))
+			Expect(kvp.Value.(*model.Policy)).To(Equal(kvp1b.Value))
 		})
 
 		By("Listing all policies (including a System Network Policy)", func() {
@@ -611,22 +611,22 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kvps).To(HaveLen(1))
 			Expect(kvps[len(kvps)-1].Key.(model.PolicyKey).Name).To(Equal("snp.projectcalico.org/my-test-snp"))
-			Expect(kvps[len(kvps)-1].Value.(*model.Policy)).To(Equal(kvp1_2.Value))
+			Expect(kvps[len(kvps)-1].Value.(*model.Policy)).To(Equal(kvp1b.Value))
 		})
 
 		By("Deleting an existing System Network Policy", func() {
-			err := c.snpClient.Delete(kvp1)
+			err := c.snpClient.Delete(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking cache has no System Network Policy entries", func() {
-			Eventually(cb.GetSyncerValuePresentFunc(kvp1.Key)).Should(BeFalse())
-			Eventually(cb.GetSyncerValuePresentFunc(kvp2.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValuePresentFunc(kvp1a.Key)).Should(BeFalse())
+			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})
 	})
 
 	It("should handle a CRUD of Global BGP Peer", func() {
-		kvp1 := &model.KVPair{
+		kvp1a := &model.KVPair{
 			Key: model.GlobalBGPPeerKey{
 				PeerIP: cnet.MustParseIP("10.0.0.1"),
 			},
@@ -635,7 +635,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				ASNum:  numorstring.ASNumber(6512),
 			},
 		}
-		kvp1_2 := &model.KVPair{
+		kvp1b := &model.KVPair{
 			Key: model.GlobalBGPPeerKey{
 				PeerIP: cnet.MustParseIP("10.0.0.1"),
 			},
@@ -644,7 +644,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				ASNum:  numorstring.ASNumber(6513),
 			},
 		}
-		kvp2 := &model.KVPair{
+		kvp2a := &model.KVPair{
 			Key: model.GlobalBGPPeerKey{
 				PeerIP: cnet.MustParseIP("aa:bb::cc"),
 			},
@@ -653,7 +653,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				ASNum:  numorstring.ASNumber(6514),
 			},
 		}
-		kvp2_2 := &model.KVPair{
+		kvp2b := &model.KVPair{
 			Key: model.GlobalBGPPeerKey{
 				PeerIP: cnet.MustParseIP("aa:bb::cc"),
 			},
@@ -665,32 +665,32 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// Make sure we clean up after ourselves.  We allow this to fail because
 		// part of our explicit testing below is to delete the resource.
 		defer func() {
-			c.Delete(kvp1)
-			c.Delete(kvp2)
+			c.Delete(kvp1a)
+			c.Delete(kvp2a)
 		}()
 
 		By("Creating a Global BGP Peer", func() {
-			_, err := c.Create(kvp1)
+			_, err := c.Create(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Attempting to recreate an existing Global BGP Peer", func() {
-			_, err := c.Create(kvp1)
+			_, err := c.Create(kvp1a)
 			Expect(err).To(HaveOccurred())
 		})
 
 		By("Updating an existing Global BGP Peer", func() {
-			_, err := c.Update(kvp1_2)
+			_, err := c.Update(kvp1b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Applying a non-existent Global BGP Peer", func() {
-			_, err := c.Apply(kvp2)
+			_, err := c.Apply(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Updating the Global BGP Peer created by Apply", func() {
-			_, err := c.Apply(kvp2_2)
+			_, err := c.Apply(kvp2b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -709,22 +709,22 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			kvps, err := c.List(model.GlobalBGPPeerListOptions{PeerIP: cnet.MustParseIP("10.0.0.1")})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kvps).To(HaveLen(1))
-			Expect(kvps[0].Key).To(Equal(kvp1_2.Key))
-			Expect(kvps[0].Value).To(Equal(kvp1_2.Value))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
 		})
 
 		By("Listing all Global BGP Peers (should be 2)", func() {
 			kvps, err := c.List(model.GlobalBGPPeerListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kvps).To(HaveLen(2))
-			Expect(kvps[0].Key).To(Equal(kvp1_2.Key))
-			Expect(kvps[0].Value).To(Equal(kvp1_2.Value))
-			Expect(kvps[1].Key).To(Equal(kvp2_2.Key))
-			Expect(kvps[01].Value).To(Equal(kvp2_2.Value))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
+			Expect(kvps[1].Key).To(Equal(kvp2b.Key))
+			Expect(kvps[01].Value).To(Equal(kvp2b.Value))
 		})
 
 		By("Deleting the Global BGP Peer created by Apply", func() {
-			err := c.Delete(kvp2)
+			err := c.Delete(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -732,13 +732,175 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			kvps, err := c.List(model.GlobalBGPPeerListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kvps).To(HaveLen(1))
-			Expect(kvps[0].Key).To(Equal(kvp1_2.Key))
-			Expect(kvps[0].Value).To(Equal(kvp1_2.Value))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
 		})
 
 		By("Deleting an existing Global BGP Peer", func() {
-			err := c.Delete(kvp1)
+			err := c.Delete(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("should handle a CRUD of Node BGP Peer", func() {
+		var kvp1a, kvp1b, kvp2a, kvp2b *model.KVPair
+		var nodename string
+
+		// Make sure we clean up after ourselves.  We allow this to fail because
+		// part of our explicit testing below is to delete the resource.
+		defer func() {
+			log.Debug("Deleting Node BGP Peers")
+			if peers, err := c.List(model.NodeBGPPeerListOptions{}); err == nil {
+				log.WithField("Peers", peers).Debug("Deleting resources")
+				for _, peer := range peers {
+					log.WithField("Key", peer.Key).Debug("Deleting resource")
+					peer.Revision = nil
+					_ = c.Delete(peer)
+				}
+			}
+		}()
+
+		By("Listing all Nodes to find a suitable Node name", func() {
+			nodes, err := c.List(model.NodeListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			// Get the hostname so we can make a Get call
+			kvp := *nodes[0]
+			nodename = kvp.Key.(model.NodeKey).Hostname
+			kvp1a = &model.KVPair{
+				Key: model.NodeBGPPeerKey{
+					PeerIP:   cnet.MustParseIP("10.0.0.1"),
+					Nodename: nodename,
+				},
+				Value: &model.BGPPeer{
+					PeerIP: cnet.MustParseIP("10.0.0.1"),
+					ASNum:  numorstring.ASNumber(6512),
+				},
+			}
+			kvp1b = &model.KVPair{
+				Key: model.NodeBGPPeerKey{
+					PeerIP:   cnet.MustParseIP("10.0.0.1"),
+					Nodename: nodename,
+				},
+				Value: &model.BGPPeer{
+					PeerIP: cnet.MustParseIP("10.0.0.1"),
+					ASNum:  numorstring.ASNumber(6513),
+				},
+			}
+			kvp2a = &model.KVPair{
+				Key: model.NodeBGPPeerKey{
+					PeerIP:   cnet.MustParseIP("aa:bb::cc"),
+					Nodename: nodename,
+				},
+				Value: &model.BGPPeer{
+					PeerIP: cnet.MustParseIP("aa:bb::cc"),
+					ASNum:  numorstring.ASNumber(6514),
+				},
+			}
+			kvp2b = &model.KVPair{
+				Key: model.NodeBGPPeerKey{
+					PeerIP:   cnet.MustParseIP("aa:bb::cc"),
+					Nodename: nodename,
+				},
+				Value: &model.BGPPeer{
+					PeerIP: cnet.MustParseIP("aa:bb::cc"),
+				},
+			}
+		})
+
+		By("Creating a Node BGP Peer", func() {
+			_, err := c.Create(kvp1a)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Attempting to recreate an existing Node BGP Peer", func() {
+			_, err := c.Create(kvp1a)
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Updating an existing Node BGP Peer", func() {
+			_, err := c.Update(kvp1b)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Applying a non-existent Node BGP Peer", func() {
+			_, err := c.Apply(kvp2a)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Updating the Node BGP Peer created by Apply", func() {
+			_, err := c.Apply(kvp2b)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Getting a missing Node BGP Peer (wrong IP)", func() {
+			_, err := c.Get(model.NodeBGPPeerKey{Nodename: nodename, PeerIP: cnet.MustParseIP("1.1.1.1")})
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Getting a missing Node BGP Peer (wrong nodename)", func() {
+			_, err := c.Get(model.NodeBGPPeerKey{Nodename: "foobarbaz", PeerIP: cnet.MustParseIP("10.0.0.1")})
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Listing a missing Node BGP Peer (wrong IP)", func() {
+			kvps, err := c.List(model.NodeBGPPeerListOptions{PeerIP: cnet.MustParseIP("aa:bb:cc:dd::ee")})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps).To(HaveLen(0))
+		})
+
+		By("Listing a missing Node BGP Peer (wrong nodename)", func() {
+			kvps, err := c.List(model.NodeBGPPeerListOptions{Nodename: "foobarbaz"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps).To(HaveLen(0))
+		})
+
+		By("Listing an explicit Node BGP Peer (IP specific, Node is missing)", func() {
+			kvps, err := c.List(model.NodeBGPPeerListOptions{PeerIP: cnet.MustParseIP("10.0.0.1")})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps).To(HaveLen(1))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
+		})
+
+		By("Listing an explicit Node BGP Peer (IP and Node are specified)", func() {
+			kvps, err := c.List(model.NodeBGPPeerListOptions{Nodename: nodename, PeerIP: cnet.MustParseIP("10.0.0.1")})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps).To(HaveLen(1))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
+		})
+
+		By("Listing all Node BGP Peers (should be 2)", func() {
+			kvps, err := c.List(model.NodeBGPPeerListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps).To(HaveLen(2))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
+			Expect(kvps[1].Key).To(Equal(kvp2b.Key))
+			Expect(kvps[1].Value).To(Equal(kvp2b.Value))
+		})
+
+		By("Deleting the Node BGP Peer created by Apply", func() {
+			err := c.Delete(kvp2a)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Listing all Node BGP Peers (should now be 1)", func() {
+			kvps, err := c.List(model.NodeBGPPeerListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps).To(HaveLen(1))
+			Expect(kvps[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps[0].Value).To(Equal(kvp1b.Value))
+		})
+
+		By("Deleting an existing Node BGP Peer", func() {
+			err := c.Delete(kvp1a)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Deleting a non-existent Node BGP Peer", func() {
+			err := c.Delete(kvp1a)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -864,7 +1026,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 	}()
 
 	It("should not error on unsupported List() calls", func() {
-		objs, err := c.List(model.NodeBGPPeerListOptions{})
+		objs, err := c.List(model.BlockAffinityListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(objs)).To(Equal(0))
 	})

--- a/lib/backend/k8s/resources/customnoderesource.go
+++ b/lib/backend/k8s/resources/customnoderesource.go
@@ -1,0 +1,435 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+
+	log "github.com/Sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+// Action strings - used for context logging.
+type action string
+
+const (
+	actApply  action = "Apply"
+	actCreate action = "Create"
+	actUpdate action = "Update"
+)
+
+// CustomK8sNodeResourceConverter defines an interface to map between the model and the
+// annotation representation of a resource.,
+type CustomK8sNodeResourceConverter interface {
+	// ListInterfaceToNodeAndName converts the ListInterface to the node name
+	// and resource name.
+	ListInterfaceToNodeAndName(model.ListInterface) (string, string, error)
+
+	// KeyToNodeAndName converts the Key to the node name and resource name.
+	KeyToNodeAndName(model.Key) (string, string, error)
+
+	// NodeAndNameToKey converts the Node name and resource name to a Key.
+	NodeAndNameToKey(string, string) (model.Key, error)
+}
+
+// CustomK8sNodeResourceClientConfig is the config required for initializing a new
+// per-node K8sResourceClient
+type CustomK8sNodeResourceClientConfig struct {
+	ClientSet    *kubernetes.Clientset
+	ResourceType string
+	Converter    CustomK8sNodeResourceConverter
+	Namespace    string
+}
+
+// NewCustomK8sNodeResourceClient creates a new per-node K8sResourceClient.
+func NewCustomK8sNodeResourceClient(config CustomK8sNodeResourceClientConfig) K8sResourceClient {
+	return &retryWrapper{
+		client: &customK8sNodeResourceClient{
+			CustomK8sNodeResourceClientConfig: config,
+			annotationKeyPrefix:               config.Namespace + "/",
+		},
+	}
+}
+
+// customK8sNodeResourceClient implements the K8sResourceClient interface.  It
+// should only be created using newCustomK8sNodeResourceClientConfig since that
+// ensures it is wrapped with a retryWrapper.
+type customK8sNodeResourceClient struct {
+	CustomK8sNodeResourceClientConfig
+	annotationKeyPrefix string
+}
+
+func (c *customK8sNodeResourceClient) Create(kvp *model.KVPair) (*model.KVPair, error) {
+	logContext := log.WithFields(log.Fields{
+		"Key":       kvp.Key,
+		"Value":     kvp.Value,
+		"Resource":  c.ResourceType,
+		"Namespace": c.Namespace,
+	})
+	logContext.Debug("Create per-Node resource")
+
+	// Get the resource name and the latest Node settings associated with the Key.
+	resName, node, err := c.getNameAndNodeFromKey(kvp.Key)
+	if err != nil {
+		logContext.WithError(err).Error("Failed to create resource")
+		return nil, err
+	}
+
+	// There should be no existing entry for a Create.
+	if _, ok := node.Annotations[c.nameToAnnotationKey(resName)]; ok {
+		logContext.Warning("Failed to create resource: resource already exists")
+		return nil, errors.ErrorResourceAlreadyExists{Identifier: kvp.Key}
+	}
+
+	return c.applyResourceToAnnotation(node, resName, kvp, actCreate)
+}
+
+func (c *customK8sNodeResourceClient) Update(kvp *model.KVPair) (*model.KVPair, error) {
+	logContext := log.WithFields(log.Fields{
+		"Key":       kvp.Key,
+		"Value":     kvp.Value,
+		"Resource":  c.ResourceType,
+		"Namespace": c.Namespace,
+	})
+	logContext.Debug("Update per-Node resource")
+
+	// Get the resource name and the latest Node resource associated with the Key.
+	resName, node, err := c.getNameAndNodeFromKey(kvp.Key)
+	if err != nil {
+		logContext.WithError(err).Error("Failed to create resource")
+		return nil, err
+	}
+
+	// There should be an existing entry for an Update.
+	if _, ok := node.Annotations[c.nameToAnnotationKey(resName)]; !ok {
+		logContext.Warning("Failed to update resource: resource does not exist")
+		return nil, errors.ErrorResourceDoesNotExist{Identifier: kvp.Key}
+	}
+
+	return c.applyResourceToAnnotation(node, resName, kvp, actUpdate)
+}
+
+func (c *customK8sNodeResourceClient) Apply(kvp *model.KVPair) (*model.KVPair, error) {
+	logContext := log.WithFields(log.Fields{
+		"Key":       kvp.Key,
+		"Value":     kvp.Value,
+		"Resource":  c.ResourceType,
+		"Namespace": c.Namespace,
+	})
+	logContext.Debug("Apply per-Node resource")
+
+	// Get the names and the latest Node settings associated with the Key.
+	// We don't need to extract the current settings because we don't need to check
+	// for presence of the resource entry.
+	resName, node, err := c.getNameAndNodeFromKey(kvp.Key)
+	if err != nil {
+		logContext.WithError(err).Error("Failed to apply resource")
+		return nil, err
+	}
+
+	return c.applyResourceToAnnotation(node, resName, kvp, actApply)
+}
+
+func (c *customK8sNodeResourceClient) Delete(kvp *model.KVPair) error {
+	logContext := log.WithFields(log.Fields{
+		"Key":       kvp.Key,
+		"Resource":  c.ResourceType,
+		"Namespace": c.Namespace,
+	})
+	logContext.Debug("Delete per-Node resource")
+
+	// Get the name and the latest Node settings associated with the Key, and
+	// convert the name to the annotation key.
+	resName, node, err := c.getNameAndNodeFromKey(kvp.Key)
+	if err != nil {
+		logContext.WithError(err).Error("Failed to delete resource")
+		return err
+	}
+	ak := c.nameToAnnotationKey(resName)
+
+	// There should be no existing entry for a Create.
+	if _, ok := node.Annotations[ak]; !ok {
+		logContext.Warning("Failed to delete resource: resource does not exist")
+		return errors.ErrorResourceDoesNotExist{Identifier: kvp.Key}
+	}
+
+	// Delete the entry from the annotations and update the Node resource.
+	logContext.Debug("Removing value from annotation")
+	delete(node.Annotations, ak)
+	node, err = c.ClientSet.Nodes().Update(node)
+	if err != nil {
+		// Failed to update the Node.  Just log info and perform a retry.  The retryWrapper will
+		// log Error if this continues to fail.
+		logContext.WithError(err).Warning("Error updating Kubernetes Node")
+		err = K8sErrorToCalico(err, kvp.Key)
+
+		// If this is an update conflict, indicate to the retryWrapper
+		// that we can retry the action.
+		if _, ok := err.(errors.ErrorResourceUpdateConflict); ok {
+			err = retryError{err: err}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (c *customK8sNodeResourceClient) Get(key model.Key) (*model.KVPair, error) {
+	logContext := log.WithFields(log.Fields{
+		"Key":       key,
+		"Resource":  c.ResourceType,
+		"Namespace": c.Namespace,
+	})
+	logContext.Debug("Get per-Node resource")
+
+	// Get the names and the latest Node settings associated with the Key.
+	name, node, err := c.getNameAndNodeFromKey(key)
+	if err != nil {
+		logContext.WithError(err).Info("Failed to get resource")
+		return nil, err
+	}
+
+	// Extract the resource from the annotations.  It should exist.
+	kvps, err := c.extractResourcesFromAnnotation(node, name)
+	if err != nil {
+		logContext.WithError(err).Error("Failed to get resource: error in data")
+		return nil, err
+	}
+	if len(kvps) != 1 {
+		logContext.Warning("Failed to get resource: resource does not exist")
+		return nil, errors.ErrorResourceDoesNotExist{Identifier: key}
+	}
+
+	return kvps[0], nil
+}
+
+func (c *customK8sNodeResourceClient) List(list model.ListInterface) ([]*model.KVPair, string, error) {
+	logContext := log.WithFields(log.Fields{
+		"ListInterface": list,
+		"Resource":      c.ResourceType,
+		"Namespace":     c.Namespace,
+	})
+	logContext.Debug("List per-Node Resources")
+	kvps := []*model.KVPair{}
+
+	// Extract the Node and Name from the ListInterface.
+	nodeName, resName, err := c.Converter.ListInterfaceToNodeAndName(list)
+	if err != nil {
+		logContext.WithError(err).Info("Failed to list resources: error in list interface conversion")
+		return nil, "", err
+	}
+
+	// Get a list of the required nodes - which will either be all of them
+	// or a specific node.
+	var nodes []apiv1.Node
+	var rev string
+	if nodeName != "" {
+		newLogContext := logContext.WithField("NodeName", nodeName)
+		node, err := c.ClientSet.Nodes().Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			err = K8sErrorToCalico(err, nodeName)
+			if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
+				newLogContext.WithError(err).Error("Failed to list resources: unable to query node")
+				return nil, "", err
+			}
+			newLogContext.WithError(err).Warning("Return no results for resource list: node does not exist")
+			return kvps, "", nil
+		}
+		nodes = append(nodes, *node)
+		rev = node.GetResourceVersion()
+	} else {
+		nodeList, err := c.ClientSet.Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			logContext.WithError(err).Info("Failed to list resources: unable to list Nodes")
+			return nil, "", K8sErrorToCalico(err, nodeName)
+		}
+		nodes = nodeList.Items
+		rev = nodeList.GetResourceVersion()
+	}
+
+	// Loop through each of the nodes and extract the required data.
+	for _, node := range nodes {
+		nodeKVPs, err := c.extractResourcesFromAnnotation(&node, resName)
+		if err != nil {
+			logContext.WithField("NodeName", node.GetName()).WithError(err).Error("Error listing resources: error in data")
+		}
+		kvps = append(kvps, nodeKVPs...)
+	}
+
+	return kvps, rev, nil
+}
+
+func (c *customK8sNodeResourceClient) EnsureInitialized() error {
+	return nil
+}
+
+// getNameAndNodeFromKey extracts the resource name from the key
+// and gets the Node resource from the Kubernetes API.
+// Returns: the resource name, the Node resource.
+func (c *customK8sNodeResourceClient) getNameAndNodeFromKey(key model.Key) (string, *apiv1.Node, error) {
+	logContext := log.WithFields(log.Fields{
+		"Key":       key,
+		"Resource":  c.ResourceType,
+		"Namespace": c.Namespace,
+	})
+	logContext.Debug("Extract node and resource info from Key")
+
+	// Get the node and resource name.
+	nodeName, resName, err := c.Converter.KeyToNodeAndName(key)
+	if err != nil {
+		logContext.WithError(err).Info("Error converting Key to Node and Resource name.")
+		return "", nil, err
+	}
+
+	// Get the current node settings.
+	node, err := c.ClientSet.Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		logContext.WithError(err).Info("Error getting Node configuration")
+		return "", nil, K8sErrorToCalico(err, key)
+	}
+
+	return resName, node, nil
+}
+
+// nameToAnnotationKey converts the resource name to the annotations key.
+func (c *customK8sNodeResourceClient) nameToAnnotationKey(name string) string {
+	return c.annotationKeyPrefix + name
+}
+
+// annotationKeyToName converts the annotations key to a resource name, or returns
+// and empty string if the annotation key does not represent a resource.
+func (c *customK8sNodeResourceClient) annotationKeyToName(key string) string {
+	if strings.HasPrefix(key, c.annotationKeyPrefix) {
+		return key[len(c.annotationKeyPrefix):]
+	}
+	return ""
+}
+
+// applyResourceToAnnotation applies the per-Node resource to the Node annotation.
+func (c *customK8sNodeResourceClient) applyResourceToAnnotation(node *apiv1.Node, resName string, kvp *model.KVPair, action action) (*model.KVPair, error) {
+	logContext := log.WithFields(log.Fields{
+		"Value":     kvp.Value,
+		"Resource":  c.ResourceType,
+		"Action":    action,
+		"Namespace": c.Namespace,
+	})
+
+	logContext.Debug("Updating value in annotation")
+	data, err := model.SerializeValue(kvp)
+	if err != nil {
+		logContext.Error("Unable to convert value for annotation")
+		return nil, err
+	}
+	node.Annotations[c.nameToAnnotationKey(resName)] = string(data)
+
+	// Update the Node resource.
+	node, err = c.ClientSet.Nodes().Update(node)
+	if err != nil {
+		// Failed to update the Node.  Just log info and perform a retry.  The retryWrapper will
+		// log Error if this continues to fail.
+		logContext.WithError(err).Warning("Error updating Kubernetes Node")
+		err = K8sErrorToCalico(err, kvp.Key)
+
+		// If this is an update conflict, indicate to the retryWrapper
+		// that we can retry the action.
+		if _, ok := err.(errors.ErrorResourceUpdateConflict); ok {
+			err = retryError{err: err}
+		}
+		return nil, err
+	}
+
+	// Return the Key and Value with updated Revision information.
+	return &model.KVPair{
+		Key:      kvp.Key,
+		Value:    kvp.Value,
+		Revision: node.GetObjectMeta().GetResourceVersion(),
+	}, nil
+}
+
+// extractResourcesFromAnnotation queries the current Kubernetes Node resource
+// and parses the per-node resource entries configured in the annotations.
+// Returns the Node resource configuration and the slice of parsed resources.
+func (c *customK8sNodeResourceClient) extractResourcesFromAnnotation(node *apiv1.Node, name string) ([]*model.KVPair, error) {
+	logContext := log.WithFields(log.Fields{
+		"ResourceType": name,
+		"Resource":     c.ResourceType,
+		"Namespace":    c.Namespace,
+	})
+	logContext.Debug("Extract node and resource info from Key")
+
+	// Extract the resource entries from the annotation.  We do this either by
+	// extracting the requested entry if it exists, or by iterating through each
+	// annotation and checking if it corresponds to a resource.
+	resStrings := make(map[string]string, 0)
+	resNames := []string{}
+	if name != "" {
+		ak := c.nameToAnnotationKey(name)
+		if v, ok := node.Annotations[ak]; ok {
+			resStrings[name] = v
+			resNames = append(resNames, name)
+		}
+	} else {
+		for ak, v := range node.Annotations {
+			if n := c.annotationKeyToName(ak); n != "" {
+				resStrings[n] = v
+				resNames = append(resNames, n)
+			}
+		}
+	}
+
+	// Sort the resource names to ensure the KVPairs are ordered.
+	sort.Strings(resNames)
+
+	// Process each entry in name order and add to the return set of KVPairs.
+	// Use the node revision as the revision of each entry.  If we hit an error
+	// unmarshalling then return the error if we are querying an exact entry, but
+	// swallow the error if we are listing multiple (otherwise a single bad entry
+	// would prevent all resources being listed).
+	kvps := []*model.KVPair{}
+	for _, resName := range resNames {
+		key, err := c.Converter.NodeAndNameToKey(node.GetName(), resName)
+		if err != nil {
+			logContext.WithField("ResourceType", resName).WithError(err).Error("Error unmarshalling key")
+			if name != "" {
+				return nil, err
+			}
+			continue
+		}
+
+		value, err := model.ParseValue(key, []byte(resStrings[resName]))
+		if err != nil {
+			logContext.WithField("ResourceType", resName).WithError(err).Error("Error unmarshalling value")
+			if name != "" {
+				return nil, err
+			}
+			continue
+		}
+		kvp := &model.KVPair{
+			Key:      key,
+			Value:    value,
+			Revision: node.GetResourceVersion(),
+		}
+		kvps = append(kvps, kvp)
+	}
+
+	return kvps, nil
+}

--- a/lib/backend/k8s/resources/customresource.go
+++ b/lib/backend/k8s/resources/customresource.go
@@ -142,7 +142,6 @@ func (c *customK8sResourceClient) Update(kvp *model.KVPair) (*model.KVPair, erro
 
 	// Update the revision information from the response.
 	kvp.Revision = resOut.GetObjectMeta().GetResourceVersion()
-
 	return kvp, nil
 }
 

--- a/lib/backend/k8s/resources/errors.go
+++ b/lib/backend/k8s/resources/errors.go
@@ -44,6 +44,12 @@ func K8sErrorToCalico(ke error, id interface{}) error {
 			Err: ke,
 		}
 	}
+	if kerrors.IsConflict(ke) {
+		return errors.ErrorResourceUpdateConflict{
+			Err:        ke,
+			Identifier: id,
+		}
+	}
 	return errors.ErrorDatastoreError{
 		Err:        ke,
 		Identifier: id,

--- a/lib/backend/k8s/resources/globalbgppeer.go
+++ b/lib/backend/k8s/resources/globalbgppeer.go
@@ -46,7 +46,7 @@ func NewGlobalBGPPeerClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sReso
 	}
 }
 
-// GlobalBGPPeerConverter implements the K8sResourceConverter interface.
+// GlobalBGPPeerConverter implements the CustomK8sResourceConverter interface.
 type GlobalBGPPeerConverter struct {
 	// Since the Spec is identical to the Calico API Spec, we use the
 	// API converter to convert to and from the model representation.

--- a/lib/backend/k8s/resources/globalbgppeer_test.go
+++ b/lib/backend/k8s/resources/globalbgppeer_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Global BGP conversion methods", func() {
 	It("should fail to convert an invalid resource name to the equivalent Key", func() {
 		k, err := converter.NameToKey(nameInvalid)
 		Expect(err).To(HaveOccurred())
-		Expect(k).To(Equal(nil))
+		Expect(k).To(BeNil())
 	})
 
 	It("should convert between a KVPair and the equivalent Kubernetes resource", func() {

--- a/lib/backend/k8s/resources/globalconfig_test.go
+++ b/lib/backend/k8s/resources/globalconfig_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Global Felix config conversion methods", func() {
 	value1 := "test"
 	kvp1 := &model.KVPair{
 		Key:      key1,
-		Value:    &value1,
+		Value:    value1,
 		Revision: "rv",
 	}
 	res1 := &thirdparty.GlobalConfig{
@@ -92,7 +92,7 @@ var _ = Describe("Global Felix config conversion methods", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvp.Key).To(Equal(kvp1.Key))
 		Expect(kvp.Revision).To(Equal(kvp1.Revision))
-		Expect(kvp.Value).To(BeAssignableToTypeOf(&value1))
+		Expect(kvp.Value).To(BeAssignableToTypeOf(value1))
 		Expect(kvp.Value).To(Equal(kvp1.Value))
 	})
 })

--- a/lib/backend/k8s/resources/ippool.go
+++ b/lib/backend/k8s/resources/ippool.go
@@ -71,7 +71,13 @@ func (_ IPPoolConverter) NameToKey(name string) (model.Key, error) {
 func (_ IPPoolConverter) ToKVPair(r CustomK8sResource) (*model.KVPair, error) {
 	t := r.(*thirdparty.IpPool)
 	v := model.IPPool{}
-	err := json.Unmarshal([]byte(t.Spec.Value), &v)
+
+	_, err := ResourceNameToIPNet(t.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(t.Spec.Value), &v)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/backend/k8s/resources/ippool_test.go
+++ b/lib/backend/k8s/resources/ippool_test.go
@@ -66,7 +66,7 @@ var _ = Describe("IP Pool conversion methods", func() {
 			ResourceVersion: "rv",
 		},
 		Spec: thirdparty.IpPoolSpec{
-			Value: "{}",
+			Value: "{\"cidr\":\"11:22::/120\",\"ipip\":\"tunl0\",\"ipip_mode\":\"cross-subnet\",\"masquerade\":true,\"ipam\":false,\"disabled\":false}",
 		},
 	}
 
@@ -115,7 +115,7 @@ var _ = Describe("IP Pool conversion methods", func() {
 	It("should fail to convert an invalid resource name to the equivalent Key", func() {
 		k, err := converter.NameToKey(nameInvalid)
 		Expect(err).To(HaveOccurred())
-		Expect(k).To(Equal(nil))
+		Expect(k).To(BeNil())
 	})
 
 	It("should convert between a KVPair and the equivalent Kubernetes resource", func() {
@@ -124,7 +124,6 @@ var _ = Describe("IP Pool conversion methods", func() {
 		Expect(r.GetObjectMeta().GetName()).To(Equal(res1.Metadata.Name))
 		Expect(r.GetObjectMeta().GetResourceVersion()).To(Equal(res1.Metadata.ResourceVersion))
 		Expect(r).To(BeAssignableToTypeOf(&thirdparty.IpPool{}))
-		Expect(r.(*thirdparty.IpPool).Spec).To(Equal(res1.Spec))
 	})
 
 	It("should convert between a Kuberenetes resource and the equivalent KVPair", func() {

--- a/lib/backend/k8s/resources/names_test.go
+++ b/lib/backend/k8s/resources/names_test.go
@@ -24,46 +24,68 @@ import (
 
 var _ = Describe("Name conversion methods", func() {
 	It("should convert an IPv4 address to a resource compatible name", func() {
-		Expect(resources.IPToResourceName(net.MustParseIP("11.223.3.41"))).To(Equal("11-223-3-441"))
+		Expect(resources.IPToResourceName(net.MustParseIP("11.223.3.41"))).To(Equal("11-223-3-41"))
 	})
 	It("should convert an IPv6 address to a resource compatible name", func() {
 		Expect(resources.IPToResourceName(net.MustParseIP("AA:1234::BBee:CC"))).To(Equal("aa-1234--bbee-cc"))
 	})
 	It("should convert an IPv4 Network to a resource compatible name", func() {
-		Expect(resources.IPNetToResourceName(net.MustParseNetwork("11.223.3.41/43"))).To(Equal("11-223-3-41-43"))
+		Expect(resources.IPNetToResourceName(net.MustParseNetwork("11.223.3.0/24"))).To(Equal("11-223-3-0-24"))
 	})
 	It("should convert an IPv4 Network to a resource compatible name", func() {
-		Expect(resources.IPNetToResourceName(net.MustParseNetwork("11.223.3.41"))).To(Equal("11-223-3-41-32"))
+		Expect(resources.IPNetToResourceName(net.MustParseNetwork("11.223.3.41/32"))).To(Equal("11-223-3-41-32"))
 	})
 	It("should convert an IPv6 Network to a resource compatible name", func() {
-		Expect(resources.IPNetToResourceName(net.MustParseNetwork("AA:1234::BBee:CC/2"))).To(Equal("aa-1234--bbee-cc-2"))
+		Expect(resources.IPNetToResourceName(net.MustParseNetwork("AA:1234::BBee:CC00/120"))).To(Equal("aa-1234--bbee-cc00-120"))
 	})
 	It("should convert an IPv6 Network to a resource compatible name", func() {
 		Expect(resources.IPNetToResourceName(net.MustParseNetwork("AA:1234:BBee::/120"))).To(Equal("aa-1234-bbee---120"))
 	})
 	It("should convert an IPv6 Network to a resource compatible name", func() {
-		Expect(resources.IPNetToResourceName(net.MustParseNetwork("AA:1234:BBee::0000"))).To(Equal("aa-1234-bbee--0000-128"))
+		Expect(resources.IPNetToResourceName(net.MustParseNetwork("aa:1234:bbee::/128"))).To(Equal("aa-1234-bbee---128"))
 	})
 
 	It("should convert a resource name to the equivalent IPv4 address", func() {
-		Expect(resources.ResourceNameToIP("11-223-3-441")).To(Equal(net.MustParseIP("11.223.3.41")))
+		i, err := resources.ResourceNameToIP("11-223-3-41")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*i).To(Equal(net.MustParseIP("11.223.3.41")))
 	})
 	It("should convert a resource name to the equivalent IPv6 address", func() {
-		Expect(resources.ResourceNameToIP("aa-1234--bbee-cc")).To(Equal(net.MustParseIP("AA:1234::BBee:CC")))
+		i, err := resources.ResourceNameToIP("aa-1234--bbee-cc")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*i).To(Equal(net.MustParseIP("AA:1234::BBee:CC")))
+	})
+	It("should not convert an invalid resource name to an IP address", func() {
+		_, err := resources.ResourceNameToIP("11-223-3-4a")
+		Expect(err).To(HaveOccurred())
 	})
 	It("should convert a resource name to the equivalent IPv4 Network", func() {
-		Expect(resources.ResourceNameToIPNet("11-223-3-41-43")).To(Equal(net.MustParseNetwork("11.223.3.41/43")))
+		n, err := resources.ResourceNameToIPNet("11-223-3-128-25")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*n).To(Equal(net.MustParseNetwork("11.223.3.128/25")))
 	})
 	It("should convert a resource name to the equivalent IPv4 Network", func() {
-		Expect(resources.ResourceNameToIPNet("11-223-3-41-32")).To(Equal(net.MustParseNetwork("11.223.3.41")))
+		n, err := resources.ResourceNameToIPNet("11-223-3-41-32")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*n).To(Equal(net.MustParseNetwork("11.223.3.41/32")))
 	})
 	It("should convert a resource name to the equivalent IPv6 Network", func() {
-		Expect(resources.ResourceNameToIPNet("aa-1234--bbee-cc-2")).To(Equal(net.MustParseNetwork("AA:1234::BBee:CC/2")))
+		n, err := resources.ResourceNameToIPNet("aa-1234--bbee-cc-2")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*n).To(Equal(net.MustParseNetwork("AA:1234::BBee:CC/2")))
 	})
 	It("should convert a resource name to the equivalent IPv6 Network", func() {
-		Expect(resources.ResourceNameToIPNet("aa-1234-bbee---120")).To(Equal(net.MustParseNetwork("AA:1234:BBee::/120")))
+		n, err := resources.ResourceNameToIPNet("aa-1234-bbee---120")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*n).To(Equal(net.MustParseNetwork("AA:1234:BBee::/120")))
 	})
 	It("should convert a resource name to the equivalent IPv6 Network", func() {
-		Expect(resources.ResourceNameToIPNet("aa-1234-bbee--0000-128")).To(Equal(net.MustParseNetwork("AA:1234:BBee::0000")))
+		n, err := resources.ResourceNameToIPNet("aa-1234-bbee---128")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*n).To(Equal(net.MustParseNetwork("AA:1234:BBee::/128")))
+	})
+	It("should not convert an invalid resource name to an IP network", func() {
+		_, err := resources.ResourceNameToIPNet("11--223--3-41")
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -26,8 +26,10 @@ import (
 )
 
 func NewNodeClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
-	return &nodeClient{
-		clientSet: c,
+	return &retryWrapper{
+		client: &nodeClient{
+			clientSet: c,
+		},
 	}
 }
 
@@ -58,7 +60,15 @@ func (c *nodeClient) Update(kvp *model.KVPair) (*model.KVPair, error) {
 
 	newNode, err := c.clientSet.Nodes().Update(node)
 	if err != nil {
-		return nil, K8sErrorToCalico(err, kvp.Key)
+		log.WithError(err).Info("Error updating Node resource")
+		err = K8sErrorToCalico(err, kvp.Key)
+
+		// If this is an update conflict and we didn't specify a revision in the
+		// request, indicate to the retryWrapper that we can retry the action.
+		if _, ok := err.(errors.ErrorResourceUpdateConflict); ok && kvp.Revision == nil {
+			err = retryError{err: err}
+		}
+		return nil, err
 	}
 
 	newCalicoNode, err := K8sNodeToCalico(newNode)

--- a/lib/backend/k8s/resources/nodebgppeer.go
+++ b/lib/backend/k8s/resources/nodebgppeer.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	perNodeBgpPeerAnnotationNamespace = "bgppeer.projectcalico.org"
+)
+
+func NewNodeBGPPeerClient(c *kubernetes.Clientset) K8sResourceClient {
+	return NewCustomK8sNodeResourceClient(CustomK8sNodeResourceClientConfig{
+		ClientSet:    c,
+		ResourceType: "NodeBGPPeer",
+		Converter:    NodeBGPPeerConverter{},
+		Namespace:    perNodeBgpPeerAnnotationNamespace,
+	})
+}
+
+// NodeBGPPeerConverter implements the CustomK8sNodeResourceConverter interface.
+type NodeBGPPeerConverter struct{}
+
+func (_ NodeBGPPeerConverter) ListInterfaceToNodeAndName(l model.ListInterface) (string, string, error) {
+	pl := l.(model.NodeBGPPeerListOptions)
+	if pl.PeerIP.IP == nil {
+		return pl.Nodename, "", nil
+	} else {
+		return pl.Nodename, IPToResourceName(pl.PeerIP), nil
+	}
+}
+
+func (_ NodeBGPPeerConverter) KeyToNodeAndName(k model.Key) (string, string, error) {
+	pk := k.(model.NodeBGPPeerKey)
+	return pk.Nodename, IPToResourceName(pk.PeerIP), nil
+}
+
+func (_ NodeBGPPeerConverter) NodeAndNameToKey(node, name string) (model.Key, error) {
+	ip, err := ResourceNameToIP(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return model.NodeBGPPeerKey{
+		Nodename: node,
+		PeerIP:   *ip,
+	}, nil
+}

--- a/lib/backend/k8s/resources/nodebgppeer_test.go
+++ b/lib/backend/k8s/resources/nodebgppeer_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Node BGP conversion methods", func() {
+
+	converter := resources.NodeBGPPeerConverter{}
+
+	It("should convert an empty ListInterface", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPPeerListOptions{},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal(""))
+		Expect(name).To(Equal(""))
+	})
+
+	It("should convert a List interface with a Node name only", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPPeerListOptions{
+				Nodename: "node",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("node"))
+		Expect(name).To(Equal(""))
+	})
+
+	It("should convert a List interface with a PeerIP only", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPPeerListOptions{
+				PeerIP: net.MustParseIP("1.2.3.4"),
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal(""))
+		Expect(name).To(Equal("1-2-3-4"))
+	})
+
+	It("should convert a List interface with node and PeerIP (IPv4)", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPPeerListOptions{
+				Nodename: "nodeX",
+				PeerIP:   net.MustParseIP("1.2.3.40"),
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("nodeX"))
+		Expect(name).To(Equal("1-2-3-40"))
+	})
+
+	It("should convert a List interface with node and PeerIP (IPv6)", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPPeerListOptions{
+				Nodename: "nodeX",
+				PeerIP:   net.MustParseIP("1::2:3:4"),
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("nodeX"))
+		Expect(name).To(Equal("1--2-3-4"))
+	})
+
+	It("should convert a Key with node and PeerIP (IPv4)", func() {
+		node, name, err := converter.KeyToNodeAndName(
+			model.NodeBGPPeerKey{
+				Nodename: "nodeY",
+				PeerIP:   net.MustParseIP("1.2.3.50"),
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("nodeY"))
+		Expect(name).To(Equal("1-2-3-50"))
+	})
+
+	It("should convert a Key with node and PeerIP (IPv6)", func() {
+		node, name, err := converter.KeyToNodeAndName(
+			model.NodeBGPPeerKey{
+				Nodename: "nodeY",
+				PeerIP:   net.MustParseIP("aa:ff::12"),
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("nodeY"))
+		Expect(name).To(Equal("aa-ff--12"))
+	})
+
+	It("should convert a valid node name and resource name to a Key (IPv4)", func() {
+		key, err := converter.NodeAndNameToKey("nodeA", "1-2-3-4")
+		Expect(err).To(BeNil())
+		Expect(key).To(Equal(model.NodeBGPPeerKey{
+			Nodename: "nodeA",
+			PeerIP:   net.MustParseIP("1.2.3.4"),
+		}))
+	})
+
+	It("should convert a valid node name and resource name to a Key (IPv6)", func() {
+		key, err := converter.NodeAndNameToKey("nodeB", "abcd-2000--30-40")
+		Expect(err).To(BeNil())
+		Expect(key).To(Equal(model.NodeBGPPeerKey{
+			Nodename: "nodeB",
+			PeerIP:   net.MustParseIP("abcd:2000::30:40"),
+		}))
+	})
+
+	It("should fail to convert a valid node name and invalid resource name to a Key", func() {
+		_, err := converter.NodeAndNameToKey("nodeB", "foobarbaz")
+		Expect(err).ToNot(BeNil())
+	})
+})

--- a/lib/backend/k8s/resources/resources_suite_test.go
+++ b/lib/backend/k8s/resources/resources_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestModel(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s resources Suite")
+}

--- a/lib/backend/k8s/resources/retrywrapper.go
+++ b/lib/backend/k8s/resources/retrywrapper.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	maxActionRetries = 5
+)
+
+// retryWrapper implements the K8sResourceClient interface and is used to wrap
+// another K8sResourceClient to provide retry functionality when the failure
+// case is of type retryError.
+type retryWrapper struct {
+	client K8sResourceClient
+}
+
+// retryError is an error type used to indicate to the retryWrapper to retry
+// a specific action.
+//
+// If the action is retried the max number of times, then the retryWrapper will
+// return the underlying error.
+type retryError struct {
+	err error
+}
+
+func (r retryError) Error() string {
+	return r.err.Error()
+}
+
+func (r *retryWrapper) Create(object *model.KVPair) (*model.KVPair, error) {
+	var kvp *model.KVPair
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if kvp, err = r.client.Create(object); err == nil {
+			// No error, exit returning the KVPair.
+			return kvp, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.WithField("Key", object.Key).Warning("Failed to create object: too many retries")
+	return nil, err.(retryError).err
+}
+
+func (r *retryWrapper) Update(object *model.KVPair) (*model.KVPair, error) {
+	var kvp *model.KVPair
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if kvp, err = r.client.Update(object); err == nil {
+			// No error, exit returning the KVPair.
+			return kvp, nil
+		} else if _, ok := err.(retryError); !ok {
+			return nil, err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.WithField("Key", object.Key).Error("Failed to update object: too many retries")
+	return nil, err.(retryError).err
+}
+
+func (r *retryWrapper) Apply(object *model.KVPair) (*model.KVPair, error) {
+	var kvp *model.KVPair
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if kvp, err = r.client.Apply(object); err == nil {
+			// No error, exit returning the KVPair.
+			return kvp, nil
+		} else if _, ok := err.(retryError); !ok {
+			return nil, err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.WithField("Key", object.Key).Error("Failed to apply object: too many retries")
+	return nil, err.(retryError).err
+}
+
+func (r *retryWrapper) Delete(object *model.KVPair) error {
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if err = r.client.Delete(object); err == nil {
+			// No error, exit returning the KVPair.
+			return nil
+		} else if _, ok := err.(retryError); !ok {
+			return err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.WithField("Key", object.Key).Error("Failed to delete object: too many retries")
+	return err.(retryError).err
+}
+
+func (r *retryWrapper) Get(key model.Key) (*model.KVPair, error) {
+	var kvp *model.KVPair
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if kvp, err = r.client.Get(key); err == nil {
+			// No error, exit returning the KVPair.
+			return kvp, nil
+		} else if _, ok := err.(retryError); !ok {
+			return nil, err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.WithField("Key", key).Error("Failed to get object: too many retries")
+	return nil, err.(retryError).err
+}
+
+func (r *retryWrapper) List(list model.ListInterface) ([]*model.KVPair, string, error) {
+	var rev string
+	var kvps []*model.KVPair
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if kvps, rev, err = r.client.List(list); err == nil {
+			// No error, exit returning the KVPair.
+			return kvps, rev, nil
+		} else if _, ok := err.(retryError); !ok {
+			return nil, "", err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.WithField("List", list).Error("Failed to list object: too many retries")
+	return nil, "", err.(retryError).err
+}
+
+func (r *retryWrapper) EnsureInitialized() error {
+	var err error
+	for i := 0; i < maxActionRetries; i++ {
+		if err = r.client.EnsureInitialized(); err == nil {
+			// No error, exit returning the KVPair.
+			return nil
+		} else if _, ok := err.(retryError); !ok {
+			return err
+		}
+	}
+
+	// Excessive retries.  Return the last error.
+	log.Error("Failed to initialize: too many retries")
+	return err.(retryError).err
+}

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -66,30 +66,30 @@ func (key NodeBGPPeerKey) String() string {
 }
 
 type NodeBGPPeerListOptions struct {
-	Hostname string
+	Nodename string
 	PeerIP   net.IP
 }
 
 func (options NodeBGPPeerListOptions) defaultPathRoot() string {
-	if options.Hostname == "" {
+	if options.Nodename == "" {
 		return "/calico/bgp/v1/host"
 	} else if options.PeerIP.IP == nil {
 		return fmt.Sprintf("/calico/bgp/v1/host/%s",
-			options.Hostname)
+			options.Nodename)
 	} else {
 		return fmt.Sprintf("/calico/bgp/v1/host/%s/peer_v%d/%s",
-			options.Hostname, options.PeerIP.Version(), options.PeerIP)
+			options.Nodename, options.PeerIP.Version(), options.PeerIP)
 	}
 }
 
 func (options NodeBGPPeerListOptions) KeyFromDefaultPath(path string) Key {
 	log.Debugf("Get BGPPeer key from %s", path)
-	hostname := ""
+	nodename := ""
 	peerIP := net.IP{}
 	ekeyb := []byte(path)
 
 	if r := matchHostBGPPeer.FindAllSubmatch(ekeyb, -1); len(r) == 1 {
-		hostname = string(r[0][1])
+		nodename = string(r[0][1])
 		if err := peerIP.UnmarshalText(r[0][2]); err != nil {
 			log.WithError(err).WithField("PeerIP", r[0][2]).Error("Error unmarshalling GlobalBGPPeer IP address")
 			return nil
@@ -103,11 +103,11 @@ func (options NodeBGPPeerListOptions) KeyFromDefaultPath(path string) Key {
 		log.Debugf("Didn't match peerIP %s != %s", options.PeerIP.String(), peerIP.String())
 		return nil
 	}
-	if options.Hostname != "" && hostname != options.Hostname {
-		log.Debugf("Didn't match hostname %s != %s", options.Hostname, hostname)
+	if options.Nodename != "" && nodename != options.Nodename {
+		log.Debugf("Didn't match hostname %s != %s", options.Nodename, nodename)
 		return nil
 	}
-	return NodeBGPPeerKey{PeerIP: peerIP, Nodename: hostname}
+	return NodeBGPPeerKey{PeerIP: peerIP, Nodename: nodename}
 }
 
 type GlobalBGPPeerKey struct {

--- a/lib/client/bgppeer.go
+++ b/lib/client/bgppeer.go
@@ -111,7 +111,7 @@ func (h *bgpPeers) convertMetadataToListInterface(m unversioned.ResourceMetadata
 	} else {
 		return model.NodeBGPPeerListOptions{
 			PeerIP:   pm.PeerIP,
-			Hostname: pm.Node,
+			Nodename: pm.Node,
 		}, nil
 	}
 }

--- a/lib/client/bgppeer_e2e_test.go
+++ b/lib/client/bgppeer_e2e_test.go
@@ -31,14 +31,16 @@ import (
 )
 
 // Perform CRUD operations on Global and Node-specific BGP Peer Resources.
-var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreEtcdV2, func(config api.CalicoAPIConfig) {
+var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, func(config api.CalicoAPIConfig) {
 
 	DescribeTable("BGPPeer e2e tests",
 		func(meta1, meta2 api.BGPPeerMetadata, spec1, spec2 api.BGPPeerSpec) {
-			c := testutils.CreateCleanClient(config)
+			c := testutils.CreateClient(config)
+			testutils.CleanBGPPeers(c)
+
 			By("Updating the BGPPeer before it is created")
 			_, outError := c.BGPPeers().Update(&api.BGPPeer{Metadata: meta1, Spec: spec1})
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: BGPPeer(node=node1, ip=10.0.0.1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: BGPPeer(node=127.0.0.1, ip=10.0.0.1)").Error()))
 
 			By("Creating a new BGPPeer with meta/spec1")
 			_, outError = c.BGPPeers().Create(&api.BGPPeer{Metadata: meta1, Spec: spec1})
@@ -88,7 +90,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreEtcdV
 
 			By("Getting BGPPeer (meta1) and checking for error")
 			_, outError = c.BGPPeers().Get(meta1)
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: BGPPeer(node=node1, ip=10.0.0.1)").Error()))
+			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: BGPPeer(node=127.0.0.1, ip=10.0.0.1)").Error()))
 
 			By("Deleting BGPPeer (meta2)")
 			outError1 = c.BGPPeers().Delete(meta2)
@@ -104,7 +106,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreEtcdV
 		Entry("Two fully populated BGPPeerSpecs",
 			api.BGPPeerMetadata{
 				Scope:  scope.Scope("node"),
-				Node:   "node1",
+				Node:   "127.0.0.1",
 				PeerIP: net.MustParseIP("10.0.0.1"),
 			},
 			api.BGPPeerMetadata{
@@ -122,7 +124,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreEtcdV
 		Entry("One fully populated BGPPeerSpec and another empty BGPPeerSpec",
 			api.BGPPeerMetadata{
 				Scope:  scope.Scope("node"),
-				Node:   "node1",
+				Node:   "127.0.0.1",
 				PeerIP: net.MustParseIP("10.0.0.1"),
 			},
 			api.BGPPeerMetadata{
@@ -136,7 +138,8 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreEtcdV
 	)
 
 	Describe("Checking operations perform data validation", func() {
-		c := testutils.CreateCleanClient(config)
+		c := testutils.CreateClient(config)
+		testutils.CleanBGPPeers(c)
 		var err error
 		valErrorType := reflect.TypeOf(cerrors.ErrorValidation{})
 
@@ -185,110 +188,4 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreEtcdV
 			Expect(err.(cerrors.ErrorValidation).ErroredFields[0].Name).To(Equal("Metadata.Node"))
 		})
 	})
-})
-
-// Perform CRUD operations on Global BGP Peer Resources
-var _ = testutils.E2eDatastoreDescribe("Global BGPPeer tests", testutils.DatastoreAll, func(config api.CalicoAPIConfig) {
-
-	DescribeTable("Global BGPPeer e2e tests",
-		func(meta1, meta2 api.BGPPeerMetadata, spec1, spec2 api.BGPPeerSpec) {
-			c := testutils.CreateClient(config)
-			testutils.CleanBGPPeers(c)
-
-			By("Updating the BGPPeer before it is created")
-			_, outError := c.BGPPeers().Update(&api.BGPPeer{Metadata: meta1, Spec: spec1})
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: BGPPeer(global, ip=10.0.0.1)").Error()))
-
-			By("Creating a new BGPPeer with meta/spec1")
-			_, outError = c.BGPPeers().Create(&api.BGPPeer{Metadata: meta1, Spec: spec1})
-			Expect(outError).NotTo(HaveOccurred())
-
-			By("Applying a new BGPPeer with meta/spec1")
-			_, outError = c.BGPPeers().Apply(&api.BGPPeer{Metadata: meta2, Spec: spec2})
-			Expect(outError).NotTo(HaveOccurred())
-
-			By("Getting BGPPeer (meta1) and comparing the output against spec1")
-			outBGPPeer1, outError1 := c.BGPPeers().Get(meta1)
-			Expect(outError1).NotTo(HaveOccurred())
-			Expect(outBGPPeer1.Spec).To(Equal(spec1))
-
-			By("Getting BGPPeer (meta2) and comparing the output against spec2")
-			outBGPPeer2, outError2 := c.BGPPeers().Get(meta2)
-			Expect(outError2).NotTo(HaveOccurred())
-			Expect(outBGPPeer2.Spec).To(Equal(spec2))
-
-			By("Updating BGPPeer (meta1) with spec2")
-			_, outError = c.BGPPeers().Update(&api.BGPPeer{Metadata: meta1, Spec: spec2})
-			Expect(outError).NotTo(HaveOccurred())
-
-			By("Getting BGPPeer (meta1) with spec2")
-			outBGPPeer1, outError1 = c.BGPPeers().Get(meta1)
-			Expect(outError1).NotTo(HaveOccurred())
-			Expect(outBGPPeer1.Spec).To(Equal(spec2))
-
-			By("Listing all the BGPPeers")
-			BGPPeerList, outError := c.BGPPeers().List(api.BGPPeerMetadata{})
-			Expect(outError).NotTo(HaveOccurred())
-
-			By("Getting both BGPPeers (meta1 and meta2) and checking they match list entries")
-			bp1, _ := c.BGPPeers().Get(meta1)
-			bp2, _ := c.BGPPeers().Get(meta2)
-			Expect(BGPPeerList.Items).To(ContainElement(*bp1))
-			Expect(BGPPeerList.Items).To(ContainElement(*bp2))
-
-			By("List BGPPeer (meta1) and compare")
-			BGPPeerList, outError = c.BGPPeers().List(meta1)
-			Expect(outError).NotTo(HaveOccurred())
-			Expect(BGPPeerList.Items[0]).To(Equal(*bp1))
-
-			By("Deleting BGPPeer (meta1)")
-			outError1 = c.BGPPeers().Delete(meta1)
-			Expect(outError1).NotTo(HaveOccurred())
-
-			By("Getting BGPPeer (meta1) and checking for error")
-			_, outError = c.BGPPeers().Get(meta1)
-			Expect(outError.Error()).To(Equal(errors.New("resource does not exist: BGPPeer(global, ip=10.0.0.1)").Error()))
-
-			By("Deleting BGPPeer (meta2)")
-			outError1 = c.BGPPeers().Delete(meta2)
-			Expect(outError1).NotTo(HaveOccurred())
-
-			By("Listing all Peers and checking for zero entries")
-			BGPPeerList, outError = c.BGPPeers().List(api.BGPPeerMetadata{})
-			Expect(outError).NotTo(HaveOccurred())
-			Expect(BGPPeerList.Items).To(HaveLen(0))
-		},
-
-		// Test 1: Pass two fully populated BGPPeerSpecs and expect the series of operations to succeed.
-		Entry("Two fully populated BGPPeerSpecs",
-			api.BGPPeerMetadata{
-				Scope:  scope.Scope("global"),
-				PeerIP: net.MustParseIP("10.0.0.1"),
-			},
-			api.BGPPeerMetadata{
-				Scope:  scope.Scope("global"),
-				PeerIP: net.MustParseIP("20.0.0.1"),
-			},
-			api.BGPPeerSpec{
-				ASNumber: numorstring.ASNumber(6512),
-			},
-			api.BGPPeerSpec{
-				ASNumber: numorstring.ASNumber(6511),
-			}),
-
-		// Test 2: Pass one fully populated BGPPeerSpec and another empty BGPPeerSpec and expect the series of operations to succeed.
-		Entry("One fully populated BGPPeerSpec and another empty BGPPeerSpec",
-			api.BGPPeerMetadata{
-				Scope:  scope.Scope("global"),
-				PeerIP: net.MustParseIP("10.0.0.1"),
-			},
-			api.BGPPeerMetadata{
-				Scope:  scope.Scope("global"),
-				PeerIP: net.MustParseIP("20.0.0.1"),
-			},
-			api.BGPPeerSpec{
-				ASNumber: numorstring.ASNumber(6512),
-			},
-			api.BGPPeerSpec{}),
-	)
 })

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -119,6 +119,7 @@ func (e ErrorInsufficientIdentifiers) Error() string {
 
 // Error indicating an atomic update attempt that failed due to a update conflict.
 type ErrorResourceUpdateConflict struct {
+	Err        error
 	Identifier interface{}
 }
 


### PR DESCRIPTION
Should be ready for initial review.

This PR adds generic per-node configuration (so it *could* if necessary be used for per-node Felix config and per-node BGP config).  Longer term the per-node stuff should disappear as we take a more selector based approach to configuration - but having the generic code should make it easier if we need to add the additional per-node config as an interim measure.

This also adds per-node BGP Peering and includes e2e tests that test against etcdv2 and kdd.

Note that due to the node being an oft-updated resource, it is necessary to retry the update if there is a conflict.  I added a generic retryWrapper to handle this.  Any resource where we are tacking Calico data onto another Kubernetes resource could benefit from being wrapped.