### PR TITLE
Add validation for pre-DNAT policy

### DIFF
--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -83,7 +83,6 @@ var policySpec2AfterRead = api.PolicySpec{
 var policySpec3 = api.PolicySpec{
 	Order:        &order2,
 	IngressRules: []api.Rule{testutils.InRule2, testutils.InRule1},
-	EgressRules:  []api.Rule{testutils.EgressRule2, testutils.EgressRule1},
 	Selector:     "thing2 == 'value2'",
 	PreDNAT:      true,
 }
@@ -92,7 +91,6 @@ var policySpec3 = api.PolicySpec{
 var policySpec3AfterRead = api.PolicySpec{
 	Order:        &order2,
 	IngressRules: []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
-	EgressRules:  []api.Rule{testutils.EgressRule2AfterRead, testutils.EgressRule1AfterRead},
 	Selector:     "thing2 == 'value2'",
 	PreDNAT:      true,
 }

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -113,6 +113,7 @@ func init() {
 	registerStructValidator(validateBackendRule, model.Rule{})
 	registerStructValidator(validateNodeSpec, api.NodeSpec{})
 	registerStructValidator(validateBGPPeerMeta, api.BGPPeerMetadata{})
+	registerStructValidator(validatePolicySpec, api.PolicySpec{})
 }
 
 // reason returns the provided error reason prefixed with an identifier that
@@ -503,5 +504,19 @@ func validateBGPPeerMeta(v *validator.Validate, structLevel *validator.StructLev
 	if m.Scope == scope.Global && m.Node != "" {
 		structLevel.ReportError(reflect.ValueOf(m.Node),
 			"Metadata.Node", "", reason("no BGP Peer node name should be specified when scope is global"))
+	}
+}
+
+func validatePolicySpec(v *validator.Validate, structLevel *validator.StructLevel) {
+	m := structLevel.CurrentStruct.Interface().(api.PolicySpec)
+
+	if m.DoNotTrack && m.PreDNAT {
+		structLevel.ReportError(reflect.ValueOf(m.PreDNAT),
+			"PolicySpec.PreDNAT", "", reason("PreDNAT and DoNotTrack cannot both be true, for a given PolicySpec"))
+	}
+
+	if m.PreDNAT && len(m.EgressRules) > 0 {
+		structLevel.ReportError(reflect.ValueOf(m.EgressRules),
+			"PolicySpec.EgressRules", "", reason("PreDNAT PolicySpec cannot have any EgressRules"))
 	}
 }

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -641,6 +641,30 @@ func init() {
 		Entry("should reject node with BGP but no IPs", api.NodeSpec{BGP: &api.NodeBGPSpec{}}, false),
 		Entry("should reject node with IPv6 address in IPv4 field", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: &netv6_1}}, false),
 		Entry("should reject node with IPv4 address in IPv6 field", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: &netv4_1}}, false),
+		Entry("should reject Policy with both PreDNAT and DoNotTrack",
+			api.PolicySpec{
+				PreDNAT:    true,
+				DoNotTrack: true,
+			}, false),
+		Entry("should accept Policy with PreDNAT but not DoNotTrack",
+			api.PolicySpec{
+				PreDNAT: true,
+			}, true),
+		Entry("should accept Policy with DoNotTrack but not PreDNAT",
+			api.PolicySpec{
+				PreDNAT:    false,
+				DoNotTrack: true,
+			}, true),
+		Entry("should reject pre-DNAT Policy with egress rules",
+			api.PolicySpec{
+				PreDNAT:     true,
+				EgressRules: []api.Rule{{Action: "allow"}},
+			}, false),
+		Entry("should accept pre-DNAT Policy with ingress rules",
+			api.PolicySpec{
+				PreDNAT:      true,
+				IngressRules: []api.Rule{{Action: "allow"}},
+			}, true),
 	)
 }
 


### PR DESCRIPTION
- Validate DoNotTrack and PreDNAT not both true
- Validate PreDNAT policy only has inbound rules

(Part of https://github.com/projectcalico/calico/issues/823 - see there for the wider context.)