### PR TITLE
Make WorkloadEndpoint conversion code public

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -137,9 +137,9 @@ func (c Converter) hasIPAddress(pod *kapiv1.Pod) bool {
 	return pod.Status.PodIP != ""
 }
 
-// podToWorkloadEndpoint converts a Pod to a WorkloadEndpoint.  It assumes the calling code
+// PodToWorkloadEndpoint converts a Pod to a WorkloadEndpoint.  It assumes the calling code
 // has verified that the provided Pod is valid to convert to a WorkloadEndpoint.
-func (c Converter) podToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error) {
+func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error) {
 	// Pull out the profile and workload ID based on pod name and Namespace.
 	profile := fmt.Sprintf("k8s_ns.%s", pod.ObjectMeta.Namespace)
 	workload := fmt.Sprintf("%s.%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Test Pod conversion", func() {
 			},
 		}
 
-		wep, err := c.podToWorkloadEndpoint(&pod)
+		wep, err := c.PodToWorkloadEndpoint(&pod)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields.
@@ -192,7 +192,7 @@ var _ = Describe("Test Pod conversion", func() {
 			Status: k8sapi.PodStatus{},
 		}
 
-		_, err := c.podToWorkloadEndpoint(&pod)
+		_, err := c.PodToWorkloadEndpoint(&pod)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -210,7 +210,7 @@ var _ = Describe("Test Pod conversion", func() {
 			},
 		}
 
-		wep, err := c.podToWorkloadEndpoint(&pod)
+		wep, err := c.PodToWorkloadEndpoint(&pod)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields.
@@ -238,7 +238,7 @@ var _ = Describe("Test Pod conversion", func() {
 			},
 		}
 
-		_, err := c.podToWorkloadEndpoint(&pod)
+		_, err := c.PodToWorkloadEndpoint(&pod)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -512,7 +512,7 @@ func (c *KubeClient) applyWorkloadEndpoint(k *model.KVPair) (*model.KVPair, erro
 			return nil, resources.K8sErrorToCalico(err, k.Key)
 		}
 		log.Debugf("Successfully applied pod: %+v", pod)
-		return c.converter.podToWorkloadEndpoint(pod)
+		return c.converter.PodToWorkloadEndpoint(pod)
 	}
 	return k, nil
 }
@@ -553,7 +553,7 @@ func (c *KubeClient) listWorkloadEndpoints(l model.WorkloadEndpointListOptions) 
 			continue
 		}
 
-		kvp, err := c.converter.podToWorkloadEndpoint(&pod)
+		kvp, err := c.converter.PodToWorkloadEndpoint(&pod)
 		if err != nil {
 			return nil, err
 		}
@@ -577,7 +577,7 @@ func (c *KubeClient) getWorkloadEndpoint(k model.WorkloadEndpointKey) (*model.KV
 	if !c.converter.isReadyCalicoPod(pod) {
 		return nil, errors.ErrorResourceDoesNotExist{Identifier: k}
 	}
-	return c.converter.podToWorkloadEndpoint(pod)
+	return c.converter.PodToWorkloadEndpoint(pod)
 }
 
 // listPolicies lists the Policies from the k8s API based on NetworkPolicy objects.

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -702,7 +702,7 @@ func (syn *kubeSyncer) performSnapshot(versions *resourceVersions) (map[string][
 				}
 
 				// Convert to a workload endpoint.
-				wep, err := syn.converter.podToWorkloadEndpoint(&po)
+				wep, err := syn.converter.PodToWorkloadEndpoint(&po)
 				if err != nil {
 					log.WithError(err).Error("Failed to convert pod to workload endpoint")
 					continue
@@ -964,7 +964,7 @@ func (syn *kubeSyncer) parsePodEvent(e watch.Event) *model.KVPair {
 	}
 
 	// Convert the received Pod into a KVPair.
-	kvp, err := syn.converter.podToWorkloadEndpoint(pod)
+	kvp, err := syn.converter.PodToWorkloadEndpoint(pod)
 	if err != nil {
 		// If we fail to parse, then ignore this update and emit a log.
 		log.WithField("error", err).Error("Failed to parse Pod event")

--- a/lib/converter/workloadendpoint.go
+++ b/lib/converter/workloadendpoint.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// WorkloadEndpointConverter implements a set of functions used for converting between
+// API and backend representations of the WorkloadEndpoint resource.
+type WorkloadEndpointConverter struct{}
+
+// ConvertMetadataToKey converts a WorkloadEndpointMetadata to a WorkloadEndpointKey
+func (w *WorkloadEndpointConverter) ConvertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
+	hm := m.(api.WorkloadEndpointMetadata)
+	k := model.WorkloadEndpointKey{
+		Hostname:       hm.Node,
+		OrchestratorID: hm.Orchestrator,
+		WorkloadID:     hm.Workload,
+		EndpointID:     hm.Name,
+	}
+	return k, nil
+}
+
+// ConvertAPIToKVPair converts an API WorkloadEndpoint structure to a KVPair containing a
+// backend WorkloadEndpoint and WorkloadEndpointKey.
+func (w *WorkloadEndpointConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error) {
+	ah := a.(api.WorkloadEndpoint)
+	k, err := w.ConvertMetadataToKey(ah.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	// IP networks are stored in the datastore in separate IPv4 and IPv6
+	// fields.  We normalise the network to ensure the IP is correctly
+	// masked.
+	ipv4Nets := []net.IPNet{}
+	ipv6Nets := []net.IPNet{}
+	for _, n := range ah.Spec.IPNetworks {
+		n = *(n.Network())
+		if n.Version() == 4 {
+			ipv4Nets = append(ipv4Nets, n)
+		} else {
+			ipv6Nets = append(ipv6Nets, n)
+		}
+	}
+
+	ipv4NAT := []model.IPNAT{}
+	ipv6NAT := []model.IPNAT{}
+	for _, n := range ah.Spec.IPNATs {
+		nat := model.IPNAT{IntIP: n.InternalIP, ExtIP: n.ExternalIP}
+		if n.InternalIP.Version() == 4 {
+			ipv4NAT = append(ipv4NAT, nat)
+		} else {
+			ipv6NAT = append(ipv6NAT, nat)
+		}
+	}
+
+	d := model.KVPair{
+		Key: k,
+		Value: &model.WorkloadEndpoint{
+			Labels:           ah.Metadata.Labels,
+			ActiveInstanceID: ah.Metadata.ActiveInstanceID,
+			State:            "active",
+			Name:             ah.Spec.InterfaceName,
+			Mac:              ah.Spec.MAC,
+			ProfileIDs:       ah.Spec.Profiles,
+			IPv4Nets:         ipv4Nets,
+			IPv6Nets:         ipv6Nets,
+			IPv4NAT:          ipv4NAT,
+			IPv6NAT:          ipv6NAT,
+			IPv4Gateway:      ah.Spec.IPv4Gateway,
+			IPv6Gateway:      ah.Spec.IPv6Gateway,
+		},
+		Revision: ah.Metadata.Revision,
+	}
+
+	return &d, nil
+}
+
+// ConvertKVPairToAPI converts a KVPair containing a backend WorkloadEndpoint and WorkloadEndpointKey
+// to an API WorkloadEndpoint structure.
+func (w *WorkloadEndpointConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error) {
+	bh := d.Value.(*model.WorkloadEndpoint)
+	bk := d.Key.(model.WorkloadEndpointKey)
+
+	nets := bh.IPv4Nets
+	nets = append(nets, bh.IPv6Nets...)
+
+	nats := []api.IPNAT{}
+	mnats := bh.IPv4NAT
+	mnats = append(mnats, bh.IPv6NAT...)
+	for _, mnat := range mnats {
+		nat := api.IPNAT{InternalIP: mnat.IntIP, ExternalIP: mnat.ExtIP}
+		nats = append(nats, nat)
+	}
+
+	ah := api.NewWorkloadEndpoint()
+	ah.Metadata.Node = bk.Hostname
+	ah.Metadata.Orchestrator = bk.OrchestratorID
+	ah.Metadata.Workload = bk.WorkloadID
+	ah.Metadata.Name = bk.EndpointID
+	ah.Metadata.Labels = bh.Labels
+	ah.Spec.InterfaceName = bh.Name
+	ah.Metadata.ActiveInstanceID = bh.ActiveInstanceID
+	ah.Spec.MAC = bh.Mac
+	ah.Spec.Profiles = bh.ProfileIDs
+	if len(nets) == 0 {
+		ah.Spec.IPNetworks = nil
+	} else {
+		ah.Spec.IPNetworks = nets
+	}
+	if len(nats) == 0 {
+		ah.Spec.IPNATs = nil
+	} else {
+		ah.Spec.IPNATs = nats
+	}
+	ah.Spec.IPv4Gateway = bh.IPv4Gateway
+	ah.Spec.IPv6Gateway = bh.IPv6Gateway
+	ah.Metadata.Revision = d.Revision
+
+	return ah, nil
+}


### PR DESCRIPTION
## Description

Make WEP conversion code public so that it can be used by the policy controller.

Necessary for making named ports available to the policy controller. 