### PR TITLE
Add pre-DNAT flag to Policy resource

### DIFF
--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -102,6 +102,9 @@ type PolicySpec struct {
 	// this policy are applied before any data plane connection tracking, and packets allowed by
 	// this policy are marked as not to be tracked.
 	DoNotTrack bool `json:"doNotTrack,omitempty"`
+
+	// PreDNAT indicates to apply the rules in this policy before any DNAT.
+	PreDNAT bool `json:"preDNAT,omitempty"`
 }
 
 // NewPolicy creates a new (zeroed) Policy struct with the TypeMetadata initialised to the current

--- a/lib/backend/k8s/resources/systemnetworkpolicies_test.go
+++ b/lib/backend/k8s/resources/systemnetworkpolicies_test.go
@@ -100,6 +100,41 @@ var _ = Describe("System Network Policies conversion methods", func() {
 		},
 	}
 
+	Context("with pre-DNAT flag", func() {
+
+		BeforeEach(func() {
+			kvp1.Value.(*model.Policy).DoNotTrack = false
+			kvp1.Value.(*model.Policy).PreDNAT = true
+			res1.Spec.DoNotTrack = false
+			res1.Spec.PreDNAT = true
+		})
+
+		AfterEach(func() {
+			kvp1.Value.(*model.Policy).DoNotTrack = true
+			kvp1.Value.(*model.Policy).PreDNAT = false
+			res1.Spec.DoNotTrack = true
+			res1.Spec.PreDNAT = false
+		})
+
+		It("should convert between a KVPair and the equivalent Kubernetes resource", func() {
+			r, err := converter.FromKVPair(kvp1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r.GetObjectMeta().GetName()).To(Equal(res1.Metadata.Name))
+			Expect(r.GetObjectMeta().GetResourceVersion()).To(Equal(res1.Metadata.ResourceVersion))
+			Expect(r).To(BeAssignableToTypeOf(&thirdparty.SystemNetworkPolicy{}))
+			Expect(r.(*thirdparty.SystemNetworkPolicy).Spec).To(Equal(res1.Spec))
+		})
+
+		It("should convert between a Kuberenetes resource and the equivalent KVPair", func() {
+			kvp, err := converter.ToKVPair(res1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kvp.Key).To(Equal(kvp1.Key))
+			Expect(kvp.Revision).To(Equal(kvp1.Revision))
+			Expect(kvp.Value).To(BeAssignableToTypeOf(&model.Policy{}))
+			Expect(kvp.Value).To(Equal(kvp1.Value))
+		})
+	})
+
 	It("should convert an incomplete ListInterface to no Key", func() {
 		Expect(converter.ListInterfaceToKey(listIncomplete)).To(BeNil())
 	})

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -95,6 +95,7 @@ type Policy struct {
 	Selector      string            `json:"selector" validate:"selector"`
 	DoNotTrack    bool              `json:"untracked,omitempty"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
+	PreDNAT       bool              `json:"pre_dnat,omitempty"`
 }
 
 func (p Policy) String() string {
@@ -114,5 +115,6 @@ func (p Policy) String() string {
 	}
 	parts = append(parts, fmt.Sprintf("outbound:%v", strings.Join(outRules, ";")))
 	parts = append(parts, fmt.Sprintf("untracked:%v", p.DoNotTrack))
+	parts = append(parts, fmt.Sprintf("pre_dnat:%v", p.PreDNAT))
 	return strings.Join(parts, ",")
 }

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -80,6 +80,23 @@ var policySpec2AfterRead = api.PolicySpec{
 	DoNotTrack:   true,
 }
 
+var policySpec3 = api.PolicySpec{
+	Order:        &order2,
+	IngressRules: []api.Rule{testutils.InRule2, testutils.InRule1},
+	EgressRules:  []api.Rule{testutils.EgressRule2, testutils.EgressRule1},
+	Selector:     "thing2 == 'value2'",
+	PreDNAT:      true,
+}
+
+// When reading back, the rules should have been updated to the newer format.
+var policySpec3AfterRead = api.PolicySpec{
+	Order:        &order2,
+	IngressRules: []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
+	EgressRules:  []api.Rule{testutils.EgressRule2AfterRead, testutils.EgressRule1AfterRead},
+	Selector:     "thing2 == 'value2'",
+	PreDNAT:      true,
+}
+
 var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2, func(config api.CalicoAPIConfig) {
 
 	DescribeTable("Policy e2e tests",
@@ -228,6 +245,16 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			api.PolicySpec{
 				Selector: "has(myLabel-8.9/88-._9)",
 			},
+			policySpec2AfterRead,
+		),
+
+		// Test 4: Two fully populated PolicySpecs, one untracked and one pre-DNAT.
+		Entry("Two fully populated PolicySpecs, one untracked and one pre-DNAT",
+			api.PolicyMetadata{Name: "policy-1/with.foo", Annotations: map[string]string{"key": "value"}},
+			api.PolicyMetadata{Name: "policy.1"},
+			policySpec3,
+			policySpec2,
+			policySpec3AfterRead,
 			policySpec2AfterRead,
 		),
 	)

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -51,6 +51,7 @@ func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPa
 			Selector:      ap.Spec.Selector,
 			DoNotTrack:    ap.Spec.DoNotTrack,
 			Annotations:   ap.Metadata.Annotations,
+			PreDNAT:       ap.Spec.PreDNAT,
 		},
 	}
 
@@ -71,6 +72,7 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 	ap.Spec.EgressRules = RulesBackendToAPI(bp.OutboundRules)
 	ap.Spec.Selector = bp.Selector
 	ap.Spec.DoNotTrack = bp.DoNotTrack
+	ap.Spec.PreDNAT = bp.PreDNAT
 
 	return ap, nil
 }


### PR DESCRIPTION
## Description
The libcalico-go part of work for https://github.com/projectcalico/calico/issues/823.  This is a new feature, comprising changes in:
- libcalico-go: adding pre-DNAT flag to the Policy resource
- calico: documentation
- felix: programming iptables differently when the pre-DNAT flag is present.

## Todos
- [x] Tests
