### PR TITLE
Add per-node and global BGP config to KDD

### DIFF
--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -15,9 +15,11 @@
 package compat
 
 import (
+	"encoding/json"
 	goerrors "errors"
 
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
@@ -46,7 +48,7 @@ func (c *ModelAdaptor) EnsureCalicoNodeInitialized(node string) error {
 // Create an entry in the datastore.  This errors if the entry already exists.
 func (c *ModelAdaptor) Create(d *model.KVPair) (*model.KVPair, error) {
 	var err error
-	switch d.Key.(type) {
+	switch k := d.Key.(type) {
 	case model.ProfileKey:
 		t, l, r := ToTagsLabelsRules(d)
 		if t, err = c.client.Create(t); err != nil {
@@ -76,6 +78,14 @@ func (c *ModelAdaptor) Create(d *model.KVPair) (*model.KVPair, error) {
 		b, err := c.client.Create(d)
 		if err != nil {
 			return nil, err
+		}
+		d.Revision = b.Revision
+		return d, nil
+	case model.GlobalBGPConfigKey:
+		nd := toDatastoreGlobalBGPConfig(*d)
+		b, err := c.client.Create(nd)
+		if err != nil {
+			return nil, errors.UpdateErrorIdentifier(err, k)
 		}
 		d.Revision = b.Revision
 		return d, nil
@@ -121,6 +131,14 @@ func (c *ModelAdaptor) Update(d *model.KVPair) (*model.KVPair, error) {
 		}
 		d.Revision = b.Revision
 		return d, nil
+	case model.GlobalBGPConfigKey:
+		nd := toDatastoreGlobalBGPConfig(*d)
+		b, err := c.client.Update(nd)
+		if err != nil {
+			return nil, errors.UpdateErrorIdentifier(err, d.Key)
+		}
+		d.Revision = b.Revision
+		return d, nil
 	default:
 		return c.client.Update(d)
 	}
@@ -138,7 +156,7 @@ func (c *ModelAdaptor) Apply(d *model.KVPair) (*model.KVPair, error) {
 		} else if _, err := c.client.Apply(l); err != nil {
 			return nil, err
 		} else if _, err := c.client.Apply(r); err != nil {
-			return nil, err
+			return nil, errors.UpdateErrorIdentifier(err, d.Key)
 		} else {
 			d.Revision = t.Revision
 			return d, nil
@@ -163,6 +181,14 @@ func (c *ModelAdaptor) Apply(d *model.KVPair) (*model.KVPair, error) {
 		}
 		d.Revision = b.Revision
 		return d, nil
+	case model.GlobalBGPConfigKey:
+		nd := toDatastoreGlobalBGPConfig(*d)
+		b, err := c.client.Apply(nd)
+		if err != nil {
+			return nil, errors.UpdateErrorIdentifier(err, d.Key)
+		}
+		d.Revision = b.Revision
+		return d, nil
 	default:
 		return c.client.Apply(d)
 	}
@@ -181,6 +207,10 @@ func (c *ModelAdaptor) Delete(d *model.KVPair) error {
 			return err
 		}
 		return nil
+	case model.GlobalBGPConfigKey:
+		nd := toDatastoreGlobalBGPConfig(*d)
+		err := c.client.Delete(nd)
+		return errors.UpdateErrorIdentifier(err, d.Key)
 	default:
 		return c.client.Delete(d)
 	}
@@ -195,6 +225,13 @@ func (c *ModelAdaptor) Get(k model.Key) (*model.KVPair, error) {
 		return c.getNode(kt)
 	case model.BlockKey:
 		return c.getBlock(k)
+	case model.GlobalBGPConfigKey:
+		nk := toDatastoreGlobalBGPConfigKey(kt)
+		if kvp, err := c.client.Get(nk); err != nil {
+			return nil, errors.UpdateErrorIdentifier(err, k)
+		} else {
+			return fromDatastoreGlobalBGPConfig(*kvp), nil
+		}
 	default:
 		return c.client.Get(k)
 	}
@@ -208,6 +245,16 @@ func (c *ModelAdaptor) List(l model.ListInterface) ([]*model.KVPair, error) {
 		return c.listNodes(lt)
 	case model.BlockListOptions:
 		return c.listBlock(lt)
+	case model.GlobalBGPConfigListOptions:
+		nl := toDatastoreGlobalBGPConfigList(lt)
+		if kvps, err := c.client.List(nl); err != nil {
+			return nil, errors.UpdateErrorIdentifier(err, l)
+		} else {
+			for i, kvp := range kvps {
+				kvps[i] = fromDatastoreGlobalBGPConfig(*kvp)
+			}
+			return kvps, nil
+		}
 	default:
 		return c.client.List(l)
 	}
@@ -371,7 +418,7 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 	var strval string
 
 	// Fill in the Metadata specific part of the node configuration.
-	if component, err = c.client.Get(model.HostBGPConfigKey{Hostname: nk.Hostname, Name: "ip_addr_v4"}); err == nil {
+	if component, err = c.client.Get(model.NodeBGPConfigKey{Nodename: nk.Hostname, Name: "ip_addr_v4"}); err == nil {
 		strval = component.Value.(string)
 		if strval != "" {
 			nv.BGPIPv4Addr = &net.IP{}
@@ -385,7 +432,7 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
-	if component, err = c.client.Get(model.HostBGPConfigKey{Hostname: nk.Hostname, Name: "network_v4"}); err == nil {
+	if component, err = c.client.Get(model.NodeBGPConfigKey{Nodename: nk.Hostname, Name: "network_v4"}); err == nil {
 		strval = component.Value.(string)
 		if strval != "" {
 			_, nv.BGPIPv4Net, err = net.ParseCIDR(strval)
@@ -398,7 +445,7 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
-	if component, err = c.client.Get(model.HostBGPConfigKey{Hostname: nk.Hostname, Name: "ip_addr_v6"}); err == nil {
+	if component, err = c.client.Get(model.NodeBGPConfigKey{Nodename: nk.Hostname, Name: "ip_addr_v6"}); err == nil {
 		strval = component.Value.(string)
 		if strval != "" {
 			nv.BGPIPv6Addr = &net.IP{}
@@ -412,7 +459,7 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
-	if component, err = c.client.Get(model.HostBGPConfigKey{Hostname: nk.Hostname, Name: "network_v6"}); err == nil {
+	if component, err = c.client.Get(model.NodeBGPConfigKey{Nodename: nk.Hostname, Name: "network_v6"}); err == nil {
 		strval = component.Value.(string)
 		if strval != "" {
 			_, nv.BGPIPv6Net, err = net.ParseCIDR(strval)
@@ -425,7 +472,7 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
-	if component, err = c.client.Get(model.HostBGPConfigKey{Hostname: nk.Hostname, Name: "as_num"}); err == nil {
+	if component, err = c.client.Get(model.NodeBGPConfigKey{Nodename: nk.Hostname, Name: "as_num"}); err == nil {
 		strval = component.Value.(string)
 		if strval != "" {
 			asn, err := numorstring.ASNumberFromString(strval)
@@ -521,15 +568,15 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 	// Add the BGP IPv4 and IPv6 values - these are always present.
 	optional = []*model.KVPair{
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "ip_addr_v4",
 			},
 			Value: ipv4Str,
 		},
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "ip_addr_v6",
 			},
 			Value: ipv6Str,
@@ -553,48 +600,48 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 
 	if n.BGPASNumber != nil {
 		optional = append(optional, &model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "as_num",
 			},
 			Value: n.BGPASNumber.String(),
 		})
 	} else {
 		optional = append(optional, &model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "as_num",
 			},
 		})
 	}
 	if n.BGPIPv4Net != nil {
 		optional = append(optional, &model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "network_v4",
 			},
 			Value: n.BGPIPv4Net.String(),
 		})
 	} else {
 		optional = append(optional, &model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "network_v4",
 			},
 		})
 	}
 	if n.BGPIPv6Net != nil {
 		optional = append(optional, &model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "network_v6",
 			},
 			Value: n.BGPIPv6Net.String(),
 		})
 	} else {
 		optional = append(optional, &model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "network_v6",
 			},
 		})
@@ -617,36 +664,133 @@ func toNodeDeleteComponents(d *model.KVPair) (primary *model.KVPair, optional []
 			Key: model.HostIPKey{nk.Hostname},
 		},
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "ip_addr_v4",
 			},
 		},
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "ip_addr_v6",
 			},
 		},
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "as_num",
 			},
 		},
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "network_v4",
 			},
 		},
 		&model.KVPair{
-			Key: model.HostBGPConfigKey{
-				Hostname: nk.Hostname,
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
 				Name:     "network_v6",
 			},
 		},
 	}
 
 	return primary, optional
+}
+
+// toDatastoreGlobalBGPConfigKey modifies the Global BGP Config key to the one required by
+// the datastore (for back-compatibility).
+func toDatastoreGlobalBGPConfigKey(key model.GlobalBGPConfigKey) model.GlobalBGPConfigKey {
+	switch key.Name {
+	case "AsNumber":
+		key = model.GlobalBGPConfigKey{Name: "as_num"}
+	case "LogLevel":
+		key = model.GlobalBGPConfigKey{Name: "loglevel"}
+	case "NodeMeshEnabled":
+		key = model.GlobalBGPConfigKey{Name: "node_mesh"}
+	}
+	return key
+}
+
+// toDatastoreGlobalBGPConfigList modifies the Global BGP Config List interface to the one required by
+// the datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+func toDatastoreGlobalBGPConfigList(l model.GlobalBGPConfigListOptions) model.GlobalBGPConfigListOptions {
+	switch l.Name {
+	case "AsNumber":
+		l = model.GlobalBGPConfigListOptions{Name: "as_num"}
+	case "LogLevel":
+		l = model.GlobalBGPConfigListOptions{Name: "loglevel"}
+	case "NodeMeshEnabled":
+		l = model.GlobalBGPConfigListOptions{Name: "node_mesh"}
+	}
+	return l
+}
+
+// fromDatastoreGlobalBGPKey modifies the Global BGP Config key from the one required by
+// the datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+func fromDatastoreGlobalBGPKey(key model.GlobalBGPConfigKey) model.GlobalBGPConfigKey {
+	switch key.Name {
+	case "as_num":
+		key = model.GlobalBGPConfigKey{Name: "AsNumber"}
+	case "loglevel":
+		key = model.GlobalBGPConfigKey{Name: "LogLevel"}
+	case "node_mesh":
+		key = model.GlobalBGPConfigKey{Name: "NodeMeshEnabled"}
+	}
+	return key
+}
+
+// toDatastoreGlobalBGPConfig modifies the Global BGP Config KVPair to the format required in the
+// datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+func toDatastoreGlobalBGPConfig(d model.KVPair) *model.KVPair {
+	// Copy the KVPair, so we aren't modifying the original.
+	modifiedKey := toDatastoreGlobalBGPConfigKey(d.Key.(model.GlobalBGPConfigKey))
+	d.Key = modifiedKey
+
+	switch modifiedKey.Name {
+	case "node_mesh":
+		// In the datastore the node_mesh parm is expected to be a JSON object with an
+		// enabled field, but the new value just uses a boolean string.
+		if d.Value != nil {
+			enabled := d.Value.(string) == "true"
+			v, _ := json.Marshal(nodeToNodeMesh{Enabled: enabled})
+			d.Value = string(v)
+		}
+	}
+
+	return &d
+}
+
+
+// fromDatastoreGlobalBGPConfig modifies the Global BGP Config KVPair from the format required in the
+// datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+func fromDatastoreGlobalBGPConfig(d model.KVPair) *model.KVPair {
+	modifiedKey := fromDatastoreGlobalBGPKey(d.Key.(model.GlobalBGPConfigKey))
+	d.Key = modifiedKey
+
+	switch modifiedKey.Name {
+	case "NodeMeshEnabled":
+		// In the datastore the node_mesh parm is expected to be a JSON object with an
+		// enabled field, but the new value just uses a boolean string.
+		if d.Value != nil {
+			var n nodeToNodeMesh
+			if err := json.Unmarshal([]byte(d.Value.(string)), &n); err != nil {
+				log.Info("Error parsing node to node mesh")
+				v, _ := json.Marshal(false)
+				d.Value = string(v)
+			} else {
+				log.Info("Returning configured node to node mesh")
+				v, _ := json.Marshal(n.Enabled)
+				d.Value = string(v)
+			}
+		}
+	}
+
+	return &d
+}
+
+// nodeToNodeMesh is a struct containing whether node-to-node mesh is enabled.  It can be
+// JSON marshalled into the correct structure that is understood by the Calico BGP component.
+type nodeToNodeMesh struct {
+	Enabled bool `json:"enabled"`
 }

--- a/lib/backend/k8s/resources/globalbgpconfig.go
+++ b/lib/backend/k8s/resources/globalbgpconfig.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	GlobalBgpConfigResourceName = "GlobalBgpConfigs"
+	GlobalBgpConfigTPRName      = "global-bgp-config.projectcalico.org"
+)
+
+func NewGlobalBGPConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	return &customK8sResourceClient{
+		clientSet:       c,
+		restClient:      r,
+		name:            GlobalBgpConfigTPRName,
+		resource:        GlobalBgpConfigResourceName,
+		description:     "Calico Global BGP Configuration",
+		k8sResourceType: reflect.TypeOf(thirdparty.GlobalBgpConfig{}),
+		k8sListType:     reflect.TypeOf(thirdparty.GlobalBgpConfigList{}),
+		converter:       GlobalBgpConfigConverter{},
+	}
+}
+
+// GlobalBgpConfigConverter implements the K8sResourceConverter interface.
+type GlobalBgpConfigConverter struct {
+}
+
+func (_ GlobalBgpConfigConverter) ListInterfaceToKey(l model.ListInterface) model.Key {
+	if name := l.(model.GlobalBGPConfigListOptions).Name; name != "" {
+		return model.GlobalBGPConfigKey{Name: name}
+	}
+	return nil
+}
+
+func (_ GlobalBgpConfigConverter) KeyToName(k model.Key) (string, error) {
+	return strings.ToLower(k.(model.GlobalBGPConfigKey).Name), nil
+}
+
+func (_ GlobalBgpConfigConverter) NameToKey(name string) (model.Key, error) {
+	return nil, fmt.Errorf("Mapping of Name to Key is not possible for global BGP config")
+}
+
+func (c GlobalBgpConfigConverter) ToKVPair(r CustomK8sResource) (*model.KVPair, error) {
+	t := r.(*thirdparty.GlobalBgpConfig)
+	return &model.KVPair{
+		Key: model.GlobalBGPConfigKey{
+			Name: t.Spec.Name,
+		},
+		Value:    t.Spec.Value,
+		Revision: t.Metadata.ResourceVersion,
+	}, nil
+}
+
+func (c GlobalBgpConfigConverter) FromKVPair(kvp *model.KVPair) (CustomK8sResource, error) {
+	name, err := c.KeyToName(kvp.Key)
+	if err != nil {
+		return nil, err
+	}
+	tpr := thirdparty.GlobalBgpConfig{
+		Metadata: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: thirdparty.GlobalBgpConfigSpec{
+			Name:  kvp.Key.(model.GlobalBGPConfigKey).Name,
+			Value: kvp.Value.(string),
+		},
+	}
+	if kvp.Revision != nil {
+		tpr.Metadata.ResourceVersion = kvp.Revision.(string)
+	}
+	return &tpr, nil
+}

--- a/lib/backend/k8s/resources/globalbgpconfig_test.go
+++ b/lib/backend/k8s/resources/globalbgpconfig_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Global BGP config conversion methods", func() {
+
+	converter := resources.GlobalBgpConfigConverter{}
+
+	// Define some useful test data.
+	listIncomplete := model.GlobalBGPConfigListOptions{}
+
+	// Compatible set of list, key and name (used for Key to Name conversion)
+	list1 := model.GlobalBGPConfigListOptions{
+		Name: "AbCd",
+	}
+	key1 := model.GlobalBGPConfigKey{
+		Name: "AbCd",
+	}
+	name1 := "abcd"
+
+	// Compatible set of KVPair and Kubernetes Resource.
+	value1 := "test"
+	kvp1 := &model.KVPair{
+		Key:      key1,
+		Value:    value1,
+		Revision: "rv",
+	}
+	res1 := &thirdparty.GlobalBgpConfig{
+		Metadata: metav1.ObjectMeta{
+			Name:            name1,
+			ResourceVersion: "rv",
+		},
+		Spec: thirdparty.GlobalBgpConfigSpec{
+			Name:  key1.Name,
+			Value: value1,
+		},
+	}
+
+	It("should convert an incomplete ListInterface to no Key", func() {
+		Expect(converter.ListInterfaceToKey(listIncomplete)).To(BeNil())
+	})
+
+	It("should convert a qualified ListInterface to the equivalent Key", func() {
+		Expect(converter.ListInterfaceToKey(list1)).To(Equal(key1))
+	})
+
+	It("should convert a Key to the equivalent resource name", func() {
+		n, err := converter.KeyToName(key1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(name1))
+	})
+
+	It("should not convert a resource name to the equivalent Key - this is not possible due to case switching", func() {
+		_, err := converter.NameToKey("test")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should convert between a KVPair and the equivalent Kubernetes resource", func() {
+		r, err := converter.FromKVPair(kvp1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(r.GetObjectMeta().GetName()).To(Equal(res1.Metadata.Name))
+		Expect(r.GetObjectMeta().GetResourceVersion()).To(Equal(res1.Metadata.ResourceVersion))
+		Expect(r).To(BeAssignableToTypeOf(&thirdparty.GlobalBgpConfig{}))
+		Expect(r.(*thirdparty.GlobalBgpConfig).Spec).To(Equal(res1.Spec))
+	})
+
+	It("should convert between a Kubernetes resource and the equivalent KVPair", func() {
+		kvp, err := converter.ToKVPair(res1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvp.Key).To(Equal(kvp1.Key))
+		Expect(kvp.Revision).To(Equal(kvp1.Revision))
+		Expect(kvp.Value).To(BeAssignableToTypeOf(value1))
+		Expect(kvp.Value).To(Equal(kvp1.Value))
+	})
+})

--- a/lib/backend/k8s/resources/nodebgpconfig.go
+++ b/lib/backend/k8s/resources/nodebgpconfig.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	perNodeBgpConfigAnnotationNamespace = "config.bgp.projectcalico.org"
+)
+
+func NewNodeBGPConfigClient(c *kubernetes.Clientset) K8sResourceClient {
+	return NewCustomK8sNodeResourceClient(CustomK8sNodeResourceClientConfig{
+		ClientSet:    c,
+		ResourceType: "NodeBGPConfig",
+		Converter:    NodeBGPConfigConverter{},
+		Namespace:    perNodeBgpConfigAnnotationNamespace,
+	})
+}
+
+// NodeBGPConfigConverter implements the CustomK8sNodeResourceConverter interface.
+type NodeBGPConfigConverter struct{}
+
+func (_ NodeBGPConfigConverter) ListInterfaceToNodeAndName(l model.ListInterface) (string, string, error) {
+	pl := l.(model.NodeBGPConfigListOptions)
+	if pl.Name == "" {
+		return pl.Nodename, "", nil
+	} else {
+		return pl.Nodename, pl.Name, nil
+	}
+}
+
+func (_ NodeBGPConfigConverter) KeyToNodeAndName(k model.Key) (string, string, error) {
+	pk := k.(model.NodeBGPConfigKey)
+	return pk.Nodename, pk.Name, nil
+}
+
+func (_ NodeBGPConfigConverter) NodeAndNameToKey(node, name string) (model.Key, error) {
+	return model.NodeBGPConfigKey{
+		Nodename: node,
+		Name:     name,
+	}, nil
+}

--- a/lib/backend/k8s/resources/nodebgpconfig_test.go
+++ b/lib/backend/k8s/resources/nodebgpconfig_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Node BGP config conversion methods", func() {
+
+	converter := resources.NodeBGPConfigConverter{}
+
+	It("should convert an empty ListInterface", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPConfigListOptions{},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal(""))
+		Expect(name).To(Equal(""))
+	})
+
+	It("should convert a List interface with a Node name only", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPConfigListOptions{
+				Nodename: "node",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("node"))
+		Expect(name).To(Equal(""))
+	})
+
+	It("should convert a List interface with a ConfigIP only", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPConfigListOptions{
+				Name: "FooFoo",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal(""))
+		Expect(name).To(Equal("FooFoo"))
+	})
+
+	It("should convert a List interface with node and name", func() {
+		node, name, err := converter.ListInterfaceToNodeAndName(
+			model.NodeBGPConfigListOptions{
+				Nodename: "nodeX",
+				Name:     "FooBar",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("nodeX"))
+		Expect(name).To(Equal("FooBar"))
+	})
+
+	It("should convert a Key with node and name", func() {
+		node, name, err := converter.KeyToNodeAndName(
+			model.NodeBGPConfigKey{
+				Nodename: "nodeY",
+				Name:     "FooBaz",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(node).To(Equal("nodeY"))
+		Expect(name).To(Equal("FooBaz"))
+	})
+
+	It("should convert a valid node name and resource name to a Key (IPv4)", func() {
+		key, err := converter.NodeAndNameToKey("nodeA", "FooBaz")
+		Expect(err).To(BeNil())
+		Expect(key).To(Equal(model.NodeBGPConfigKey{
+			Nodename: "nodeA",
+			Name:     "FooBaz",
+		}))
+	})
+})

--- a/lib/backend/k8s/resources/nodebgppeer.go
+++ b/lib/backend/k8s/resources/nodebgppeer.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	perNodeBgpPeerAnnotationNamespace = "bgppeer.projectcalico.org"
+	perNodeBgpPeerAnnotationNamespace = "peer.bgp.projectcalico.org"
 )
 
 func NewNodeBGPPeerClient(c *kubernetes.Clientset) K8sResourceClient {

--- a/lib/backend/k8s/thirdparty/globalbgpconfig.go
+++ b/lib/backend/k8s/thirdparty/globalbgpconfig.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thirdparty
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type GlobalBgpConfigSpec struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type GlobalBgpConfig struct {
+	metav1.TypeMeta `json:",inline"`
+	Metadata        metav1.ObjectMeta `json:"metadata"`
+
+	Spec GlobalBgpConfigSpec `json:"spec"`
+}
+
+type GlobalBgpConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	Metadata        metav1.ListMeta `json:"metadata"`
+
+	Items []GlobalBgpConfig `json:"items"`
+}
+
+// Required to satisfy Object interface
+func (e *GlobalBgpConfig) GetObjectKind() schema.ObjectKind {
+	return &e.TypeMeta
+}
+
+// Required to satisfy ObjectMetaAccessor interface
+func (e *GlobalBgpConfig) GetObjectMeta() metav1.Object {
+	return &e.Metadata
+}
+
+// Required to satisfy Object interface
+func (el *GlobalBgpConfigList) GetObjectKind() schema.ObjectKind {
+	return &el.TypeMeta
+}
+
+// Required to satisfy ListMetaAccessor interface
+func (el *GlobalBgpConfigList) GetListMeta() metav1.List {
+	return &el.Metadata
+}
+
+// The code below is used only to work around a known problem with third-party
+// resources and ugorji. If/when these issues are resolved, the code below
+// should no longer be required.
+
+type GlobalBgpConfigListCopy GlobalBgpConfigList
+type GlobalBgpConfigCopy GlobalBgpConfig
+
+func (g *GlobalBgpConfig) UnmarshalJSON(data []byte) error {
+	tmp := GlobalBgpConfigCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := GlobalBgpConfig(tmp)
+	*g = tmp2
+	return nil
+}
+
+func (l *GlobalBgpConfigList) UnmarshalJSON(data []byte) error {
+	tmp := GlobalBgpConfigListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := GlobalBgpConfigList(tmp)
+	*l = tmp2
+	return nil
+}

--- a/lib/backend/model/felixconfig.go
+++ b/lib/backend/model/felixconfig.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/projectcalico/libcalico-go/lib/errors"
 )
 

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -135,7 +135,7 @@ func KeyToDefaultDeletePath(key Key) (string, error) {
 //
 // For example,
 // 	KeyToDefaultDeletePaths(WorkloadEndpointKey{
-//		Hostname: "h",
+//		Nodename: "h",
 //		OrchestratorID: "o",
 //		WorkloadID: "w",
 //		EndpointID: "e",

--- a/lib/client/bgppeer_e2e_test.go
+++ b/lib/client/bgppeer_e2e_test.go
@@ -35,8 +35,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 
 	DescribeTable("BGPPeer e2e tests",
 		func(meta1, meta2 api.BGPPeerMetadata, spec1, spec2 api.BGPPeerSpec) {
-			c := testutils.CreateClient(config)
-			testutils.CleanBGPPeers(c)
+			c := testutils.CreateCleanClient(config)
 
 			By("Updating the BGPPeer before it is created")
 			_, outError := c.BGPPeers().Update(&api.BGPPeer{Metadata: meta1, Spec: spec1})
@@ -138,8 +137,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 	)
 
 	Describe("Checking operations perform data validation", func() {
-		c := testutils.CreateClient(config)
-		testutils.CleanBGPPeers(c)
+		c := testutils.CreateCleanClient(config)
 		var err error
 		valErrorType := reflect.TypeOf(cerrors.ErrorValidation{})
 

--- a/lib/client/doc.go
+++ b/lib/client/doc.go
@@ -53,7 +53,7 @@ new HostEndpoints interface and call the appropriate methods on that interface. 
 	hostEndpoint, err := hostEndpoints.Create(&api.HostEndpoint{
 		Metadata: api.HostEndpointMetadata{
 			Name: "endpoint1",
-			Hostname: "hostname1",
+			Nodename: "hostname1",
 		},
 		Spec: api.HostEndpointSpec{
 			InterfaceName: "eth0"
@@ -66,7 +66,7 @@ new HostEndpoints interface and call the appropriate methods on that interface. 
 	hostEndpoint, err = hostEndpoints.Update(&api.HostEndpoint{
 		Metadata: api.HostEndpointMetadata{
 			Name: "endpoint1",
-			Hostname: "hostname1",
+			Nodename: "hostname1",
 		},
 		Spec: api.HostEndpointSpec{
 			InterfaceName: "eth0",
@@ -79,7 +79,7 @@ new HostEndpoints interface and call the appropriate methods on that interface. 
 	hostEndpoint, err = hostEndpoints.Apply(&api.HostEndpoint{
 		Metadata: api.HostEndpointMetadata{
 			Name: "endpoint1",
-			Hostname: "hostname1",
+			Nodename: "hostname1",
 		},
 		Spec: api.HostEndpointSpec{
 			InterfaceName: "eth1",
@@ -92,7 +92,7 @@ new HostEndpoints interface and call the appropriate methods on that interface. 
 	// unique identifiers does not exist.
 	hostEndpoint, err = hostEndpoints.Delete(api.HostEndpointMetadata{
 		Name: "endpoint1",
-		Hostname: "hostname1",
+		Nodename: "hostname1",
 	})
 
 	// Get a hostEndpoint.  All Get() methods return an error of type
@@ -100,7 +100,7 @@ new HostEndpoints interface and call the appropriate methods on that interface. 
 	// unique identifiers does not exist.
 	hostEndpoint, err = hostEndpoints.Get(api.HostEndpointMetadata{
 		Name: "endpoint1",
-		Hostname: "hostname1",
+		Nodename: "hostname1",
 	})
 
 	// List all hostEndpoints.  All List() methods take a (sub-)set of the resource

--- a/lib/client/ippool_e2e_test.go
+++ b/lib/client/ippool_e2e_test.go
@@ -54,8 +54,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool e2e tests", testutils.DatastoreAl
 
 	DescribeTable("IPPool e2e tests",
 		func(meta1, meta2 api.IPPoolMetadata, spec1, spec2 api.IPPoolSpec) {
-			c := testutils.CreateClient(apiConfig)
-			testutils.CleanIPPools(c)
+			c := testutils.CreateCleanClient(apiConfig)
 
 			By("Updating the pool before it is created")
 			_, outError := c.IPPools().Update(&api.IPPool{Metadata: meta1, Spec: spec1})
@@ -260,8 +259,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool e2e tests", testutils.DatastoreAl
 	)
 
 	Describe("Checking operations perform data validation", func() {
-		c := testutils.CreateClient(apiConfig)
-		testutils.CleanIPPools(c)
+		c := testutils.CreateCleanClient(apiConfig)
 
 		var err error
 		valErrorType := reflect.TypeOf(cerrors.ErrorValidation{})

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -126,3 +126,31 @@ type ErrorResourceUpdateConflict struct {
 func (e ErrorResourceUpdateConflict) Error() string {
 	return fmt.Sprintf("update conflict: '%s'", e.Identifier)
 }
+
+// UpdateErrorIdentifier modifies the supplied error to use the new resource
+// identifier.
+func UpdateErrorIdentifier(err error, id interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	switch e := err.(type) {
+	case ErrorDatastoreError:
+		e.Identifier = id
+		err = e
+	case ErrorResourceDoesNotExist:
+		e.Identifier = id
+		err = e
+	case ErrorOperationNotSupported:
+		e.Identifier = id
+		err = e
+	case ErrorResourceAlreadyExists:
+		e.Identifier = id
+		err = e
+	case ErrorResourceUpdateConflict:
+		e.Identifier = id
+		err = e
+	}
+	return err
+}
+


### PR DESCRIPTION
Adds per-node and global BGP config to KDD.   Most importantly the global BGP config option to enabled/disable the node mesh is present.

This PR includes some changes to the client and etcd code too:
Reason:
-  etcd exposes the BGP config parameters in an odd way:
  -  capitalization differs from the Felix "standard"
  -  the node-2-node mesh is a json blob rather than a single boolean value.

Changes:
-  Hide the etcd oddities in the compat driver - so on the KVPair interface we'll just define camelcase options AsNumber NodeMeshEnabled (this is what Felix uses, should we? ... or should I change AsNumber to ASNumber?) parameters.
-  compat module will convert these to the original as_num and node_mesh.
-  In addition, the NodeMeshEnabled will be exposed in the KVPair as a boolean string - in compat we'll convert this to the json blob.

This allows the KVPair interface to expose sensible config names and values with consistent format as used by Felix.  I think this is *only* used by etcd so I'm wondering if we should just be more explicit about that and do all conversion in that module.   

Converting KVPairs / Keys in the compat module is a bit of a PITA because error responses from the etcd driver will have the modified Key as the Identifier -- so that means we have to jump through hoops to adjust the Identifier in the error back to the original Key.  Nothing terrible, but a side effect of adding the identifier inforamation in the backend when it should really be handed by the client.  Anyhoo.