### PR TITLE
Tweak names of objects generated by KDD

### DIFF
--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -46,13 +46,6 @@ var _ = Describe("Test parsing strings", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ns).To(Equal("Namespace"))
 		Expect(polName).To(Equal("policyName"))
-
-		// Parse a Namespace backed Policy.
-		name = "ns.projectcalico.org/Namespace"
-		ns, err = c.parsePolicyNameNamespace(name)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ns).To(Equal("Namespace"))
-
 	})
 
 	It("should not parse invalid policy names", func() {
@@ -63,22 +56,17 @@ var _ = Describe("Test parsing strings", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(ns).To(Equal(""))
 		Expect(polName).To(Equal(""))
-
-		// As a Namespace.
-		ns, err = c.parsePolicyNameNamespace(name)
-		Expect(err).To(HaveOccurred())
-		Expect(ns).To(Equal(""))
 	})
 
 	It("should parse valid profile names", func() {
-		name := "ns.projectcalico.org/default"
+		name := "k8s_ns.default"
 		ns, err := c.parseProfileName(name)
 		Expect(ns).To(Equal("default"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not parse invalid profile names", func() {
-		name := "k8s_ns.default"
+		name := "ns.projectcalico.org/default"
 		ns, err := c.parseProfileName(name)
 		Expect(err).To(HaveOccurred())
 		Expect(ns).To(Equal(""))
@@ -650,8 +638,8 @@ var _ = Describe("Test Namespace conversion", func() {
 
 		// Check labels.
 		labels := p.Value.(*model.Profile).Labels
-		Expect(labels["k8s_ns/label/foo"]).To(Equal("bar"))
-		Expect(labels["k8s_ns/label/roger"]).To(Equal("rabbit"))
+		Expect(labels["pcns.foo"]).To(Equal("bar"))
+		Expect(labels["pcns.roger"]).To(Equal("rabbit"))
 	})
 
 	It("should parse a Namespace to a Profile with no labels", func() {

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -320,12 +320,12 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Performing a Get on the Profile and ensure no error in the Calico API", func() {
-			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("ns.projectcalico.org/%s", ns.ObjectMeta.Name)})
+			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("k8s_ns.%s", ns.ObjectMeta.Name)})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking the correct entries are in our cache", func() {
-			expectedName := "ns.projectcalico.org/test-syncer-namespace-default-deny"
+			expectedName := "k8s_ns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileTagsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
@@ -337,7 +337,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Checking the correct entries are no longer in our cache", func() {
-			expectedName := "ns.projectcalico.org/test-syncer-namespace-default-deny"
+			expectedName := "k8s_ns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileTagsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
@@ -377,13 +377,13 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 
 		// Perform a Get and ensure no error in the Calico API.
 		By("getting a Profile", func() {
-			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("ns.projectcalico.org/%s", ns.ObjectMeta.Name)})
+			_, err := c.Get(model.ProfileKey{Name: fmt.Sprintf("k8s_ns.%s", ns.ObjectMeta.Name)})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Expect corresponding Profile updates over the syncer for this Namespace.
 		By("Checking the correct entries are in our cache", func() {
-			expectedName := "ns.projectcalico.org/test-syncer-namespace-no-default-deny"
+			expectedName := "k8s_ns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileTagsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
@@ -395,7 +395,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Checking the correct entries are in no longer in our cache", func() {
-			expectedName := "ns.projectcalico.org/test-syncer-namespace-no-default-deny"
+			expectedName := "k8s_ns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileTagsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())


### PR DESCRIPTION
## Description

Part of an effort to:
- Share code between KDD and etcd (policy controller)
- Make the naming and generated resources align between kdd and etcd.