### PR TITLE
Updated the import for logrus to use lowercasing

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5a8e8f9d19d935d4247638b121a09ff5f53411623f01251a0cf9029fd7693b7b
-updated: 2017-07-14T11:08:47.961492803-07:00
+hash: bd6a4894e17f6b1ec214e325c515ea6e88e8e75a4c92aad729891074fedc7784
+updated: 2017-07-28T14:13:02.27723981-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -63,7 +63,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: 8bf4bbfc795e2c7c8a5ea47b707453ed019e2ad4
+  version: 70f0258d44cbaa3b6a2581d82f58da01a38e4de4
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -75,7 +75,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/onsi/ginkgo
-  version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
+  version: 8382b23d18dbaaff8e5f7e83784c53ebb8ec2f47
   subpackages:
   - config
   - extensions/table
@@ -126,8 +126,8 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
-- name: github.com/Sirupsen/logrus
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
@@ -145,20 +145,34 @@ imports:
   version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
+  - html
+  - html/atom
+  - html/charset
   - http2
   - http2/hpack
   - idna
   - lex/httplex
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 739734461d1c916b6c72a63d7efda2b27edb369f
   subpackages:
   - unix
 - name: golang.org/x/text
   version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
   subpackages:
   - cases
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
   - internal
   - internal/tag
+  - internal/utf8internal
   - language
   - runes
   - secure/bidirule
@@ -314,7 +328,7 @@ imports:
   - util/integer
 testImports:
 - name: github.com/onsi/gomega
-  version: 9b8c753e8dfb382618ba8fa19b4197b5dcb0434c
+  version: c893efa28eb45626cdaa76c9f653b62488858837
   subpackages:
   - format
   - internal/assertion

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ owners:
 - name: Rob Brockbank
   email: rob@tigera.io
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ^0.10.0
 - package: github.com/coreos/etcd
   subpackages:

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -18,12 +18,12 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/compat"
 	"github.com/projectcalico/libcalico-go/lib/backend/etcd"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewClient creates a new backend datastore client.

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	goerrors "errors"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -20,13 +20,13 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/pkg/transport"
 	capi "github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -21,12 +21,12 @@ import (
 
 	"net"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/client"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/hwm"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 

--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kapiv1 "k8s.io/client-go/pkg/api/v1"

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	capi "github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	capi "github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"

--- a/lib/backend/k8s/resources/customnoderesource.go
+++ b/lib/backend/k8s/resources/customnoderesource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/lib/backend/k8s/resources/customresource.go
+++ b/lib/backend/k8s/resources/customresource.go
@@ -17,9 +17,9 @@ package resources
 import (
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/lib/backend/k8s/resources/names.go
+++ b/lib/backend/k8s/resources/names.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/net"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // This file contains various name conversion methods that can be used to convert

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -15,7 +15,7 @@
 package resources
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
@@ -27,7 +27,7 @@ import (
 
 const (
 	nodeBgpIpv4CidrAnnotation = "projectcalico.org/IPv4Address"
-	nodeBgpAsnAnnotation = "projectcalico.org/ASNumber"
+	nodeBgpAsnAnnotation      = "projectcalico.org/ASNumber"
 )
 
 func NewNodeClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {

--- a/lib/backend/k8s/resources/retrywrapper.go
+++ b/lib/backend/k8s/resources/retrywrapper.go
@@ -17,7 +17,7 @@ package resources
 import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -17,11 +17,11 @@ package k8s
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/compat"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	log "github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/lib/backend/k8s/syncer_test.go
+++ b/lib/backend/k8s/syncer_test.go
@@ -17,12 +17,12 @@ package k8s
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	k8sapi "k8s.io/client-go/pkg/api/v1"

--- a/lib/backend/model/bgpconfig.go
+++ b/lib/backend/model/bgpconfig.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"regexp"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/errors"
 )

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -20,10 +20,10 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -20,9 +20,9 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/block_affinity.go
+++ b/lib/backend/model/block_affinity.go
@@ -20,9 +20,9 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/felixconfig.go
+++ b/lib/backend/model/felixconfig.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"regexp"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/errors"
 )

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -21,9 +21,9 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/hostendpointstatus.go
+++ b/lib/backend/model/hostendpointstatus.go
@@ -21,8 +21,8 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/ipam_handle.go
+++ b/lib/backend/model/ipam_handle.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"regexp"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/ippool.go
+++ b/lib/backend/model/ippool.go
@@ -21,10 +21,10 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -23,8 +23,8 @@ import (
 	net2 "net"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 // RawString is used a value type to indicate that the value is a bare non-JSON string

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -21,10 +21,10 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -22,8 +22,8 @@ import (
 
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -22,8 +22,8 @@ import (
 
 	"sort"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/statusreports.go
+++ b/lib/backend/model/statusreports.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"regexp"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -21,9 +21,9 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/backend/model/workloadendpointstatus.go
+++ b/lib/backend/model/workloadendpointstatus.go
@@ -21,8 +21,8 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/kelseyhightower/envconfig"
 	yaml "github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/api"
@@ -32,6 +31,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/validator"
 	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // Client contains

--- a/lib/client/config.go
+++ b/lib/client/config.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	log "github.com/sirupsen/logrus"
 )
 
 type ConfigLocation int8

--- a/lib/client/ipam.go
+++ b/lib/client/ipam.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/lib/client/ipam_block.go
+++ b/lib/client/ipam_block.go
@@ -21,9 +21,9 @@ import (
 	"net"
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/lib/client/ipam_block_reader_writer.go
+++ b/lib/client/ipam_block_reader_writer.go
@@ -24,11 +24,11 @@ import (
 
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 type blockReaderWriter struct {

--- a/lib/client/ippool.go
+++ b/lib/client/ippool.go
@@ -15,11 +15,11 @@
 package client
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/ipip"
+	log "github.com/sirupsen/logrus"
 )
 
 // PoolInterface has methods to work with Pool resources.

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -15,7 +15,7 @@
 package client
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -15,11 +15,11 @@
 package client
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/converter"
+	log "github.com/sirupsen/logrus"
 )
 
 // ProfileInterface has methods to work with Profile resources.

--- a/lib/converter/rule.go
+++ b/lib/converter/rule.go
@@ -17,7 +17,7 @@ package converter
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/lib/health/health.go
+++ b/lib/health/health.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // The HealthReport struct has slots for the levels of health that we monitor and aggregate.

--- a/lib/hwm/hwm.go
+++ b/lib/hwm/hwm.go
@@ -16,7 +16,7 @@
 package hwm
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/tchap/go-patricia.v2/patricia"
 )
 

--- a/lib/logutils/logutils.go
+++ b/lib/logutils/logutils.go
@@ -26,8 +26,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 // FilterLevels returns all the logrus.Level values <= maxLevel.

--- a/lib/logutils/logutils_suite_test.go
+++ b/lib/logutils/logutils_suite_test.go
@@ -20,8 +20,8 @@ import (
 
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/onsi/ginkgo/reporters"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/libcalico-go/lib/testutils"

--- a/lib/logutils/logutils_test.go
+++ b/lib/logutils/logutils_test.go
@@ -24,11 +24,11 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	. "github.com/projectcalico/libcalico-go/lib/logutils"
 )

--- a/lib/selector/parser/parser.go
+++ b/lib/selector/parser/parser.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/selector/tokenizer"
+	log "github.com/sirupsen/logrus"
 )
 
 const parserDebug = false

--- a/lib/selector/tokenizer/tokenizer.go
+++ b/lib/selector/tokenizer/tokenizer.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type tokenKind uint8

--- a/lib/set/set.go
+++ b/lib/set/set.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type Set interface {

--- a/lib/testutils/client.go
+++ b/lib/testutils/client.go
@@ -17,12 +17,12 @@ package testutils
 import (
 	"net"
 
-	log "github.com/Sirupsen/logrus"
 	etcdclient "github.com/coreos/etcd/client"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 
 	"errors"
 	"fmt"

--- a/lib/testutils/ginkgolog.go
+++ b/lib/testutils/ginkgolog.go
@@ -14,8 +14,8 @@
 package testutils
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/onsi/ginkgo"
+	"github.com/sirupsen/logrus"
 )
 
 func HookLogrusForGinkgo() {

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	calinet "github.com/projectcalico/libcalico-go/lib/net"
@@ -28,6 +27,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/scope"
 	"github.com/projectcalico/libcalico-go/lib/selector"
 	"github.com/projectcalico/libcalico-go/lib/selector/tokenizer"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"gopkg.in/go-playground/validator.v8"


### PR DESCRIPTION
## Description
Any time we use a package that also imports logrus, they should be updated to use the user's updated user name (which is lowercased).  This will prevent import errors with the vendoring going forward.

Found when implementing https://github.com/projectcalico/calicoctl/pull/1564

Details can be found here: https://github.com/sirupsen/logrus/issues/451

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note
- [x] Uptake changes in https://github.com/projectcalico/calico
- [x] Uptake changes in https://github.com/projectcalico/calicoctl
- [x] Uptake changes in https://github.com/projectcalico/felix
- [x] Uptake changes in https://github.com/projectcalico/cni-plugin
- [x] Uptake changes in https://github.com/projectcalico/libnetwork-plugin
- [x] Uptake changes in https://github.com/projectcalico/typha
- [x] Uptake changes in https://github.com/projectcalico/calico-bgp-daemon

## Release Note
```release-note
None required
```
