### PR TITLE
Policy conversion code made public

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -198,8 +198,8 @@ func (c converter) podToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 	return &kvp, nil
 }
 
-// networkPolicyToPolicy converts a k8s NetworkPolicy to a model.KVPair.
-func (c converter) networkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.KVPair, error) {
+// NetworkPolicyToPolicy converts a k8s NetworkPolicy to a model.KVPair.
+func (c converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.KVPair, error) {
 	// Pull out important fields.
 	policyName := fmt.Sprintf("knp.default.%s.%s", np.ObjectMeta.Namespace, np.ObjectMeta.Name)
 

--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -36,7 +36,8 @@ var (
 	protoTCP = kapiv1.ProtocolTCP
 )
 
-type converter struct {
+//TODO: make this private and expose a public conversion interface instead
+type Converter struct {
 }
 
 // VethNameForWorkload returns a deterministic veth name
@@ -50,13 +51,13 @@ func VethNameForWorkload(workload string) string {
 }
 
 // parseWorkloadID extracts the Namespace and Pod name from the given workload ID.
-func (c converter) parseWorkloadID(workloadID string) (string, string) {
+func (c Converter) parseWorkloadID(workloadID string) (string, string) {
 	splits := strings.SplitN(workloadID, ".", 2)
 	return splits[0], splits[1]
 }
 
 // parsePolicyNameNamespace extracts the Kubernetes Namespace that backs the given Policy.
-func (c converter) parsePolicyNameNamespace(name string) (string, error) {
+func (c Converter) parsePolicyNameNamespace(name string) (string, error) {
 	// Policy objects backed by Namespaces have form "ns.projectcalico.org/<ns_name>"
 	if !strings.HasPrefix(name, "ns.projectcalico.org/") {
 		// This is not backed by a Kubernetes Namespace.
@@ -67,7 +68,7 @@ func (c converter) parsePolicyNameNamespace(name string) (string, error) {
 }
 
 // parsePolicyNameNetworkPolicy extracts the Kubernetes Namespace and NetworkPolicy that backs the given Policy.
-func (c converter) parsePolicyNameNetworkPolicy(name string) (string, string, error) {
+func (c Converter) parsePolicyNameNetworkPolicy(name string) (string, string, error) {
 	// Policies backed by NetworkPolicies have form "knp.default.<ns_name>.<np_name>"
 	if !strings.HasPrefix(name, "knp.default.") {
 		// This is not backed by a Kubernetes NetworkPolicy.
@@ -83,7 +84,7 @@ func (c converter) parsePolicyNameNetworkPolicy(name string) (string, string, er
 }
 
 // parseProfileName extracts the Namespace name from the given Profile name.
-func (c converter) parseProfileName(profileName string) (string, error) {
+func (c Converter) parseProfileName(profileName string) (string, error) {
 	// Profile objects backed by Namespaces have form "ns.projectcalico.org/<ns_name>"
 	if !strings.HasPrefix(profileName, "ns.projectcalico.org/") {
 		// This is not backed by a Kubernetes Namespace.
@@ -96,7 +97,7 @@ func (c converter) parseProfileName(profileName string) (string, error) {
 // namespaceToProfile converts a Namespace to a Calico Profile.  The Profile stores
 // labels from the Namespace which are inherited by the WorkloadEndpoints within
 // the Profile. This Profile also has the default ingress and egress rules, which are both 'allow'.
-func (c converter) namespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, error) {
+func (c Converter) namespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, error) {
 	// Generate the labels to apply to the profile, using a special prefix
 	// to indicate that these are the labels from the parent Kubernetes Namespace.
 	labels := map[string]string{}
@@ -121,7 +122,7 @@ func (c converter) namespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, erro
 
 // isReadyCalicoPod returns true if the pod should be shown as a workloadEndpoint
 // in the Calico API and false otherwise.
-func (c converter) isReadyCalicoPod(pod *kapiv1.Pod) bool {
+func (c Converter) isReadyCalicoPod(pod *kapiv1.Pod) bool {
 	if c.isHostNetworked(pod) {
 		log.WithField("pod", pod.Name).Debug("Pod is host networked.")
 		return false
@@ -135,21 +136,21 @@ func (c converter) isReadyCalicoPod(pod *kapiv1.Pod) bool {
 	return true
 }
 
-func (c converter) isScheduled(pod *kapiv1.Pod) bool {
+func (c Converter) isScheduled(pod *kapiv1.Pod) bool {
 	return pod.Spec.NodeName != ""
 }
 
-func (c converter) isHostNetworked(pod *kapiv1.Pod) bool {
+func (c Converter) isHostNetworked(pod *kapiv1.Pod) bool {
 	return pod.Spec.HostNetwork
 }
 
-func (c converter) hasIPAddress(pod *kapiv1.Pod) bool {
+func (c Converter) hasIPAddress(pod *kapiv1.Pod) bool {
 	return pod.Status.PodIP != ""
 }
 
 // podToWorkloadEndpoint converts a Pod to a WorkloadEndpoint.  It assumes the calling code
 // has verified that the provided Pod is valid to convert to a WorkloadEndpoint.
-func (c converter) podToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error) {
+func (c Converter) podToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error) {
 	// Pull out the profile and workload ID based on pod name and Namespace.
 	profile := fmt.Sprintf("ns.projectcalico.org/%s", pod.ObjectMeta.Namespace)
 	workload := fmt.Sprintf("%s.%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
@@ -199,7 +200,7 @@ func (c converter) podToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 }
 
 // NetworkPolicyToPolicy converts a k8s NetworkPolicy to a model.KVPair.
-func (c converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.KVPair, error) {
+func (c Converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.KVPair, error) {
 	// Pull out important fields.
 	policyName := fmt.Sprintf("knp.default.%s.%s", np.ObjectMeta.Namespace, np.ObjectMeta.Name)
 
@@ -230,7 +231,7 @@ func (c converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.K
 
 // k8sSelectorToCalico takes a namespaced k8s label selector and returns the Calico
 // equivalent.
-func (c converter) k8sSelectorToCalico(s *metav1.LabelSelector, ns *string) string {
+func (c Converter) k8sSelectorToCalico(s *metav1.LabelSelector, ns *string) string {
 	// If this is a podSelector, it needs to be namespaced, and it
 	// uses a different prefix.  Otherwise, treat this as a NamespaceSelector.
 	selectors := []string{}
@@ -277,7 +278,7 @@ func (c converter) k8sSelectorToCalico(s *metav1.LabelSelector, ns *string) stri
 	return strings.Join(selectors, " && ")
 }
 
-func (c converter) k8sIngressRuleToCalico(r extensions.NetworkPolicyIngressRule, ns string) []model.Rule {
+func (c Converter) k8sIngressRuleToCalico(r extensions.NetworkPolicyIngressRule, ns string) []model.Rule {
 	rules := []model.Rule{}
 	peers := []*extensions.NetworkPolicyPeer{}
 	ports := []*extensions.NetworkPolicyPort{}
@@ -331,7 +332,7 @@ func (c converter) k8sIngressRuleToCalico(r extensions.NetworkPolicyIngressRule,
 	return rules
 }
 
-func (c converter) buildRule(port *extensions.NetworkPolicyPort, peer *extensions.NetworkPolicyPeer, ns string) model.Rule {
+func (c Converter) buildRule(port *extensions.NetworkPolicyPort, peer *extensions.NetworkPolicyPeer, ns string) model.Rule {
 	var protocol *numorstring.Protocol
 	dstPorts := []numorstring.Port{}
 	srcSelector := ""
@@ -354,7 +355,7 @@ func (c converter) buildRule(port *extensions.NetworkPolicyPort, peer *extension
 	}
 }
 
-func (c converter) k8sProtocolToCalico(protocol *kapiv1.Protocol) *numorstring.Protocol {
+func (c Converter) k8sProtocolToCalico(protocol *kapiv1.Protocol) *numorstring.Protocol {
 	if protocol != nil {
 		p := numorstring.ProtocolFromString(strings.ToLower(string(*protocol)))
 		return &p
@@ -362,7 +363,7 @@ func (c converter) k8sProtocolToCalico(protocol *kapiv1.Protocol) *numorstring.P
 	return nil
 }
 
-func (c converter) k8sPeerToCalicoSelector(peer extensions.NetworkPolicyPeer, ns string) string {
+func (c Converter) k8sPeerToCalicoSelector(peer extensions.NetworkPolicyPeer, ns string) string {
 	// Determine the source selector for the rule.
 	// Only one of PodSelector / NamespaceSelector can be defined.
 	if peer.PodSelector != nil {
@@ -376,7 +377,7 @@ func (c converter) k8sPeerToCalicoSelector(peer extensions.NetworkPolicyPeer, ns
 	return ""
 }
 
-func (c converter) k8sPortToCalico(port extensions.NetworkPolicyPort) []numorstring.Port {
+func (c Converter) k8sPortToCalico(port extensions.NetworkPolicyPort) []numorstring.Port {
 	if port.Port != nil {
 		p, err := numorstring.PortFromString(port.Port.String())
 		if err != nil {

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.networkPolicyToPolicy(&np)
+		pol, err := c.NetworkPolicyToPolicy(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
@@ -285,7 +285,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.networkPolicyToPolicy(&np)
+		pol, err := c.NetworkPolicyToPolicy(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
@@ -343,7 +343,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		var pol *model.KVPair
 		var err error
 		By("parsing the policy", func() {
-			pol, err = c.networkPolicyToPolicy(&np)
+			pol, err = c.NetworkPolicyToPolicy(&np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pol.Key.(model.PolicyKey).Name).To(Equal("knp.default.default.testPolicy"))
 			Expect(int(*pol.Value.(*model.Policy).Order)).To(Equal(1000))
@@ -419,7 +419,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		var pol *model.KVPair
 		var err error
 		By("parsing the policy", func() {
-			pol, err = c.networkPolicyToPolicy(&np)
+			pol, err = c.NetworkPolicyToPolicy(&np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pol.Key.(model.PolicyKey).Name).To(Equal("knp.default.default.testPolicy"))
 			Expect(int(*pol.Value.(*model.Policy).Order)).To(Equal(1000))
@@ -467,7 +467,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.networkPolicyToPolicy(&np)
+		pol, err := c.NetworkPolicyToPolicy(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
@@ -511,7 +511,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.networkPolicyToPolicy(&np)
+		pol, err := c.NetworkPolicyToPolicy(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
@@ -551,7 +551,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.networkPolicyToPolicy(&np)
+		pol, err := c.NetworkPolicyToPolicy(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
@@ -594,7 +594,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.networkPolicyToPolicy(&np)
+		pol, err := c.NetworkPolicyToPolicy(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -29,8 +29,8 @@ import (
 
 var _ = Describe("Test parsing strings", func() {
 
-	// Use a single instance of the converter for these tests.
-	c := converter{}
+	// Use a single instance of the Converter for these tests.
+	c := Converter{}
 
 	It("should parse workloadIDs", func() {
 		workloadName := "Namespace.podName"
@@ -87,8 +87,8 @@ var _ = Describe("Test parsing strings", func() {
 
 var _ = Describe("Test Pod conversion", func() {
 
-	// Use a single instance of the converter for these tests.
-	c := converter{}
+	// Use a single instance of the Converter for these tests.
+	c := Converter{}
 
 	It("should parse a Pod with an IP to a WorkloadEndpoint", func() {
 		pod := k8sapi.Pod{
@@ -206,8 +206,8 @@ var _ = Describe("Test Pod conversion", func() {
 
 var _ = Describe("Test NetworkPolicy conversion", func() {
 
-	// Use a single instance of the converter for these tests.
-	c := converter{}
+	// Use a single instance of the Converter for these tests.
+	c := Converter{}
 
 	It("should parse a basic NetworkPolicy to a Policy", func() {
 		port80 := intstr.FromInt(80)
@@ -619,8 +619,8 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 
 var _ = Describe("Test Namespace conversion", func() {
 
-	// Use a single instance of the converter for these tests.
-	c := converter{}
+	// Use a single instance of the Converter for these tests.
+	c := Converter{}
 
 	It("should parse a Namespace to a Profile", func() {
 		ns := k8sapi.Namespace{

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -612,7 +612,7 @@ func (c *KubeClient) listPolicies(l model.PolicyListOptions) ([]*model.KVPair, e
 	// For each policy, turn it into a Policy and generate the list.
 	ret := []*model.KVPair{}
 	for _, p := range networkPolicies.Items {
-		kvp, err := c.converter.networkPolicyToPolicy(&p)
+		kvp, err := c.converter.NetworkPolicyToPolicy(&p)
 		if err != nil {
 			return nil, err
 		}
@@ -655,7 +655,7 @@ func (c *KubeClient) getPolicy(k model.PolicyKey) (*model.KVPair, error) {
 		if err != nil {
 			return nil, resources.K8sErrorToCalico(err, k)
 		}
-		return c.converter.networkPolicyToPolicy(&networkPolicy)
+		return c.converter.NetworkPolicyToPolicy(&networkPolicy)
 	} else {
 		// This is backed by a Global Network Policy CRD.
 		return c.gnpClient.Get(k)

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -56,7 +56,7 @@ type KubeClient struct {
 
 	// Contains methods for converting Kubernetes resources to
 	// Calico resources.
-	converter converter
+	converter Converter
 
 	// Clients for interacting with Calico resources.
 	globalBgpPeerClient     resources.K8sResourceClient

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -153,7 +153,7 @@ func (k *realKubeAPI) getReadyStatus(key model.ReadyFlagKey) (*model.KVPair, err
 	return k.kc.getReadyStatus(key)
 }
 
-func newSyncer(kubeAPI kubeAPI, converter converter, callbacks api.SyncerCallbacks, disableNodePoll bool) *kubeSyncer {
+func newSyncer(kubeAPI kubeAPI, converter Converter, callbacks api.SyncerCallbacks, disableNodePoll bool) *kubeSyncer {
 	syn := &kubeSyncer{
 		kubeAPI:   kubeAPI,
 		converter: converter,
@@ -189,7 +189,7 @@ func newSyncer(kubeAPI kubeAPI, converter converter, callbacks api.SyncerCallbac
 
 type kubeSyncer struct {
 	kubeAPI         kubeAPI
-	converter       converter
+	converter       Converter
 	callbacks       api.SyncerCallbacks
 	OneShot         bool
 	disableNodePoll bool

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -650,7 +650,7 @@ func (syn *kubeSyncer) performSnapshot(versions *resourceVersions) (map[string][
 
 			versions.networkPolicyVersion = npList.ListMeta.ResourceVersion
 			for _, np := range npList.Items {
-				pol, _ := syn.converter.networkPolicyToPolicy(&np)
+				pol, _ := syn.converter.NetworkPolicyToPolicy(&np)
 				snap[KEY_NP] = append(snap[KEY_NP], *pol)
 				keys[KEY_NP][pol.Key.String()] = true
 			}
@@ -991,7 +991,7 @@ func (syn *kubeSyncer) parseNetworkPolicyEvent(e watch.Event) *model.KVPair {
 	}
 
 	// Convert the received NetworkPolicy into a profile KVPair.
-	kvp, err := syn.converter.networkPolicyToPolicy(np)
+	kvp, err := syn.converter.NetworkPolicyToPolicy(np)
 	if err != nil {
 		log.Panicf("%s", err)
 	}

--- a/lib/backend/k8s/syncer_test.go
+++ b/lib/backend/k8s/syncer_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Test Syncer", func() {
 			poolC: make(chan watch.Event),
 			state: map[model.Key]interface{}{},
 		}
-		syn = newSyncer(tc, converter{}, tc, false)
+		syn = newSyncer(tc, Converter{}, tc, false)
 	})
 
 	It("should create a syncer", func() {


### PR DESCRIPTION
## Description
To avoid duplication of policy conversion code in k8s-policy, made Kubernetes network policy to calico policy conversion API public so that k8s-policy can simply import backend package and reuse existing code.
-  Tests ran: `make test-containerized` 

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
