### PR TITLE
Now specify UpdateType for ExpectExists helper function & add new test for Node sync

### DIFF
--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -981,8 +981,15 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				EndpointID:     "eth0",
 			}}
 
+		hostKey := model.KVPair{
+			Key: model.HostConfigKey{
+				Hostname:       "127.0.0.1",
+				Name:           "IpInIpTunnelAddr",
+			}}
+
 		expectedKeys := []api.Update{
 			api.Update{wepKey, api.UpdateTypeKVNew},	// expected WEP resulting from creating this pod
+			api.Update{hostKey, api.UpdateTypeKVNew},	// expected host resulting from starting client
 		}
 
 		log.Infof("[TEST] Syncer received new: %+v", expectedKeys)


### PR DESCRIPTION
## Description
This request adds two commits:
 1. Modify ExpectExists() to accept an Update which consists of both a KVPair as well as an UpdateType. ExpectExists now requires that the update type match as well as that the KVPair is present. All existing unit tests pass consistently (on my laptop).
2. Add another expected HostConfigKey that should be updated at initial sync time. This is a test to cover https://github.com/projectcalico/libcalico-go/issues/485.

Note this additional test verifies the fix associated with above issue - the test fails when the fix is removed.

## Todos
- [x] Tests - all unit tests are passing

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
