### PR TITLE
Ensuring calico-node does not leak dirs into etcd

### DIFF
--- a/lib/backend/model/bgp_node.go
+++ b/lib/backend/model/bgp_node.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+var (
+	typeBGPNode = reflect.TypeOf(BGPNode{})
+)
+
+type BGPNodeKey struct {
+	Host string
+}
+
+func (key BGPNodeKey) defaultPath() (string, error) {
+	if key.Host == "" {
+		return "", errors.ErrorInsufficientIdentifiers{Name: "host"}
+	}
+
+	k := "/calico/bgp/v1/host/" + key.Host
+	return k, nil
+}
+
+func (key BGPNodeKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
+}
+
+func (key BGPNodeKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
+func (key BGPNodeKey) valueType() reflect.Type {
+	return typeBGPNode
+}
+
+func (key BGPNodeKey) String() string {
+	return fmt.Sprintf("BGPNodeKey(host=%s)", key.Host)
+}
+
+type BGPNode struct {
+}


### PR DESCRIPTION
## Description
Fixes #370 

I've added a test to ensure we're not leaking directories into etcd when we delete a node.  I've also fixed a directory leak we were aware of by adding a new model similar to how we do with the IPAM data.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico Node will now ensure it is not leaking directories into etcd.
```
