### PR TITLE
Added generic validations to ensure the existence of lookup fields

### DIFF
--- a/lib/api/bgppeer.go
+++ b/lib/api/bgppeer.go
@@ -33,6 +33,10 @@ type BGPPeer struct {
 	Spec BGPPeerSpec `json:"spec,omitempty"`
 }
 
+func (t BGPPeer) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // BGPPeerMetadata contains the metadata for a BGPPeer resource.
 type BGPPeerMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -27,6 +27,10 @@ type HostEndpoint struct {
 	Spec     HostEndpointSpec     `json:"spec,omitempty"`
 }
 
+func (t HostEndpoint) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // HostEndpointMetadata contains the Metadata for a HostEndpoint resource.
 type HostEndpointMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/api/ippool.go
+++ b/lib/api/ippool.go
@@ -33,6 +33,10 @@ type IPPool struct {
 	Spec     IPPoolSpec     `json:"spec,omitempty"`
 }
 
+func (t IPPool) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // IPPoolMetadata contains the metadata for an IP pool resource.
 type IPPoolMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -40,6 +40,10 @@ type Node struct {
 	Spec     NodeSpec     `json:"spec,omitempty"`
 }
 
+func (t Node) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // NodeMetadata contains the metadata for a Calico Node resource.
 type NodeMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -42,6 +42,10 @@ type Policy struct {
 	Spec     PolicySpec     `json:"spec,omitempty"`
 }
 
+func (t Policy) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // PolicyMetadata contains the metadata for a selector-based security Policy resource.
 type PolicyMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/api/profile.go
+++ b/lib/api/profile.go
@@ -29,6 +29,10 @@ type Profile struct {
 	Spec     ProfileSpec     `json:"spec,omitempty"`
 }
 
+func (t Profile) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // ProfileMetadata contains the metadata for a security Profile resource.
 type ProfileMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/api/unversioned/types.go
+++ b/lib/api/unversioned/types.go
@@ -19,6 +19,12 @@ type Resource interface {
 	GetTypeMetadata() TypeMetadata
 }
 
+// All singular resources (all resources not including lists) implement the ResourceObject interface
+type ResourceObject interface {
+	Resource
+	GetResourceMetadata() ResourceMetadata
+}
+
 // Define available versions.
 var (
 	// `apiVersion` in the config yaml files

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -27,6 +27,10 @@ type WorkloadEndpoint struct {
 	Spec     WorkloadEndpointSpec     `json:"spec,omitempty"`
 }
 
+func (t WorkloadEndpoint) GetResourceMetadata() unversioned.ResourceMetadata {
+	return t.Metadata
+}
+
 // WorkloadEndpointMetadata contains the Metadata for a WorkloadEndpoint resource.
 type WorkloadEndpointMetadata struct {
 	unversioned.ObjectMetadata

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -221,9 +221,13 @@ type conversionHelper interface {
 // Untyped interface for creating an API object.  This is called from the
 // typed interface.  This assumes a 1:1 mapping between the API resource and
 // the backend object.
-func (c *Client) create(apiObject unversioned.Resource, helper conversionHelper) error {
+func (c *Client) create(apiObject unversioned.ResourceObject, helper conversionHelper) error {
 	// Validate the supplied data before writing to the datastore.
 	if err := validator.Validate(apiObject); err != nil {
+		return err
+	}
+
+	if err := validator.ValidateMetadataIDsAssigned(apiObject.GetResourceMetadata()); err != nil {
 		return err
 	}
 
@@ -238,9 +242,13 @@ func (c *Client) create(apiObject unversioned.Resource, helper conversionHelper)
 
 // Untyped interface for updating an API object.  This is called from the
 // typed interface.
-func (c *Client) update(apiObject unversioned.Resource, helper conversionHelper) error {
+func (c *Client) update(apiObject unversioned.ResourceObject, helper conversionHelper) error {
 	// Validate the supplied data before writing to the datastore.
 	if err := validator.Validate(apiObject); err != nil {
+		return err
+	}
+
+	if err := validator.ValidateMetadataIDsAssigned(apiObject.GetResourceMetadata()); err != nil {
 		return err
 	}
 
@@ -255,9 +263,13 @@ func (c *Client) update(apiObject unversioned.Resource, helper conversionHelper)
 
 // Untyped interface for applying an API object.  This is called from the
 // typed interface.
-func (c *Client) apply(apiObject unversioned.Resource, helper conversionHelper) error {
+func (c *Client) apply(apiObject unversioned.ResourceObject, helper conversionHelper) error {
 	// Validate the supplied data before writing to the datastore.
 	if err := validator.Validate(apiObject); err != nil {
+		return err
+	}
+
+	if err := validator.ValidateMetadataIDsAssigned(apiObject.GetResourceMetadata()); err != nil {
 		return err
 	}
 
@@ -278,6 +290,10 @@ func (c *Client) delete(metadata unversioned.ResourceMetadata, helper conversion
 		return err
 	}
 
+	if err := validator.ValidateMetadataIDsAssigned(metadata); err != nil {
+		return err
+	}
+
 	// Convert the Metadata to a Key and combine with the Metadata revision to create
 	// a KVPair for the delete operation.  At the moment only the WorkloadEndpoint Get
 	// operations fills in the revision information.
@@ -295,6 +311,10 @@ func (c *Client) delete(metadata unversioned.ResourceMetadata, helper conversion
 func (c *Client) get(metadata unversioned.ResourceMetadata, helper conversionHelper) (unversioned.Resource, error) {
 	// Validate the supplied Metadata.
 	if err := validator.Validate(metadata); err != nil {
+		return nil, err
+	}
+
+	if err := validator.ValidateMetadataIDsAssigned(metadata); err != nil {
 		return nil, err
 	}
 

--- a/lib/validator/common.go
+++ b/lib/validator/common.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/scope"
+)
+
+// ValidateMetadataIDsAssigned is used to validate the Resource Metadata to ensure
+// that all necessary fields are present.
+// This is split from the validator so it can be used conditionally
+// depending on the command.
+func ValidateMetadataIDsAssigned(rm unversioned.ResourceMetadata) error {
+	switch metadata := rm.(type) {
+	case api.BGPPeerMetadata:
+		if metadata.PeerIP.IP == nil {
+			return errors.ErrorInsufficientIdentifiers{Name: "peerIP"}
+		}
+		if metadata.Scope == scope.Undefined ||
+			(metadata.Scope != scope.Global && metadata.Node == "") {
+			return errors.ErrorInsufficientIdentifiers{Name: "node"}
+		}
+	case api.HostEndpointMetadata:
+		if metadata.Node == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "node"}
+		}
+		if metadata.Name == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "name"}
+		}
+	case api.IPPoolMetadata:
+		if metadata.CIDR.IP == nil {
+			return errors.ErrorInsufficientIdentifiers{Name: "cidr"}
+		}
+	case api.NodeMetadata:
+		if metadata.Name == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "name"}
+		}
+	case api.PolicyMetadata:
+		if metadata.Name == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "name"}
+		}
+	case api.ProfileMetadata:
+		if metadata.Name == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "name"}
+		}
+	case api.WorkloadEndpointMetadata:
+		if metadata.Node == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "node"}
+		}
+		if metadata.Orchestrator == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "orchestrator"}
+		}
+		if metadata.Workload == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "workload"}
+		}
+		if metadata.Name == "" {
+			return errors.ErrorInsufficientIdentifiers{Name: "name"}
+		}
+	default:
+		log.Fatal(fmt.Errorf("Unexpected resource metadata: %s", metadata))
+	}
+
+	return nil
+}

--- a/lib/validator/common_test.go
+++ b/lib/validator/common_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/validator"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/scope"
+)
+
+var _ = Describe("Test ValidateMetadataIDsAssigned function", func() {
+	Context("with BGP Peer Metadata", func() {
+		var bgppeer *api.BGPPeer
+		testIP := net.ParseIP("192.168.22.33")
+		BeforeEach(func() {
+			bgppeer = api.NewBGPPeer()
+			bgppeer.Metadata.Scope = scope.Global
+		})
+		It("should fail if missing a Peer IP", func() {
+			err := validator.ValidateMetadataIDsAssigned(bgppeer.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail if it is Node scope without specifying a node", func() {
+			bgppeer.Metadata.PeerIP = *testIP
+			bgppeer.Metadata.Scope = scope.Node
+			err := validator.ValidateMetadataIDsAssigned(bgppeer.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail if the scope is Undefined", func() {
+			bgppeer.Metadata.PeerIP = *testIP
+			bgppeer.Metadata.Scope = scope.Undefined
+			err := validator.ValidateMetadataIDsAssigned(bgppeer.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass if the Global scope is specified, even if a node is not specified", func() {
+			bgppeer.Metadata.PeerIP = *testIP
+			err := validator.ValidateMetadataIDsAssigned(bgppeer.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with Host Endpoint Metadata", func() {
+		var hep *api.HostEndpoint
+		BeforeEach(func() {
+			hep = api.NewHostEndpoint()
+			hep.Metadata.Name = "testHostEndpoint"
+			hep.Metadata.Node = "testNode"
+		})
+		It("should fail if missing a Name", func() {
+			hep.Metadata.Name = ""
+			err := validator.ValidateMetadataIDsAssigned(hep.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail if missing a Node name", func() {
+			hep.Metadata.Node = ""
+			err := validator.ValidateMetadataIDsAssigned(hep.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass with both a Name and Node", func() {
+			err := validator.ValidateMetadataIDsAssigned(hep.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with IP Pool Metadata", func() {
+		var ipp *api.IPPool
+		_, testCIDR, _ := net.ParseCIDR("192.168.22.0/24")
+		BeforeEach(func() {
+			ipp = api.NewIPPool()
+		})
+		It("should fail if missing CIDR", func() {
+			err := validator.ValidateMetadataIDsAssigned(ipp.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass with a CIDR", func() {
+			ipp.Metadata.CIDR = *testCIDR
+			err := validator.ValidateMetadataIDsAssigned(ipp.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with Node Metadata", func() {
+		var node *api.Node
+		BeforeEach(func() {
+			node = api.NewNode()
+			node.Metadata.Name = "testNode"
+		})
+		It("should fail if missing Name", func() {
+			node.Metadata.Name = ""
+			err := validator.ValidateMetadataIDsAssigned(node.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass with a Name specified", func() {
+			err := validator.ValidateMetadataIDsAssigned(node.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with Policy Metadata", func() {
+		var policy *api.Policy
+		BeforeEach(func() {
+			policy = api.NewPolicy()
+			policy.Metadata.Name = "testPolicy"
+		})
+		It("should fail if missing Name", func() {
+			policy.Metadata.Name = ""
+			err := validator.ValidateMetadataIDsAssigned(policy.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass with a Name specified", func() {
+			err := validator.ValidateMetadataIDsAssigned(policy.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with Profile Metadata", func() {
+		var profile *api.Profile
+		BeforeEach(func() {
+			profile = api.NewProfile()
+			profile.Metadata.Name = "testProfile"
+		})
+		It("should fail if missing Name", func() {
+			profile.Metadata.Name = ""
+			err := validator.ValidateMetadataIDsAssigned(profile.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass with a Name specified", func() {
+			err := validator.ValidateMetadataIDsAssigned(profile.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with Workload Endpoint Metadata", func() {
+		var wep *api.WorkloadEndpoint
+		BeforeEach(func() {
+			wep = api.NewWorkloadEndpoint()
+			wep.Metadata.Node = "testNode"
+			wep.Metadata.Orchestrator = "testOrchestrator"
+			wep.Metadata.Workload = "testWorkload"
+			wep.Metadata.Name = "testWorkloadEndpoint"
+		})
+		It("should fail if missing Node", func() {
+			wep.Metadata.Node = ""
+			err := validator.ValidateMetadataIDsAssigned(wep.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail if missing Orchestrator", func() {
+			wep.Metadata.Orchestrator = ""
+			err := validator.ValidateMetadataIDsAssigned(wep.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail if missing Workload", func() {
+			wep.Metadata.Workload = ""
+			err := validator.ValidateMetadataIDsAssigned(wep.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail if missing Name", func() {
+			wep.Metadata.Name = ""
+			err := validator.ValidateMetadataIDsAssigned(wep.Metadata)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should pass with a Node, Orchestrator, Workload, and Name specified", func() {
+			err := validator.ValidateMetadataIDsAssigned(wep.Metadata)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Description
Validations for missing fields were complete on etcd but incomplete for KDD.  Wrote generic validations for Key fields that are used for looking up resources that will run no matter what datastore is used.

Addresses #65 .  Validations seem to have already been removed on spec data where it is unnecessary so those changes are not covered in this PR.

## Testing
- Wrote/Ran Unit Tests
- Ran manual tests against KDD and observed the correct errors were thrown

