### PR TITLE
Expose per-node listing as external interfaces

### DIFF
--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -761,7 +761,6 @@ func toDatastoreGlobalBGPConfig(d model.KVPair) *model.KVPair {
 	return &d
 }
 
-
 // fromDatastoreGlobalBGPConfig modifies the Global BGP Config KVPair from the format required in the
 // datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
 func fromDatastoreGlobalBGPConfig(d model.KVPair) *model.KVPair {

--- a/lib/backend/k8s/resources/client.go
+++ b/lib/backend/k8s/resources/client.go
@@ -16,6 +16,8 @@ package resources
 
 import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	apiv1 "k8s.io/client-go/pkg/api/v1"
 )
 
 // K8sResourceClient is the interface to the k8s datastore for CRUD operations
@@ -62,4 +64,12 @@ type K8sResourceClient interface {
 	// EnsureInitialized ensures that the backend is initialized
 	// any ready to be used.
 	EnsureInitialized() error
+}
+
+// K8sNodeResourceClient extends the K8sResourceClient to add a helper method to
+// extract resources from the supplied K8s Node.  This convenience interface is
+// expected to be removed in a future libcalico-go release.
+type K8sNodeResourceClient interface {
+	K8sResourceClient
+	ExtractResourcesFromNode(node *apiv1.Node) ([]*model.KVPair, error)
 }

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -64,7 +64,7 @@ func (c *nodeClient) Update(kvp *model.KVPair) (*model.KVPair, error) {
 		err = K8sErrorToCalico(err, kvp.Key)
 
 		// If this is an update conflict and we didn't specify a revision in the
-		// request, indicate to the retryWrapper that we can retry the action.
+		// request, indicate to the nodeRetryWrapper that we can retry the action.
 		if _, ok := err.(errors.ErrorResourceUpdateConflict); ok && kvp.Revision == nil {
 			err = retryError{err: err}
 		}

--- a/lib/backend/k8s/resources/nodebgpconfig.go
+++ b/lib/backend/k8s/resources/nodebgpconfig.go
@@ -24,7 +24,7 @@ const (
 	perNodeBgpConfigAnnotationNamespace = "config.bgp.projectcalico.org"
 )
 
-func NewNodeBGPConfigClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewNodeBGPConfigClient(c *kubernetes.Clientset) K8sNodeResourceClient {
 	return NewCustomK8sNodeResourceClient(CustomK8sNodeResourceClientConfig{
 		ClientSet:    c,
 		ResourceType: "NodeBGPConfig",

--- a/lib/backend/k8s/resources/nodebgppeer.go
+++ b/lib/backend/k8s/resources/nodebgppeer.go
@@ -24,7 +24,7 @@ const (
 	perNodeBgpPeerAnnotationNamespace = "peer.bgp.projectcalico.org"
 )
 
-func NewNodeBGPPeerClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewNodeBGPPeerClient(c *kubernetes.Clientset) K8sNodeResourceClient {
 	return NewCustomK8sNodeResourceClient(CustomK8sNodeResourceClientConfig{
 		ClientSet:    c,
 		ResourceType: "NodeBGPPeer",

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -153,4 +153,3 @@ func UpdateErrorIdentifier(err error, id interface{}) error {
 	}
 	return err
 }
-


### PR DESCRIPTION
Add the ability to query the per-node resources from the k8s Node config.

Whilst generic, the primary focus of this is for simplifying the processing in confd.

