### PR TITLE
Add ID fields to Resource Objects for easy lookup and validations

### DIFF
--- a/lib/api/bgppeer.go
+++ b/lib/api/bgppeer.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
@@ -35,6 +37,15 @@ type BGPPeer struct {
 
 func (t BGPPeer) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
+}
+
+// String() returns the human-readable string representation of a BGPPeer instance
+// which is defined by its PeerIP and Scope.
+func (t BGPPeer) String() string {
+	if t.Metadata.Scope == scope.Node && t.Metadata.Node == "" {
+		return fmt.Sprintf("BGPPeer(PeerIP=%s, Scope=%s)", t.Metadata.PeerIP.IP.String(), t.Metadata.Scope)
+	}
+	return fmt.Sprintf("BGPPeer(PeerIP=%s, Scope=%s, Node=%s)", t.Metadata.PeerIP.IP.String(), t.Metadata.Scope, t.Metadata.Node)
 }
 
 // BGPPeerMetadata contains the metadata for a BGPPeer resource.

--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
@@ -29,6 +31,12 @@ type HostEndpoint struct {
 
 func (t HostEndpoint) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
+}
+
+// String() returns the human-readable string representation of a HostEndpoint instance
+// which is defined by its Node and Name.
+func (t HostEndpoint) String() string {
+	return fmt.Sprintf("HostEndpoint(Node=%s, Name=%s)", t.Metadata.Node, t.Metadata.Name)
 }
 
 // HostEndpointMetadata contains the Metadata for a HostEndpoint resource.

--- a/lib/api/ippool.go
+++ b/lib/api/ippool.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/net"
@@ -35,6 +37,12 @@ type IPPool struct {
 
 func (t IPPool) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
+}
+
+// String() returns the human-readable string representation of an IPPool instance
+// which is defined by its CIDR.
+func (t IPPool) String() string {
+	return fmt.Sprintf("IPPool(CIDR=%s)", t.Metadata.CIDR.String())
 }
 
 // IPPoolMetadata contains the metadata for an IP pool resource.

--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
@@ -42,6 +44,12 @@ type Node struct {
 
 func (t Node) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
+}
+
+// String() returns the human-readable string representation of a Node instance
+// which is defined by its Name.
+func (t Node) String() string {
+	return fmt.Sprintf("Node(Name=%s)", t.Metadata.Name)
 }
 
 // NodeMetadata contains the metadata for a Calico Node resource.

--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 )
 
@@ -44,6 +46,12 @@ type Policy struct {
 
 func (t Policy) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
+}
+
+// String() returns the human-readable string representation of a Policy instance
+// which is defined by its Name.
+func (t Policy) String() string {
+	return fmt.Sprintf("Policy(Name=%s)", t.Metadata.Name)
 }
 
 // PolicyMetadata contains the metadata for a selector-based security Policy resource.

--- a/lib/api/profile.go
+++ b/lib/api/profile.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 )
 
@@ -31,6 +33,12 @@ type Profile struct {
 
 func (t Profile) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
+}
+
+// String() returns the human-readable string representation of a Profile instance
+// which is defined by its Name.
+func (t Profile) String() string {
+	return fmt.Sprintf("Profile(Name=%s)", t.Metadata.Name)
 }
 
 // ProfileMetadata contains the metadata for a security Profile resource.

--- a/lib/api/unversioned/types.go
+++ b/lib/api/unversioned/types.go
@@ -19,10 +19,16 @@ type Resource interface {
 	GetTypeMetadata() TypeMetadata
 }
 
-// All singular resources (all resources not including lists) implement the ResourceObject interface
+// All singular resources (all resources not including lists) implement the ResourceObject interface.
 type ResourceObject interface {
 	Resource
+
+	// GetResourceMetadata returns the ResourceMetadata for each Resource Object.
 	GetResourceMetadata() ResourceMetadata
+
+	// String returns a human-readable string representation of a ResourceObject which
+	// includes the important ID fields for a ResourceObject.
+	String() string
 }
 
 // Define available versions.
@@ -46,6 +52,7 @@ func (md TypeMetadata) GetTypeMetadata() TypeMetadata {
 
 // All resource Metadata (not lists) implement the ResourceMetadata interface.
 type ResourceMetadata interface {
+	// GetObjectMetadata returns the ObjectMetadata instance of the ResourceMetadata.
 	GetObjectMetadata() ObjectMetadata
 }
 

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -31,6 +31,15 @@ func (t WorkloadEndpoint) GetResourceMetadata() unversioned.ResourceMetadata {
 	return t.Metadata
 }
 
+// String() returns the human-readable string representation of a WorkloadEndpoint which is
+// defined by its Node, Orchestrator, Workload, Name, and Active Instance ID (if it exists).
+func (t WorkloadEndpoint) String() string {
+	if t.Metadata.ActiveInstanceID == "" {
+		return fmt.Sprintf("WorkloadEndpoint(Node=%s, Orchestrator=%s, Workload=%s, Name=%s)", t.Metadata.Node, t.Metadata.Orchestrator, t.Metadata.Workload, t.Metadata.Name)
+	}
+	return fmt.Sprintf("WorkloadEndpoint(Node=%s, Orchestrator=%s, Workload=%s, Name=%s, ActiveInstanceID=%s)", t.Metadata.Node, t.Metadata.Orchestrator, t.Metadata.Workload, t.Metadata.Name, t.Metadata.ActiveInstanceID)
+}
+
 // WorkloadEndpointMetadata contains the Metadata for a WorkloadEndpoint resource.
 type WorkloadEndpointMetadata struct {
 	unversioned.ObjectMetadata


### PR DESCRIPTION
## Description
Adds in an ID field for every Resource Object and validations on top of those ID fields to make it easier to validate that important fields were not changed.

Will be of help to finishing https://github.com/projectcalico/calicoctl/pull/1564

## Todos
- [x] Tests
- [x] Documentation (none required)
- [x] Release note (none required)

## Release Note
```release-note
None required
```
