### PR TITLE
Support annotations on Policy objects

### DIFF
--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -48,6 +48,9 @@ type PolicyMetadata struct {
 
 	// The name of the selector-based security policy.
 	Name string `json:"name,omitempty" validate:"omitempty,namespacedname"`
+
+	// Arbitrary key-value information to be used by clients.
+	Annotations map[string]string `json:"annotations,omitempty" validate:"omitempty"`
 }
 
 // PolicySpec contains the specification for a selector-based security Policy resource.

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -89,11 +89,12 @@ func (options PolicyListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type Policy struct {
-	Order         *float64 `json:"order,omitempty" validate:"omitempty"`
-	InboundRules  []Rule   `json:"inbound_rules,omitempty" validate:"omitempty,dive"`
-	OutboundRules []Rule   `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
-	Selector      string   `json:"selector" validate:"selector"`
-	DoNotTrack    bool     `json:"untracked,omitempty"`
+	Order         *float64          `json:"order,omitempty" validate:"omitempty"`
+	InboundRules  []Rule            `json:"inbound_rules,omitempty" validate:"omitempty,dive"`
+	OutboundRules []Rule            `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
+	Selector      string            `json:"selector" validate:"selector"`
+	DoNotTrack    bool              `json:"untracked,omitempty"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
 }
 
 func (p Policy) String() string {

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -111,6 +111,9 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			Expect(outError1).NotTo(HaveOccurred())
 			Expect(outPolicy1.Spec).To(Equal(spec2))
 
+			// Assert the Metadata for policy with meta1 matches meta1.
+			Expect(outPolicy1.Metadata).To(Equal(meta1))
+
 			By("List all the policies and compare")
 
 			// Get a list of policiess.
@@ -179,7 +182,7 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 
 		// Test 1: Pass two fully populated PolicySpecs and expect the series of operations to succeed.
 		Entry("Two fully populated PolicySpecs",
-			api.PolicyMetadata{Name: "policy-1/with.foo"},
+			api.PolicyMetadata{Name: "policy-1/with.foo", Annotations: map[string]string{"key": "value"}},
 			api.PolicyMetadata{Name: "policy.1"},
 			policySpec1,
 			policySpec2,

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -50,6 +50,7 @@ func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPa
 			OutboundRules: RulesAPIToBackend(ap.Spec.EgressRules),
 			Selector:      ap.Spec.Selector,
 			DoNotTrack:    ap.Spec.DoNotTrack,
+			Annotations:   ap.Metadata.Annotations,
 		},
 	}
 
@@ -64,6 +65,7 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 
 	ap := api.NewPolicy()
 	ap.Metadata.Name = bk.Name
+	ap.Metadata.Annotations = bp.Annotations
 	ap.Spec.Order = bp.Order
 	ap.Spec.IngressRules = RulesBackendToAPI(bp.InboundRules)
 	ap.Spec.EgressRules = RulesBackendToAPI(bp.OutboundRules)


### PR DESCRIPTION
## Description

Enhance Policy objects so that they support annotations.  This will be useful for clients who want to track extra metadata about a given resource, or e.g. keep track of resources they specifically have created.

Once this is approved, I intend to do the same for Profiles.

## Todos
- [x] Tests
- [x] Documentation

