### PR TITLE
Add Types field to Policy

### DIFF
--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -118,8 +118,20 @@ type PolicySpec struct {
 	// PreDNAT indicates to apply the rules in this policy before any DNAT.
 	PreDNAT bool `json:"preDNAT,omitempty"`
 
-	// Types indicates whether this policy applies to ingress, or to egress, or to both.  An
-	// empty or nil value here indicates both ingress and egress.
+	// Types indicates whether this policy applies to ingress, or to egress, or to both.  When
+	// not explicitly specified (and so the value on creation is empty or nil), Calico defaults
+	// Types according to what IngressRules and EgressRules are present in the policy.  The
+	// default is:
+	//
+	// - [ PolicyTypeIngress ], if there are no EgressRules (including the case where there are
+	//   also no IngressRules)
+	//
+	// - [ PolicyTypeEgress ], if there are EgressRules but no IngressRules
+	//
+	// - [ PolicyTypeIngress, PolicyTypeEgress ], if there are both IngressRules and EgressRules.
+	//
+	// When the policy is read back again, Types will always be one of these values, never empty
+	// or nil.
 	Types []PolicyType `json:"types,omitempty" validate:"omitempty,dive,policytype"`
 }
 

--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -117,6 +117,10 @@ type PolicySpec struct {
 
 	// PreDNAT indicates to apply the rules in this policy before any DNAT.
 	PreDNAT bool `json:"preDNAT,omitempty"`
+
+	// Types indicates whether this policy applies to ingress, or to egress, or to both.  An
+	// empty or nil value here indicates both ingress and egress.
+	Types []string `json:"types,omitempty" validate:"omitempty,dive,policytype"`
 }
 
 // NewPolicy creates a new (zeroed) Policy struct with the TypeMetadata initialised to the current

--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -120,8 +120,16 @@ type PolicySpec struct {
 
 	// Types indicates whether this policy applies to ingress, or to egress, or to both.  An
 	// empty or nil value here indicates both ingress and egress.
-	Types []string `json:"types,omitempty" validate:"omitempty,dive,policytype"`
+	Types []PolicyType `json:"types,omitempty" validate:"omitempty,dive,policytype"`
 }
+
+// PolicyType enumerates the possible values of the PolicySpec Types field.
+type PolicyType string
+
+const (
+	PolicyTypeIngress PolicyType = "ingress"
+	PolicyTypeEgress  PolicyType = "egress"
+)
 
 // NewPolicy creates a new (zeroed) Policy struct with the TypeMetadata initialised to the current
 // version.

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -536,6 +536,12 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Checking cache has correct Global Network Policy entries", func() {
+			// The GNP has been roundtripped through conversion to and from an API
+			// Policy object, and in that process the Types field has been defaulted.
+			kvp1a.Value.(*model.Policy).Types = []string{
+				string(capi.PolicyTypeIngress),
+				string(capi.PolicyTypeEgress),
+			}
 			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1a.Value))
 			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})
@@ -551,6 +557,12 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Checking cache has correct Global Network Policy entries", func() {
+			// The GNP has been roundtripped through conversion to and from an API
+			// Policy object, and in that process the Types field has been defaulted.
+			kvp1b.Value.(*model.Policy).Types = []string{
+				string(capi.PolicyTypeIngress),
+				string(capi.PolicyTypeEgress),
+			}
 			Eventually(cb.GetSyncerValueFunc(kvp1a.Key)).Should(Equal(kvp1b.Value))
 			Eventually(cb.GetSyncerValuePresentFunc(kvp2a.Key)).Should(BeFalse())
 		})

--- a/lib/backend/k8s/resources/globalnetworkpolicies_test.go
+++ b/lib/backend/k8s/resources/globalnetworkpolicies_test.go
@@ -68,6 +68,7 @@ var _ = Describe("Global Network Policies conversion methods", func() {
 			}},
 			Selector:   "has(foobar)",
 			DoNotTrack: true,
+			Types:      []string{"ingress", "egress"},
 		},
 		Revision: "rv",
 	}
@@ -94,6 +95,7 @@ var _ = Describe("Global Network Policies conversion methods", func() {
 			}},
 			Selector:   "has(foobar)",
 			DoNotTrack: true,
+			Types:      []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 		},
 	}
 

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -96,6 +96,7 @@ type Policy struct {
 	DoNotTrack    bool              `json:"untracked,omitempty"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
 	PreDNAT       bool              `json:"pre_dnat,omitempty"`
+	Types         []string          `json:"types,omitempty"`
 }
 
 func (p Policy) String() string {
@@ -116,5 +117,6 @@ func (p Policy) String() string {
 	parts = append(parts, fmt.Sprintf("outbound:%v", strings.Join(outRules, ";")))
 	parts = append(parts, fmt.Sprintf("untracked:%v", p.DoNotTrack))
 	parts = append(parts, fmt.Sprintf("pre_dnat:%v", p.PreDNAT))
+	parts = append(parts, fmt.Sprintf("types:%v", strings.Join(p.Types, ";")))
 	return strings.Join(parts, ",")
 }

--- a/lib/backend/model/policy_test.go
+++ b/lib/backend/model/policy_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model_test
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Policy functions", func() {
+
+	It("Policy should stringify correctly", func() {
+		order := 10.5
+		p := model.Policy{
+			Order:         &order,
+			InboundRules:  []model.Rule{model.Rule{Action: "deny"}},
+			OutboundRules: []model.Rule{model.Rule{Action: "allow"}},
+			Selector:      "apples=='oranges'",
+			DoNotTrack:    false,
+			PreDNAT:       true,
+			Types:         []string{"ingress", "egress"},
+		}
+		Expect(p.String()).To(Equal("order:10.5,selector:\"apples=='oranges'\",inbound:deny,outbound:allow,untracked:false,pre_dnat:true,types:ingress;egress"))
+	})
+})

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -103,6 +103,20 @@ var emptyPolicyAfterRead = api.PolicySpec{
 	Types: []api.PolicyType{api.PolicyTypeIngress},
 }
 
+var egressPolicy = api.PolicySpec{
+	Order:       &order2,
+	EgressRules: []api.Rule{testutils.InRule2, testutils.InRule1},
+	Selector:    "thing2 == 'value2'",
+}
+
+// When reading back, the rules should have been updated to the newer format.
+var egressPolicyAfterRead = api.PolicySpec{
+	Order:       &order2,
+	EgressRules: []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
+	Selector:    "thing2 == 'value2'",
+	Types:       []api.PolicyType{api.PolicyTypeEgress},
+}
+
 var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2, func(config api.CalicoAPIConfig) {
 
 	DescribeTable("Policy e2e tests",
@@ -262,6 +276,16 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			policySpec3,
 			policySpec2,
 			policySpec3AfterRead,
+			policySpec2AfterRead,
+		),
+
+		// An egress Policy and an ingress Policy.
+		Entry("An egress Policy and an ingress Policy",
+			api.PolicyMetadata{Name: "policy-1/with.foo", Annotations: map[string]string{"key": "value"}},
+			api.PolicyMetadata{Name: "policy.1"},
+			egressPolicy,
+			policySpec2,
+			egressPolicyAfterRead,
 			policySpec2AfterRead,
 		),
 	)

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -61,6 +61,7 @@ var policySpec1AfterRead = api.PolicySpec{
 	IngressRules: []api.Rule{testutils.InRule1AfterRead, testutils.InRule2AfterRead},
 	EgressRules:  []api.Rule{testutils.EgressRule1AfterRead, testutils.EgressRule2AfterRead},
 	Selector:     "thing == 'value'",
+	Types:        []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 }
 
 var policySpec2 = api.PolicySpec{
@@ -78,6 +79,7 @@ var policySpec2AfterRead = api.PolicySpec{
 	EgressRules:  []api.Rule{testutils.EgressRule2AfterRead, testutils.EgressRule1AfterRead},
 	Selector:     "thing2 == 'value2'",
 	DoNotTrack:   true,
+	Types:        []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 }
 
 var policySpec3 = api.PolicySpec{
@@ -93,6 +95,12 @@ var policySpec3AfterRead = api.PolicySpec{
 	IngressRules: []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
 	Selector:     "thing2 == 'value2'",
 	PreDNAT:      true,
+	Types:        []api.PolicyType{api.PolicyTypeIngress},
+}
+
+// When reading back, an empty policy has Types 'ingress'.
+var emptyPolicyAfterRead = api.PolicySpec{
+	Types: []api.PolicyType{api.PolicyTypeIngress},
 }
 
 var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2, func(config api.CalicoAPIConfig) {
@@ -229,7 +237,7 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			policySpec1,
 			api.PolicySpec{},
 			policySpec1AfterRead,
-			api.PolicySpec{},
+			emptyPolicyAfterRead,
 		),
 
 		// Test 3: Pass one partially populated PolicySpec and another fully populated PolicySpec and expect the series of operations to succeed.
@@ -242,6 +250,7 @@ var _ = testutils.E2eDatastoreDescribe("Policy tests", testutils.DatastoreEtcdV2
 			policySpec2,
 			api.PolicySpec{
 				Selector: "has(myLabel-8.9/88-._9)",
+				Types:    []api.PolicyType{api.PolicyTypeIngress},
 			},
 			policySpec2AfterRead,
 		),

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -52,8 +52,33 @@ func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPa
 			DoNotTrack:    ap.Spec.DoNotTrack,
 			Annotations:   ap.Metadata.Annotations,
 			PreDNAT:       ap.Spec.PreDNAT,
-			Types:         ap.Spec.Types,
+			Types:         nil, // filled in below
 		},
+	}
+
+	if len(ap.Spec.Types) == 0 {
+		// Default the Types field according to what inbound and outbound rules are present
+		// in the policy.
+		if len(ap.Spec.EgressRules) == 0 {
+			// Policy has no egress rules, so apply this policy to ingress only.  (Note:
+			// intentionally including the case where the policy also has no ingress
+			// rules.)
+			d.Value.(*model.Policy).Types = []string{string(api.PolicyTypeIngress)}
+		} else if len(ap.Spec.IngressRules) == 0 {
+			// Policy has egress rules but no ingress rules, so apply this policy to
+			// egress only.
+			d.Value.(*model.Policy).Types = []string{string(api.PolicyTypeEgress)}
+		} else {
+			// Policy has both ingress and egress rules, so apply this policy to both
+			// ingress and egress.
+			d.Value.(*model.Policy).Types = []string{string(api.PolicyTypeIngress), string(api.PolicyTypeEgress)}
+		}
+	} else {
+		// Convert from the API-specified Types.
+		d.Value.(*model.Policy).Types = make([]string, len(ap.Spec.Types))
+		for i, t := range ap.Spec.Types {
+			d.Value.(*model.Policy).Types[i] = string(t)
+		}
 	}
 
 	return &d, nil
@@ -74,7 +99,15 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 	ap.Spec.Selector = bp.Selector
 	ap.Spec.DoNotTrack = bp.DoNotTrack
 	ap.Spec.PreDNAT = bp.PreDNAT
-	ap.Spec.Types = bp.Types
+	ap.Spec.Types = nil
+
+	// Note: avoid accidentally converting from nil to [].
+	if bp.Types != nil {
+		ap.Spec.Types = make([]api.PolicyType, len(bp.Types))
+		for i, t := range bp.Types {
+			ap.Spec.Types[i] = api.PolicyType(t)
+		}
+	}
 
 	return ap, nil
 }

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -52,6 +52,7 @@ func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPa
 			DoNotTrack:    ap.Spec.DoNotTrack,
 			Annotations:   ap.Metadata.Annotations,
 			PreDNAT:       ap.Spec.PreDNAT,
+			Types:         ap.Spec.Types,
 		},
 	}
 
@@ -73,6 +74,7 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 	ap.Spec.Selector = bp.Selector
 	ap.Spec.DoNotTrack = bp.DoNotTrack
 	ap.Spec.PreDNAT = bp.PreDNAT
+	ap.Spec.Types = bp.Types
 
 	return ap, nil
 }

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -665,6 +665,45 @@ func init() {
 				PreDNAT:      true,
 				IngressRules: []api.Rule{{Action: "allow"}},
 			}, true),
+
+		// PolicySpec Types field checks.
+		Entry("allow missing Types", api.PolicySpec{}, true),
+		Entry("allow empty Types", api.PolicySpec{Types: []api.PolicyType{}}, true),
+		Entry("allow ingress Types", api.PolicySpec{Types: []api.PolicyType{api.PolicyTypeIngress}}, true),
+		Entry("allow egress Types", api.PolicySpec{Types: []api.PolicyType{api.PolicyTypeEgress}}, true),
+		Entry("allow ingress+egress Types", api.PolicySpec{Types: []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress}}, true),
+		Entry("disallow repeated egress Types", api.PolicySpec{Types: []api.PolicyType{api.PolicyTypeEgress, api.PolicyTypeEgress}}, false),
+		Entry("disallow unexpected value", api.PolicySpec{Types: []api.PolicyType{"unexpected"}}, false),
+		Entry("disallow Types without ingress when IngressRules present",
+			api.PolicySpec{
+				IngressRules: []api.Rule{{Action: "allow"}},
+				Types:        []api.PolicyType{api.PolicyTypeEgress},
+			}, false),
+		Entry("disallow Types without egress when EgressRules present",
+			api.PolicySpec{
+				EgressRules: []api.Rule{{Action: "allow"}},
+				Types:       []api.PolicyType{api.PolicyTypeIngress},
+			}, false),
+		Entry("allow Types with ingress when IngressRules present",
+			api.PolicySpec{
+				IngressRules: []api.Rule{{Action: "allow"}},
+				Types:        []api.PolicyType{api.PolicyTypeIngress},
+			}, true),
+		Entry("allow Types with ingress+egress when IngressRules present",
+			api.PolicySpec{
+				IngressRules: []api.Rule{{Action: "allow"}},
+				Types:        []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
+			}, true),
+		Entry("allow Types with egress when EgressRules present",
+			api.PolicySpec{
+				EgressRules: []api.Rule{{Action: "allow"}},
+				Types:       []api.PolicyType{api.PolicyTypeEgress},
+			}, true),
+		Entry("allow Types with ingress+egress when EgressRules present",
+			api.PolicySpec{
+				EgressRules: []api.Rule{{Action: "allow"}},
+				Types:       []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
+			}, true),
 	)
 }
 

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -704,6 +704,21 @@ func init() {
 				EgressRules: []api.Rule{{Action: "allow"}},
 				Types:       []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 			}, true),
+		Entry("allow ingress Types with pre-DNAT",
+			api.PolicySpec{
+				PreDNAT: true,
+				Types:   []api.PolicyType{api.PolicyTypeIngress},
+			}, true),
+		Entry("disallow egress Types with pre-DNAT",
+			api.PolicySpec{
+				PreDNAT: true,
+				Types:   []api.PolicyType{api.PolicyTypeEgress},
+			}, false),
+		Entry("disallow ingress+egress Types with pre-DNAT",
+			api.PolicySpec{
+				PreDNAT: true,
+				Types:   []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
+			}, false),
 	)
 }
 


### PR DESCRIPTION
## Description
This is the libcalico-go part of an enhancement to allow a Calico Policy to specify explicitly whether it applies on ingress or on egress, or both.
 
## Todos
- [x] Tests
- [x] Documentation - in https://github.com/projectcalico/calico/pull/1016
- [x] Release note - in https://github.com/projectcalico/calico/pull/1016
