### PR TITLE
Add flag to enable/disable host endpoint policy on forward traffic.

### DIFF
--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -118,6 +118,9 @@ type PolicySpec struct {
 	// PreDNAT indicates to apply the rules in this policy before any DNAT.
 	PreDNAT bool `json:"preDNAT,omitempty"`
 
+	// ApplyOnForward indicates to apply the rules in this policy on forward traffic.
+	ApplyOnForward bool `json:"applyOnForward,omitempty"`
+
 	// Types indicates whether this policy applies to ingress, or to egress, or to both.  When
 	// not explicitly specified (and so the value on creation is empty or nil), Calico defaults
 	// Types according to what IngressRules and EgressRules are present in the policy.  The

--- a/lib/backend/k8s/resources/globalnetworkpolicies_test.go
+++ b/lib/backend/k8s/resources/globalnetworkpolicies_test.go
@@ -104,15 +104,19 @@ var _ = Describe("Global Network Policies conversion methods", func() {
 		BeforeEach(func() {
 			kvp1.Value.(*model.Policy).DoNotTrack = false
 			kvp1.Value.(*model.Policy).PreDNAT = true
+			kvp1.Value.(*model.Policy).ApplyOnForward = true
 			res1.Spec.DoNotTrack = false
 			res1.Spec.PreDNAT = true
+			res1.Spec.ApplyOnForward = true
 		})
 
 		AfterEach(func() {
 			kvp1.Value.(*model.Policy).DoNotTrack = true
 			kvp1.Value.(*model.Policy).PreDNAT = false
+			kvp1.Value.(*model.Policy).ApplyOnForward = true
 			res1.Spec.DoNotTrack = true
 			res1.Spec.PreDNAT = false
+			res1.Spec.ApplyOnForward = true
 		})
 
 		It("should convert between a KVPair and the equivalent Kubernetes resource", func() {

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -89,14 +89,15 @@ func (options PolicyListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type Policy struct {
-	Order         *float64          `json:"order,omitempty" validate:"omitempty"`
-	InboundRules  []Rule            `json:"inbound_rules,omitempty" validate:"omitempty,dive"`
-	OutboundRules []Rule            `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
-	Selector      string            `json:"selector" validate:"selector"`
-	DoNotTrack    bool              `json:"untracked,omitempty"`
-	Annotations   map[string]string `json:"annotations,omitempty"`
-	PreDNAT       bool              `json:"pre_dnat,omitempty"`
-	Types         []string          `json:"types,omitempty"`
+	Order          *float64          `json:"order,omitempty" validate:"omitempty"`
+	InboundRules   []Rule            `json:"inbound_rules,omitempty" validate:"omitempty,dive"`
+	OutboundRules  []Rule            `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
+	Selector       string            `json:"selector" validate:"selector"`
+	DoNotTrack     bool              `json:"untracked,omitempty"`
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	PreDNAT        bool              `json:"pre_dnat,omitempty"`
+	ApplyOnForward bool              `json:"apply_on_forward,omitempty"`
+	Types          []string          `json:"types,omitempty"`
 }
 
 func (p Policy) String() string {
@@ -117,6 +118,7 @@ func (p Policy) String() string {
 	parts = append(parts, fmt.Sprintf("outbound:%v", strings.Join(outRules, ";")))
 	parts = append(parts, fmt.Sprintf("untracked:%v", p.DoNotTrack))
 	parts = append(parts, fmt.Sprintf("pre_dnat:%v", p.PreDNAT))
+	parts = append(parts, fmt.Sprintf("apply_on_forward:%v", p.ApplyOnForward))
 	parts = append(parts, fmt.Sprintf("types:%v", strings.Join(p.Types, ";")))
 	return strings.Join(parts, ",")
 }

--- a/lib/backend/model/policy_test.go
+++ b/lib/backend/model/policy_test.go
@@ -26,14 +26,15 @@ var _ = Describe("Policy functions", func() {
 	It("Policy should stringify correctly", func() {
 		order := 10.5
 		p := model.Policy{
-			Order:         &order,
-			InboundRules:  []model.Rule{model.Rule{Action: "deny"}},
-			OutboundRules: []model.Rule{model.Rule{Action: "allow"}},
-			Selector:      "apples=='oranges'",
-			DoNotTrack:    false,
-			PreDNAT:       true,
-			Types:         []string{"ingress", "egress"},
+			Order:          &order,
+			InboundRules:   []model.Rule{model.Rule{Action: "deny"}},
+			OutboundRules:  []model.Rule{model.Rule{Action: "allow"}},
+			Selector:       "apples=='oranges'",
+			DoNotTrack:     false,
+			PreDNAT:        true,
+			ApplyOnForward: true,
+			Types:          []string{"ingress", "egress"},
 		}
-		Expect(p.String()).To(Equal("order:10.5,selector:\"apples=='oranges'\",inbound:deny,outbound:allow,untracked:false,pre_dnat:true,types:ingress;egress"))
+		Expect(p.String()).To(Equal("order:10.5,selector:\"apples=='oranges'\",inbound:deny,outbound:allow,untracked:false,pre_dnat:true,apply_on_forward:true,types:ingress;egress"))
 	})
 })

--- a/lib/client/policy_e2e_test.go
+++ b/lib/client/policy_e2e_test.go
@@ -65,37 +65,41 @@ var policySpec1AfterRead = api.PolicySpec{
 }
 
 var policySpec2 = api.PolicySpec{
-	Order:        &order2,
-	IngressRules: []api.Rule{testutils.InRule2, testutils.InRule1},
-	EgressRules:  []api.Rule{testutils.EgressRule2, testutils.EgressRule1},
-	Selector:     "thing2 == 'value2'",
-	DoNotTrack:   true,
+	Order:          &order2,
+	IngressRules:   []api.Rule{testutils.InRule2, testutils.InRule1},
+	EgressRules:    []api.Rule{testutils.EgressRule2, testutils.EgressRule1},
+	Selector:       "thing2 == 'value2'",
+	DoNotTrack:     true,
+	ApplyOnForward: true,
 }
 
 // When reading back, the rules should have been updated to the newer format.
 var policySpec2AfterRead = api.PolicySpec{
-	Order:        &order2,
-	IngressRules: []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
-	EgressRules:  []api.Rule{testutils.EgressRule2AfterRead, testutils.EgressRule1AfterRead},
-	Selector:     "thing2 == 'value2'",
-	DoNotTrack:   true,
-	Types:        []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
+	Order:          &order2,
+	IngressRules:   []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
+	EgressRules:    []api.Rule{testutils.EgressRule2AfterRead, testutils.EgressRule1AfterRead},
+	Selector:       "thing2 == 'value2'",
+	DoNotTrack:     true,
+	ApplyOnForward: true,
+	Types:          []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 }
 
 var policySpec3 = api.PolicySpec{
-	Order:        &order2,
-	IngressRules: []api.Rule{testutils.InRule2, testutils.InRule1},
-	Selector:     "thing2 == 'value2'",
-	PreDNAT:      true,
+	Order:          &order2,
+	IngressRules:   []api.Rule{testutils.InRule2, testutils.InRule1},
+	Selector:       "thing2 == 'value2'",
+	PreDNAT:        true,
+	ApplyOnForward: true,
 }
 
 // When reading back, the rules should have been updated to the newer format.
 var policySpec3AfterRead = api.PolicySpec{
-	Order:        &order2,
-	IngressRules: []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
-	Selector:     "thing2 == 'value2'",
-	PreDNAT:      true,
-	Types:        []api.PolicyType{api.PolicyTypeIngress},
+	Order:          &order2,
+	IngressRules:   []api.Rule{testutils.InRule2AfterRead, testutils.InRule1AfterRead},
+	Selector:       "thing2 == 'value2'",
+	PreDNAT:        true,
+	ApplyOnForward: true,
+	Types:          []api.PolicyType{api.PolicyTypeIngress},
 }
 
 // When reading back, an empty policy has Types 'ingress'.

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -542,6 +542,11 @@ func validatePolicySpec(v *validator.Validate, structLevel *validator.StructLeve
 		}
 	}
 
+	if !m.ApplyOnForward && (m.DoNotTrack || m.PreDNAT) {
+		structLevel.ReportError(reflect.ValueOf(m.ApplyOnForward),
+			"PolicySpec.ApplyOnForward", "", reason("ApplyOnForward must be true if either PreDNAT or DoNotTrack is true, for a given PolicySpec"))
+	}
+
 	// Check (and disallow) any repeats in Types field.
 	mp := map[api.PolicyType]bool{}
 	for _, t := range m.Types {

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -643,28 +643,71 @@ func init() {
 		Entry("should reject node with IPv4 address in IPv6 field", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: &netv4_1}}, false),
 		Entry("should reject Policy with both PreDNAT and DoNotTrack",
 			api.PolicySpec{
-				PreDNAT:    true,
-				DoNotTrack: true,
+				PreDNAT:        true,
+				DoNotTrack:     true,
+				ApplyOnForward: true,
 			}, false),
 		Entry("should accept Policy with PreDNAT but not DoNotTrack",
 			api.PolicySpec{
-				PreDNAT: true,
+				PreDNAT:        true,
+				ApplyOnForward: true,
 			}, true),
 		Entry("should accept Policy with DoNotTrack but not PreDNAT",
 			api.PolicySpec{
-				PreDNAT:    false,
-				DoNotTrack: true,
+				PreDNAT:        false,
+				DoNotTrack:     true,
+				ApplyOnForward: true,
 			}, true),
 		Entry("should reject pre-DNAT Policy with egress rules",
 			api.PolicySpec{
-				PreDNAT:     true,
-				EgressRules: []api.Rule{{Action: "allow"}},
+				PreDNAT:        true,
+				ApplyOnForward: true,
+				EgressRules:    []api.Rule{{Action: "allow"}},
 			}, false),
 		Entry("should accept pre-DNAT Policy with ingress rules",
 			api.PolicySpec{
-				PreDNAT:      true,
-				IngressRules: []api.Rule{{Action: "allow"}},
+				PreDNAT:        true,
+				ApplyOnForward: true,
+				IngressRules:   []api.Rule{{Action: "allow"}},
 			}, true),
+
+		// PolicySpec ApplyOnForward field checks.
+		Entry("should accept Policy with ApplyOnForward but not PreDNAT",
+			api.PolicySpec{
+				PreDNAT:        false,
+				ApplyOnForward: true,
+			}, true),
+		Entry("should accept Policy with ApplyOnForward but not DoNotTrack",
+			api.PolicySpec{
+				DoNotTrack:     false,
+				ApplyOnForward: true,
+			}, true),
+		Entry("should accept Policy with ApplyOnForward and PreDNAT",
+			api.PolicySpec{
+				PreDNAT:        true,
+				ApplyOnForward: true,
+			}, true),
+		Entry("should accept Policy with ApplyOnForward and DoNotTrack",
+			api.PolicySpec{
+				DoNotTrack:     true,
+				ApplyOnForward: true,
+			}, true),
+		Entry("should accept Policy with no ApplyOnForward DoNotTrack PreDNAT",
+			api.PolicySpec{
+				PreDNAT:        false,
+				DoNotTrack:     false,
+				ApplyOnForward: false,
+			}, true),
+		Entry("should reject Policy with PreDNAT but not ApplyOnForward",
+			api.PolicySpec{
+				PreDNAT:        true,
+				ApplyOnForward: false,
+			}, false),
+		Entry("should reject Policy with DoNotTrack but not ApplyOnForward",
+			api.PolicySpec{
+				DoNotTrack:     true,
+				ApplyOnForward: false,
+			}, false),
 
 		// PolicySpec Types field checks.
 		Entry("allow missing Types", api.PolicySpec{}, true),
@@ -706,18 +749,21 @@ func init() {
 			}, true),
 		Entry("allow ingress Types with pre-DNAT",
 			api.PolicySpec{
-				PreDNAT: true,
-				Types:   []api.PolicyType{api.PolicyTypeIngress},
+				PreDNAT:        true,
+				ApplyOnForward: true,
+				Types:          []api.PolicyType{api.PolicyTypeIngress},
 			}, true),
 		Entry("disallow egress Types with pre-DNAT",
 			api.PolicySpec{
-				PreDNAT: true,
-				Types:   []api.PolicyType{api.PolicyTypeEgress},
+				PreDNAT:        true,
+				ApplyOnForward: true,
+				Types:          []api.PolicyType{api.PolicyTypeEgress},
 			}, false),
 		Entry("disallow ingress+egress Types with pre-DNAT",
 			api.PolicySpec{
-				PreDNAT: true,
-				Types:   []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
+				PreDNAT:        true,
+				ApplyOnForward: true,
+				Types:          []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 			}, false),
 	)
 }


### PR DESCRIPTION
## Description
This feature allow user to specify if a host endpoint policy applies on forward traffic or not. Currently host endpoint policy applies on forward traffic regardlessly.

## Todos
- [X] Tests
- [ ] Documentation
- [ ] Release note


