### PR TITLE
Fix how we generate inbound rules

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -209,7 +209,7 @@ func (c Converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.K
 	order := float64(1000.0)
 
 	// Generate the inbound rules list.
-	inboundRules := []model.Rule{}
+	var inboundRules []model.Rule
 	for _, r := range np.Spec.Ingress {
 		inboundRules = append(inboundRules, c.k8sIngressRuleToCalico(r, np.ObjectMeta.Namespace)...)
 	}
@@ -334,7 +334,7 @@ func (c Converter) k8sIngressRuleToCalico(r extensions.NetworkPolicyIngressRule,
 
 func (c Converter) buildRule(port *extensions.NetworkPolicyPort, peer *extensions.NetworkPolicyPeer, ns string) model.Rule {
 	var protocol *numorstring.Protocol
-	dstPorts := []numorstring.Port{}
+	var dstPorts []numorstring.Port
 	srcSelector := ""
 	if port != nil {
 		// Port information available.
@@ -378,14 +378,15 @@ func (c Converter) k8sPeerToCalicoSelector(peer extensions.NetworkPolicyPeer, ns
 }
 
 func (c Converter) k8sPortToCalico(port extensions.NetworkPolicyPort) []numorstring.Port {
+	var portList []numorstring.Port
 	if port.Port != nil {
 		p, err := numorstring.PortFromString(port.Port.String())
 		if err != nil {
 			log.Panic("Invalid port %+v: %s", port.Port, err)
 		}
-		return []numorstring.Port{p}
+		return append(portList, p)
 	}
 
 	// No ports - return empty list.
-	return []numorstring.Port{}
+	return portList
 }


### PR DESCRIPTION
## Description

This brings the rules generated through KDD so they match the nil vs empty semantics which is present when using etcd and certain lists are not present in the datastore.

This is important for letting the policy controller import KDD conversion code to translate policies to be programmed into etcd. 