### PR TITLE
bugfix: convert NetworkPolicy empty namespaceSelector to select all s…

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -269,6 +269,11 @@ func (c converter) k8sSelectorToCalico(s *metav1.LabelSelector, ns *string) stri
 		}
 	}
 
+	// If namespace selector is empty then we select all namespaces.
+	if len(selectors) == 0 && ns == nil {
+		selectors = []string{"has(calico/k8s_ns)"}
+	}
+
 	return strings.Join(selectors, " && ")
 }
 


### PR DESCRIPTION
…elector in the policy

## Description

fixes https://github.com/projectcalico/k8s-policy/issues/113

## Todos
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
bugfix: fix handling of empty namespaceSelector when using Kubernetes datastore driver
```
