### PR TITLE
BGP Config definition should not be camelcase

### DIFF
--- a/lib/backend/k8s/resources/globalbgpconfig.go
+++ b/lib/backend/k8s/resources/globalbgpconfig.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	GlobalBgpConfigResourceName = "GlobalBgpConfigs"
+	GlobalBgpConfigResourceName = "globalbgpconfigs"
 	GlobalBgpConfigTPRName      = "global-bgp-config.projectcalico.org"
 )
 


### PR DESCRIPTION
## Description
The BGP Config TPR definition uses camelcase for the resource name.  Other TPRs do not.

I *dont believe* this will have any impact as output from kubectl suggests it makes no difference (comparing the TPR defs and resources) - but I'm just worried that it might impact us with the TPR to CRD migration, and so would prefer to resolve.

-----  For ref. output from kubectl for TPRs and their associated data:

(e.g. compare GlobalBgpPeers with GlobalBgpConfigs

```
- apiVersion: extensions/v1beta1
  description: Calico Global BGP Configuration
  kind: ThirdPartyResource
  metadata:
    creationTimestamp: 2017-07-28T04:02:14Z
    name: global-bgp-config.projectcalico.org
    namespace: ""
    resourceVersion: "1214"
    selfLink: /apis/extensions/v1beta1/thirdpartyresources/global-bgp-config.projectcalico.org
    uid: 8a4a49b5-7349-11e7-9130-42010af0001f
  versions:
  - name: v1

- apiVersion: extensions/v1beta1
  description: Calico Global BGP Peers
  kind: ThirdPartyResource
  metadata:
    creationTimestamp: 2017-07-28T04:02:14Z
    name: global-bgp-peer.projectcalico.org
    namespace: ""
    resourceVersion: "1216"
    selfLink: /apis/extensions/v1beta1/thirdpartyresources/global-bgp-peer.projectcalico.org
    uid: 8a4a450f-7349-11e7-9130-42010af0001f
  versions:
  - name: v1

- apiVersion: projectcalico.org/v1
  kind: GlobalBgpConfig
  metadata:
    creationTimestamp: 2017-07-28T04:02:20Z
    name: asnumber
    namespace: kube-system
    resourceVersion: “1251”
    selfLink: /apis/projectcalico.org/v1/namespaces/kube-system/globalbgpconfigs/asnumber
    uid: 8d9e3363-7349-11e7-9130-42010af0001f
  spec:
    name: AsNumber
    value: “64512"
  spec:
    name: NodeMeshEnabled
    value: “false”

- apiVersion: projectcalico.org/v1
  kind: GlobalBgpPeer
  metadata:
    creationTimestamp: 2017-07-28T16:17:01Z
    name: 10-240-0-31
    namespace: kube-system
    resourceVersion: “59075”
    selfLink: /apis/projectcalico.org/v1/namespaces/kube-system/globalbgppeers/10-240-0-31
    uid: 30412c13-73b0-11e7-9130-42010af0001f
  spec:
    asNumber: 64012
```