### PR TITLE
Fixed bug preventing specific profiles from being accessed from namespaces

### DIFF
--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -73,11 +73,18 @@ var _ = Describe("Test parsing strings", func() {
 		Expect(ns).To(Equal(""))
 	})
 
-	It("should parse profile names", func() {
-		name := "k8s_ns.default"
+	It("should parse valid profile names", func() {
+		name := "ns.projectcalico.org/default"
 		ns, err := c.parseProfileName(name)
 		Expect(ns).To(Equal("default"))
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not parse invalid profile names", func() {
+		name := "k8s_ns.default"
+		ns, err := c.parseProfileName(name)
+		Expect(err).To(HaveOccurred())
+		Expect(ns).To(Equal(""))
 	})
 })
 

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -471,6 +471,7 @@ func (c *KubeClient) listProfiles(l model.ProfileListOptions) ([]*model.KVPair, 
 	if l.Name != "" {
 		kvp, err := c.getProfile(model.ProfileKey{Name: l.Name})
 		if err != nil {
+			log.WithError(err).Debug("Error retrieving profile")
 			return []*model.KVPair{}, nil
 		}
 		return []*model.KVPair{kvp}, nil

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Performing a Get on the Profile and ensure no error in the Calico API", func() {
-			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("default.%s", ns.ObjectMeta.Name)})
+			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("ns.projectcalico.org/%s", ns.ObjectMeta.Name)})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -372,7 +372,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 
 		// Perform a Get and ensure no error in the Calico API.
 		By("getting a Profile", func() {
-			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("default.%s", ns.ObjectMeta.Name)})
+			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("ns.projectcalico.org/%s", ns.ObjectMeta.Name)})
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
## Description
Fixed a bug where the calico prefix on namespaces was being used to query for profiles (which was invalid). Also added a debug statement to display errors if there are issues with accessing profile information from the KDD.

Also fixed tests which were expecting to use etcd notation for namespaces against the kube client

Fixes https://github.com/projectcalico/calicoctl/issues/1658

## Tests
Set up Calico using the kubernetes datastore.
Ran ./calicoctl -l debug get profile ns.projectcalico.org/<name> and verified profile information was returned