### PR TITLE
Calculate coverage for libcalico-go as a whole

### DIFF
--- a/run-uts
+++ b/run-uts
@@ -9,22 +9,39 @@ else
     SKIP="vendor,$SKIP"
 fi
 
+echo "Removing old coverprofiles..."
+find . -name "*.coverprofile" -type f -delete
+
+echo "Calculating packages to cover..."
+go_dirs=$(find -type f -name '*.go' | \
+	      grep -vE '/vendor/|.glide' | \
+	      xargs -n 1 dirname | \
+	      sort | uniq | \
+	      tr '\n' ',' | \
+	      sed 's/,$//' )
+echo "Covering: $go_dirs"
+test ! -z "$go_dirs"
+
 # Run tests in random order find tests recursively (-r).
 echo WHAT: $WHAT
 echo SKIP: $SKIP
-ginkgo -cover -r --skipPackage $SKIP $WHAT
+ginkgo -cover -coverpkg=${go_dirs} -r --skipPackage $SKIP $WHAT
+gocovmerge $(find . -name '*.coverprofile') > combined.coverprofile
 
 echo
 echo '+==============+'
 echo '| All coverage |'
 echo '+==============+'
 echo
-find . -iname '*.coverprofile' | xargs -I _ go tool cover -func=_
+go tool cover -func combined.coverprofile | \
+  sed 's=github.com/projectcalico/libcalico-go/==' | \
+  column -t
 
 echo
 echo '+==================+'
 echo '| Missing coverage |'
 echo '+==================+'
 echo
-find . -iname '*.coverprofile' | xargs -I _ go tool cover -func=_ | grep -v '100.0%'
-
+go tool cover -func combined.coverprofile | \
+  sed 's=github.com/projectcalico/libcalico-go/==' | grep -v '100.0%' | \
+  column -t


### PR DESCRIPTION
More specifically, and borrowing some magic from Felix,
- in each test suite, record coverage for all libcalico-go packages, not
  just those in the same directory as the test suite
- merge coverage profiles from each test suite into a single
  'combined.coverprofile'.
