### PR TITLE
Moving over logutils from Felix

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: a35ac70c3f24336298e49395f16d469f35bc7105e3d9df129c3ba948eb74132f
-updated: 2017-06-04T10:01:10.429693073-07:00
+hash: 5a8e8f9d19d935d4247638b121a09ff5f53411623f01251a0cf9029fd7693b7b
+updated: 2017-07-14T11:08:47.961492803-07:00
 imports:
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/coreos/etcd
   version: 17ae440991da3bdb2df4309936dd2074f66ec394
   subpackages:
@@ -45,6 +49,11 @@ imports:
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/protobuf
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  subpackages:
+  - jsonpb
+  - proto
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/howeyc/gopass
@@ -61,6 +70,10 @@ imports:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
   subpackages:
@@ -90,6 +103,24 @@ imports:
   version: 955bc3e451ef0c9df8b9113bf2e341139cdafab2
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 3e6a7635bac6573d43f49f97b47eb9bda195dba8
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  subpackages:
+  - xfs
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,5 +43,7 @@ import:
   - rest
   - tools/cache
   - tools/clientcmd
+- package: github.com/prometheus/client_golang
+  version: ^0.8.0
 testImport:
 - package: github.com/onsi/gomega

--- a/lib/logutils/logutils.go
+++ b/lib/logutils/logutils.go
@@ -1,0 +1,436 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// FilterLevels returns all the logrus.Level values <= maxLevel.
+func FilterLevels(maxLevel log.Level) []log.Level {
+	levels := []log.Level{}
+	for _, l := range log.AllLevels {
+		if l <= maxLevel {
+			levels = append(levels, l)
+		}
+	}
+	return levels
+}
+
+// Formatter is our custom log formatter designed to balance ease of machine processing
+// with human readability.  Logs include:
+//    - A sortable millisecond timestamp, for scanning and correlating logs
+//    - The log level, near the beginning of the line, to aid in visual scanning
+//    - The PID of the process to make it easier to spot log discontinuities (If
+//      you are looking at two disjoint chunks of log, were they written by the
+//      same process?  Was there a restart in-between?)
+//    - The file name and line number, as essential context
+//    - The message!
+//    - Log fields appended in sorted order
+//
+// Example:
+//    2017-01-05 09:17:48.238 [INFO][85386] endpoint_mgr.go 434: Skipping configuration of
+//    interface because it is oper down. ifaceName="cali1234"
+type Formatter struct{}
+
+func (f *Formatter) Format(entry *log.Entry) ([]byte, error) {
+	stamp := entry.Time.Format("2006-01-02 15:04:05.000")
+	levelStr := strings.ToUpper(entry.Level.String())
+	pid := os.Getpid()
+	fileName := entry.Data["__file__"]
+	lineNo := entry.Data["__line__"]
+	b := entry.Buffer
+	if b == nil {
+		b = &bytes.Buffer{}
+	}
+	fmt.Fprintf(b, "%s [%s][%d] %v %v: %v", stamp, levelStr, pid, fileName, lineNo, entry.Message)
+	appendKVsAndNewLine(b, entry)
+	return b.Bytes(), nil
+}
+
+// FormatForSyslog formats logs in a way tailored for syslog.  It avoids logging information that is
+// already included in the syslog metadata such as timestamp and PID.  The log level _is_ included
+// because syslog doesn't seem to output it by default and it's very useful.
+//
+//    INFO endpoint_mgr.go 434: Skipping configuration of interface because it is oper down.
+//    ifaceName="cali1234"
+func FormatForSyslog(entry *log.Entry) string {
+	levelStr := strings.ToUpper(entry.Level.String())
+	fileName := entry.Data["__file__"]
+	lineNo := entry.Data["__line__"]
+	b := entry.Buffer
+	if b == nil {
+		b = &bytes.Buffer{}
+	}
+	fmt.Fprintf(b, "%s %v %v: %v", levelStr, fileName, lineNo, entry.Message)
+	appendKVsAndNewLine(b, entry)
+	return b.String()
+}
+
+// appendKeysAndNewLine writes the KV pairs attached to the entry to the end of the buffer, then
+// finishes it with a newline.
+func appendKVsAndNewLine(b *bytes.Buffer, entry *log.Entry) {
+	// Sort the keys for consistent output.
+	var keys []string = make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if key == "__file__" || key == "__line__" {
+			continue
+		}
+		var value interface{} = entry.Data[key]
+		var stringifiedValue string
+		if err, ok := value.(error); ok {
+			stringifiedValue = err.Error()
+		} else if stringer, ok := value.(fmt.Stringer); ok {
+			// Trust the value's String() method.
+			stringifiedValue = stringer.String()
+		} else {
+			// No string method, use %#v to get a more thorough dump.
+			fmt.Fprintf(b, " %v=%#v", key, value)
+			continue
+		}
+		b.WriteByte(' ')
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(stringifiedValue)
+	}
+	b.WriteByte('\n')
+}
+
+// NullWriter is a dummy writer that always succeeds and does nothing.
+type NullWriter struct{}
+
+func (w *NullWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+type ContextHook struct {
+}
+
+func (hook ContextHook) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (hook ContextHook) Fire(entry *log.Entry) error {
+	pcs := make([]uintptr, 4)
+	if numEntries := runtime.Callers(6, pcs); numEntries > 0 {
+		frames := runtime.CallersFrames(pcs)
+		for {
+			frame, more := frames.Next()
+			if !shouldSkipFrame(frame) {
+				entry.Data["__file__"] = path.Base(frame.File)
+				entry.Data["__line__"] = frame.Line
+				break
+			}
+			if !more {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func shouldSkipFrame(frame runtime.Frame) bool {
+	return strings.LastIndex(frame.File, "exported.go") > 0 ||
+		strings.LastIndex(frame.File, "logger.go") > 0 ||
+		strings.LastIndex(frame.File, "entry.go") > 0
+}
+
+type QueuedLog struct {
+	Level         log.Level
+	Message       []byte
+	SyslogMessage string
+	WaitGroup     *sync.WaitGroup
+
+	// NumSkippedLogs contains the number of logs that were skipped before this log (due to the
+	// queue being blocked).
+	NumSkippedLogs uint
+}
+
+func (ql QueuedLog) OnLogDone() {
+	if ql.WaitGroup != nil {
+		ql.WaitGroup.Done()
+	}
+}
+
+func NewStreamDestination(
+	level log.Level,
+	writer io.Writer,
+	c chan QueuedLog,
+	disableLogDropping bool,
+	counter prometheus.Counter,
+) *Destination {
+	return &Destination{
+		Level:   level,
+		channel: c,
+		writeLog: func(ql QueuedLog) error {
+			if ql.NumSkippedLogs > 0 {
+				fmt.Fprintf(writer, "... dropped %d logs ...\n",
+					ql.NumSkippedLogs)
+			}
+			_, err := writer.Write(ql.Message)
+			return err
+		},
+		disableLogDropping: disableLogDropping,
+		counter:            counter,
+	}
+}
+
+func NewSyslogDestination(
+	level log.Level,
+	writer syslogWriter,
+	c chan QueuedLog,
+	disableLogDropping bool,
+	counter prometheus.Counter,
+) *Destination {
+	return &Destination{
+		Level:   level,
+		channel: c,
+		writeLog: func(ql QueuedLog) error {
+			if ql.NumSkippedLogs > 0 {
+				writer.Warning(fmt.Sprintf("... dropped %d logs ...\n",
+					ql.NumSkippedLogs))
+			}
+			err := writeToSyslog(writer, ql)
+			return err
+		},
+		disableLogDropping: disableLogDropping,
+		counter:            counter,
+	}
+}
+
+type Destination struct {
+	// Level is the minimum level that a log must have to be logged to this destination.
+	Level log.Level
+	// Channel is the channel used to queue logs to the background worker thread.  Public for
+	// test purposes.
+	channel chan QueuedLog
+	// WriteLog is the function to actually make a log.  The constructors above initialise this
+	// with a function that logs to a stream or to syslog, for example.
+	writeLog func(ql QueuedLog) error
+
+	// DisableLogDropping forces all logs to be queued even if the destination blocks.
+	disableLogDropping bool
+
+	// Lock protects the numDroppedLogs count.
+	lock           sync.Mutex
+	numDroppedLogs uint
+
+	// Counter is the prometheus counter for logged errors that this destination will increment
+	counter prometheus.Counter
+}
+
+// Send sends a log to the background thread.  It returns true on success or false if the channel
+// is blocked.
+func (d *Destination) Send(ql QueuedLog) (ok bool) {
+	if d.disableLogDropping {
+		d.channel <- ql
+		ok = true
+		return
+	}
+
+	d.lock.Lock()
+	ql.NumSkippedLogs = d.numDroppedLogs
+	select {
+	case d.channel <- ql:
+		// We've now queued reporting of all the dropped logs, zero out the counter.
+		d.numDroppedLogs = 0
+		ok = true
+	default:
+		d.numDroppedLogs += 1
+	}
+	d.lock.Unlock()
+	return
+}
+
+// LoopWritingLogs is intended to be used as a background go-routine.  It processes the logs from
+// the channel.
+func (d *Destination) LoopWritingLogs() {
+	for ql := range d.channel {
+		err := d.writeLog(ql)
+		if err != nil {
+			// Increment the number of errors while trying to write to log
+			d.counter.Inc()
+			fmt.Fprintf(os.Stderr, "Failed to write to log: %v", err)
+		}
+		ql.OnLogDone()
+	}
+}
+
+// Close closes the channel to the background goroutine.  This is only safe to call if you know
+// that the destination is no longer in use by any thread; in tests, for example.
+func (d *Destination) Close() {
+	close(d.channel)
+}
+
+type syslogWriter interface {
+	Debug(m string) error
+	Info(m string) error
+	Warning(m string) error
+	Err(m string) error
+	Crit(m string) error
+}
+
+func writeToSyslog(writer syslogWriter, ql QueuedLog) error {
+	switch ql.Level {
+	case log.PanicLevel:
+		return writer.Crit(ql.SyslogMessage)
+	case log.FatalLevel:
+		return writer.Crit(ql.SyslogMessage)
+	case log.ErrorLevel:
+		return writer.Err(ql.SyslogMessage)
+	case log.WarnLevel:
+		return writer.Warning(ql.SyslogMessage)
+	case log.InfoLevel:
+		return writer.Info(ql.SyslogMessage)
+	case log.DebugLevel:
+		return writer.Debug(ql.SyslogMessage)
+	default:
+		return nil
+	}
+}
+
+// BackgroundHook is a logrus Hook that (synchronously) formats each log and sends it to one or more
+// Destinations for writing ona background thread.  It supports filtering destinations on
+// individual log levels.  We write logs from background threads so that blocking of the output
+// stream doesn't block the mainline code.  Up to a point, we queue logs for writing, then we start
+// dropping logs.
+type BackgroundHook struct {
+	levels      []log.Level
+	syslogLevel log.Level
+
+	destinations []*Destination
+
+	// Our own copy of the dropped logs counter, used for logging out when we drop logs.
+	// Must be read/updated using atomic.XXX.
+	numDroppedLogs  uint64
+	lastDropLogTime time.Duration
+
+	// Counter
+	counter prometheus.Counter
+}
+
+func NewBackgroundHook(levels []log.Level, syslogLevel log.Level, destinations []*Destination, counter prometheus.Counter) *BackgroundHook {
+	return &BackgroundHook{
+		destinations: destinations,
+		levels:       levels,
+		syslogLevel:  syslogLevel,
+		counter:      counter,
+	}
+}
+
+func (h *BackgroundHook) Levels() []log.Level {
+	return h.levels
+}
+
+func (h *BackgroundHook) Fire(entry *log.Entry) (err error) {
+	var serialized []byte
+	if serialized, err = entry.Logger.Formatter.Format(entry); err != nil {
+		return
+	}
+
+	// entry's buffer will be reused after we return but we're about to send the message over
+	// a channel so we need to take a copy.
+	bufCopy := make([]byte, len(serialized))
+	copy(bufCopy, serialized)
+	if entry.Buffer != nil {
+		entry.Buffer.Truncate(0)
+	}
+
+	ql := QueuedLog{
+		Level:   entry.Level,
+		Message: bufCopy,
+	}
+
+	if entry.Level <= h.syslogLevel {
+		// syslog gets its own log string since our default log string duplicates a lot of
+		// syslog metadata.  Only calculate that string if it's needed.
+		ql.SyslogMessage = FormatForSyslog(entry)
+	}
+
+	var waitGroup *sync.WaitGroup
+	if entry.Level <= log.FatalLevel {
+		// This is a panic or a fatal log so we'll get killed immediately after we return.
+		// Use a wait group to wait for the log to get written.
+		waitGroup = &sync.WaitGroup{}
+		ql.WaitGroup = waitGroup
+	}
+
+	for _, dest := range h.destinations {
+		if ql.Level > dest.Level {
+			continue
+		}
+		if waitGroup != nil {
+			// Thread safety: we must call add before we send the wait group over the
+			// channel (or the background thread could be scheduled immediately and
+			// call Done() before we call Add()).  Since we don't know if the send
+			// will succeed that leads to the need to call Done() on the 'default:'
+			// branch below to correctly pair Add()/Done() calls.
+			waitGroup.Add(1)
+		}
+
+		if ok := dest.Send(ql); !ok {
+			// Background thread isn't keeping up.  Drop the log and count how many
+			// we've dropped.
+			if waitGroup != nil {
+				waitGroup.Done()
+			}
+			// Increment the number of dropped logs
+			dest.counter.Inc()
+		}
+	}
+	if waitGroup != nil {
+		waitGroup.Wait()
+	}
+	return
+}
+
+func (h *BackgroundHook) Start() {
+	for _, d := range h.destinations {
+		go d.LoopWritingLogs()
+	}
+}
+
+// safeParseLogLevel parses a string version of a logrus log level, defaulting
+// to logrus.PanicLevel on failure.
+func SafeParseLogLevel(logLevel string) log.Level {
+	defaultedLevel := log.PanicLevel
+	if logLevel != "" {
+		parsedLevel, err := log.ParseLevel(logLevel)
+		if err == nil {
+			defaultedLevel = parsedLevel
+		} else {
+			log.WithField("raw level", logLevel).Warn(
+				"Invalid log level, defaulting to panic")
+		}
+	}
+	return defaultedLevel
+}

--- a/lib/logutils/logutils_suite_test.go
+++ b/lib/logutils/logutils_suite_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/projectcalico/libcalico-go/lib/logutils"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+	logrus.AddHook(&logutils.ContextHook{})
+	logrus.SetFormatter(&logutils.Formatter{})
+}
+
+func TestLogutils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Logutils Suite", []Reporter{junitReporter})
+}

--- a/lib/logutils/logutils_test.go
+++ b/lib/logutils/logutils_test.go
@@ -1,0 +1,412 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutils_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+
+	. "github.com/projectcalico/libcalico-go/lib/logutils"
+)
+
+var (
+	testCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_counter",
+		Help: "Number of logs dropped and errors encountered while logging.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(testCounter)
+}
+
+var _ = Describe("Logutils", func() {
+	ourHook := ContextHook{}
+	var savedWriter io.Writer
+	var buf *bytes.Buffer
+	BeforeEach(func() {
+		log.AddHook(ourHook)
+		savedWriter = log.StandardLogger().Out
+		buf = &bytes.Buffer{}
+		log.StandardLogger().Out = buf
+	})
+	AfterEach(func() {
+		log.StandardLogger().Out = savedWriter
+		levelHooks := log.StandardLogger().Hooks
+		for level, hooks := range levelHooks {
+			j := 0
+			for _, hook := range hooks {
+				if hook == ourHook {
+					continue
+				}
+				hooks[j] = hook
+				j += 1
+			}
+			levelHooks[level] = hooks[:len(hooks)-1]
+		}
+	})
+
+	It("Should add correct file when invoked via log.Info", func() {
+		log.Info("Test log")
+		Expect(buf.String()).To(ContainSubstring("logutils_test.go"))
+	})
+	It("Should add correct file when invoked via Logger.Info", func() {
+		log.StandardLogger().Info("Test log")
+		Expect(buf.String()).To(ContainSubstring("logutils_test.go"))
+	})
+	It("Should add correct file when invoked via log.WithField(...).Info", func() {
+		log.WithField("foo", "bar").Info("Test log")
+		Expect(buf.String()).To(ContainSubstring("logutils_test.go"))
+	})
+})
+
+var _ = DescribeTable("Formatter",
+	func(entry log.Entry, expectedLog, expectedSyslog string) {
+		f := &Formatter{}
+		out, err := f.Format(&entry)
+		Expect(err).NotTo(HaveOccurred())
+		expectedLog = strings.Replace(expectedLog, "<PID>", fmt.Sprintf("%v", os.Getpid()), 1)
+		Expect(string(out)).To(Equal(expectedLog))
+		Expect(FormatForSyslog(&entry)).To(Equal(expectedSyslog))
+	},
+	Entry("Empty", log.Entry{},
+		"0001-01-01 00:00:00.000 [PANIC][<PID>] <nil> <nil>: \n",
+		"PANIC <nil> <nil>: \n"),
+	Entry("Basic",
+		log.Entry{
+			Level: log.InfoLevel,
+			Time:  theTime(),
+			Data: log.Fields{
+				"__file__": "foo.go",
+				"__line__": 123,
+			},
+			Message: "The answer is 42.",
+		},
+		"2017-03-15 11:22:33.123 [INFO][<PID>] foo.go 123: The answer is 42.\n",
+		"INFO foo.go 123: The answer is 42.\n",
+	),
+	Entry("With fields",
+		log.Entry{
+			Level: log.WarnLevel,
+			Time:  theTime(),
+			Data: log.Fields{
+				"__file__": "foo.go",
+				"__line__": 123,
+				"a":        10,
+				"b":        "foobar",
+				"c":        theTime(),
+				"err":      errors.New("an error"),
+			},
+			Message: "The answer is 42.",
+		},
+		"2017-03-15 11:22:33.123 [WARNING][<PID>] foo.go 123: The answer is 42. a=10 b=\"foobar\" c=2017-03-15 11:22:33.123 +0000 UTC err=an error\n",
+		"WARNING foo.go 123: The answer is 42. a=10 b=\"foobar\" c=2017-03-15 11:22:33.123 +0000 UTC err=an error\n"),
+)
+
+func theTime() time.Time {
+	theTime, err := time.Parse("2006-01-02 15:04:05.000", "2017-03-15 11:22:33.123")
+	if err != nil {
+		panic(err)
+	}
+	return theTime
+}
+
+var (
+	message1 = QueuedLog{
+		Level:         log.InfoLevel,
+		Message:       []byte("Message"),
+		SyslogMessage: "syslog message",
+	}
+	message2 = QueuedLog{
+		Level:         log.InfoLevel,
+		Message:       []byte("Message2"),
+		SyslogMessage: "syslog message2",
+	}
+)
+
+var _ = Describe("Stream Destination", func() {
+	var s *Destination
+	var c chan QueuedLog
+	var pr *io.PipeReader
+	var pw *io.PipeWriter
+
+	BeforeEach(func() {
+		c = make(chan QueuedLog, 1)
+		pr, pw = io.Pipe()
+		s = NewStreamDestination(
+			log.InfoLevel,
+			pw,
+			c,
+			false,
+			testCounter,
+		)
+	})
+
+	It("should report dropped logs to background thread", func() {
+		// First message should be queued on the channel.
+		ok := s.Send(message1)
+		Expect(ok).To(BeTrue())
+		// Second message should be dropped.  Drop counter should now be 1.
+		ok = s.Send(message1)
+		Expect(ok).To(BeFalse())
+		// Drain the queue.
+		Expect(<-c).To(Equal(message1))
+		// Third message should go through.
+		ok = s.Send(message1)
+		Expect(ok).To(BeTrue())
+		Expect(<-c).To(Equal(QueuedLog{
+			Level:          log.InfoLevel,
+			Message:        []byte("Message"),
+			SyslogMessage:  "syslog message",
+			NumSkippedLogs: 1,
+		}))
+		// Subsequent messages should have the counter reset.
+		ok = s.Send(message1)
+		Expect(ok).To(BeTrue())
+		Expect(<-c).To(Equal(message1))
+	})
+
+	Describe("with dropping disabled", func() {
+		BeforeEach(func() {
+			c = make(chan QueuedLog, 1)
+			pr, pw = io.Pipe()
+			s = NewStreamDestination(
+				log.InfoLevel,
+				pw,
+				c,
+				true,
+				testCounter,
+			)
+		})
+
+		It("should not drop logs", func() {
+			// First message should be queued on the channel.
+			ok := s.Send(message1)
+			Expect(ok).To(BeTrue())
+			done := make(chan bool)
+			go func() {
+				// Second message should block so we do it in a goroutine.
+				ok = s.Send(message2)
+				done <- ok
+			}()
+			// Sleep so that the background goroutine has a chance to try to write.
+			time.Sleep(10 * time.Millisecond)
+			// Drain the queue.
+			Expect(<-c).To(Equal(message1))
+			Expect(<-c).To(Equal(message2))
+			Expect(<-done).To(BeTrue())
+		})
+	})
+
+	Describe("With real background thread", func() {
+		BeforeEach(func() {
+			go s.LoopWritingLogs()
+		})
+		AfterEach(func() {
+			s.Close()
+		})
+
+		readNextMsg := func() string {
+			b := make([]byte, 1024)
+			n, err := pr.Read(b)
+			Expect(err).NotTo(HaveOccurred())
+			return string(b[:n])
+		}
+
+		It("should write a log (no WaitGroup)", func() {
+			ok := s.Send(message1)
+			Expect(ok).To(BeTrue())
+			msg := readNextMsg()
+			Expect(msg).To(Equal("Message"))
+		})
+
+		It("should log number of dropped logs", func() {
+			// Bypass Send() so we can force NumSkippedLogs to be non-zero.
+			c <- QueuedLog{
+				Level:          log.InfoLevel,
+				Message:        []byte("Message"),
+				SyslogMessage:  "syslog message",
+				NumSkippedLogs: 1,
+			}
+			msg := readNextMsg()
+			Expect(msg).To(Equal("... dropped 1 logs ...\n"))
+			msg = readNextMsg()
+			Expect(msg).To(Equal("Message"))
+		})
+
+		It("should trigger WaitGroup", func() {
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			c <- QueuedLog{
+				Level:         log.InfoLevel,
+				Message:       []byte("Message"),
+				SyslogMessage: "syslog message",
+				WaitGroup:     wg,
+			}
+			b := make([]byte, 1024)
+			n, err := pr.Read(b)
+			wg.Wait()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b[:n])).To(Equal("Message"))
+		})
+	})
+})
+
+var _ = Describe("Syslog Destination", func() {
+	var s *Destination
+	var c chan QueuedLog
+	var pr *io.PipeReader
+	var pw *io.PipeWriter
+
+	BeforeEach(func() {
+		c = make(chan QueuedLog, 1)
+		pr, pw = io.Pipe()
+		s = NewSyslogDestination(
+			log.InfoLevel,
+			(*mockSyslogWriter)(pw),
+			c,
+			false,
+			testCounter,
+		)
+	})
+
+	Describe("with dropping disabled", func() {
+		BeforeEach(func() {
+			s = NewSyslogDestination(
+				log.InfoLevel,
+				(*mockSyslogWriter)(pw),
+				c,
+				true,
+				testCounter,
+			)
+		})
+
+		It("should not drop logs", func() {
+			// First message should be queued on the channel.
+			ok := s.Send(message1)
+			Expect(ok).To(BeTrue())
+			done := make(chan bool)
+			go func() {
+				// Second message should block so we do it in a goroutine.
+				ok = s.Send(message2)
+				done <- ok
+			}()
+			// Sleep so that the background goroutine has a chance to try to write.
+			time.Sleep(10 * time.Millisecond)
+			// Drain the queue.
+			Expect(<-c).To(Equal(message1))
+			Expect(<-c).To(Equal(message2))
+			Expect(<-done).To(BeTrue())
+		})
+	})
+
+	Describe("With real background thread", func() {
+		BeforeEach(func() {
+			go s.LoopWritingLogs()
+		})
+		AfterEach(func() {
+			s.Close()
+		})
+
+		readNextMsg := func() string {
+			b := make([]byte, 1024)
+			n, err := pr.Read(b)
+			Expect(err).NotTo(HaveOccurred())
+			return string(b[:n])
+		}
+
+		defineLogLevelTest := func(level log.Level, levelName string) {
+			It("should write a log (no WaitGroup) level "+levelName, func() {
+				ql := message1
+				ql.Level = level
+				ok := s.Send(ql)
+				Expect(ok).To(BeTrue())
+				msg := readNextMsg()
+				Expect(msg).To(Equal(levelName + " syslog message"))
+			})
+		}
+		defineLogLevelTest(log.InfoLevel, "INFO")
+		defineLogLevelTest(log.WarnLevel, "WARNING")
+		defineLogLevelTest(log.DebugLevel, "DEBUG")
+		defineLogLevelTest(log.ErrorLevel, "ERROR")
+		defineLogLevelTest(log.FatalLevel, "CRITICAL")
+		defineLogLevelTest(log.PanicLevel, "CRITICAL")
+
+		It("should log number of dropped logs", func() {
+			// Bypass Send() so we can force NumSkippedLogs to be non-zero.
+			c <- QueuedLog{
+				Level:          log.InfoLevel,
+				Message:        []byte("Message"),
+				SyslogMessage:  "syslog message",
+				NumSkippedLogs: 1,
+			}
+			msg := readNextMsg()
+			Expect(msg).To(Equal("WARNING ... dropped 1 logs ...\n"))
+			msg = readNextMsg()
+			Expect(msg).To(Equal("INFO syslog message"))
+		})
+
+		It("should trigger WaitGroup", func() {
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			c <- QueuedLog{
+				Level:         log.InfoLevel,
+				Message:       []byte("Message"),
+				SyslogMessage: "syslog message",
+				WaitGroup:     wg,
+			}
+			b := make([]byte, 1024)
+			n, err := pr.Read(b)
+			wg.Wait()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b[:n])).To(Equal("INFO syslog message"))
+		})
+	})
+})
+
+type mockSyslogWriter io.PipeWriter
+
+func (s *mockSyslogWriter) Debug(m string) error {
+	_, err := fmt.Fprintf((*io.PipeWriter)(s), "DEBUG %s", m)
+	return err
+}
+func (s *mockSyslogWriter) Info(m string) error {
+	_, err := fmt.Fprintf((*io.PipeWriter)(s), "INFO %s", m)
+	return err
+}
+func (s *mockSyslogWriter) Warning(m string) error {
+	_, err := fmt.Fprintf((*io.PipeWriter)(s), "WARNING %s", m)
+	return err
+}
+func (s *mockSyslogWriter) Err(m string) error {
+	_, err := fmt.Fprintf((*io.PipeWriter)(s), "ERROR %s", m)
+	return err
+}
+func (s *mockSyslogWriter) Crit(m string) error {
+	_, err := fmt.Fprintf((*io.PipeWriter)(s), "CRITICAL %s", m)
+	return err
+}


### PR DESCRIPTION
## Description
Moving logutils functions out of Felix and into libcalico-go.  This will allow other repos to use the same log formatting that Felix does and will make logs more consistent.

## Todos
- [x] Testing

## Release note
```release-note
None required
```
