### PR TITLE
Tests and extra parent paths for deletion

### DIFF
--- a/lib/backend/model/bgpconfig.go
+++ b/lib/backend/model/bgpconfig.go
@@ -112,7 +112,7 @@ func (key NodeBGPConfigKey) defaultDeletePath() (string, error) {
 }
 
 func (key NodeBGPConfigKey) defaultDeleteParentPaths() ([]string, error) {
-	return nil, nil
+	return []string{fmt.Sprintf("/calico/bgp/v1/host/%s", key.Nodename)}, nil
 }
 
 func (key NodeBGPConfigKey) valueType() reflect.Type {

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -71,7 +71,9 @@ func (key WorkloadEndpointKey) defaultDeleteParentPaths() ([]string, error) {
 	workload := fmt.Sprintf("/calico/v1/host/%s/workload/%s/%s",
 		key.Hostname, escapeName(key.OrchestratorID), escapeName(key.WorkloadID))
 	endpoints := workload + "/endpoint"
-	return []string{endpoints, workload}, nil
+	orchestrator := fmt.Sprintf("/calico/v1/host/%s/workload/%s",
+		key.Hostname, escapeName(key.OrchestratorID))
+	return []string{endpoints, workload, orchestrator}, nil
 }
 
 func (key WorkloadEndpointKey) valueType() reflect.Type {


### PR DESCRIPTION
## Description
Fixes #370 
I've added some tests for Node and WEPs to verify they have cleaned up after themselves.

The extra parent dirs will error (though it doesn't get propegated up the chain) if they still have something in them.  This means that for the Node struct the final key to be removed will also remove its parent
directory.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico will ensure empty dirs under its control for Node and Workload Endpoints are removed once they are not needed.
```
