### PR TITLE
Named ports + FV fixes

### DIFF
--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,6 +77,9 @@ type HostEndpointSpec struct {
 	// profile is applied in the order that they appear in this list.  Profile rules are applied
 	// after the selector-based security policy.
 	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,namespacedname"`
+
+	// Ports contains the endpoint's named ports, which may be referenced in security policy rules.
+	Ports []EndpointPort `json:"ports,omitempty" validate:"omitempty,dive"`
 }
 
 // NewHostEndpoint creates a new (zeroed) HostEndpoint struct with the TypeMetadata initialised to the current

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
 type WorkloadEndpoint struct {
@@ -104,6 +105,9 @@ type WorkloadEndpointSpec struct {
 
 	// MAC is the MAC address of the endpoint interface.
 	MAC *net.MAC `json:"mac,omitempty" validate:"omitempty,mac"`
+
+	// Ports contains the endpoint's named ports, which may be referenced in security policy rules.
+	Ports []EndpointPort `json:"ports,omitempty" validate:"omitempty,dive"`
 }
 
 // IPNat contains a single NAT mapping for a WorkloadEndpoint resource.
@@ -114,6 +118,12 @@ type IPNAT struct {
 
 	// The external IP address.
 	ExternalIP net.IP `json:"externalIP"`
+}
+
+type EndpointPort struct {
+	Name     string               `json:"name" validate:"name"`
+	Protocol numorstring.Protocol `json:"protocol"`
+	Port     uint16               `json:"port" validate:"gt=0"`
 }
 
 // String returns a friendly form of an IPNAT.

--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -167,6 +167,35 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 	}
 	labels["calico/k8s_ns"] = pod.ObjectMeta.Namespace
 
+	// Map any named ports through.
+	var endpointPorts []model.EndpointPort
+	for _, container := range pod.Spec.Containers {
+		for _, containerPort := range container.Ports {
+			if containerPort.Name != "" && containerPort.ContainerPort != 0 {
+				var modelProto numorstring.Protocol
+				switch containerPort.Protocol {
+				case kapiv1.ProtocolUDP:
+					modelProto = numorstring.ProtocolFromString("udp")
+				case kapiv1.ProtocolTCP, kapiv1.Protocol("") /* K8s default is TCP. */ :
+					modelProto = numorstring.ProtocolFromString("tcp")
+				default:
+					log.WithFields(log.Fields{
+						"protocol": containerPort.Protocol,
+						"pod":      pod,
+						"port":     containerPort,
+					}).Debug("Ignoring named port with unknown protocol")
+					continue
+				}
+
+				endpointPorts = append(endpointPorts, model.EndpointPort{
+					Name:     containerPort.Name,
+					Protocol: modelProto,
+					Port:     uint16(containerPort.ContainerPort),
+				})
+			}
+		}
+	}
+
 	// Create the key / value pair to return.
 	kvp := model.KVPair{
 		Key: model.WorkloadEndpointKey{
@@ -182,6 +211,7 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 			IPv4Nets:   ipNets,
 			IPv6Nets:   []cnet.IPNet{},
 			Labels:     labels,
+			Ports:      endpointPorts,
 		},
 		Revision: pod.ObjectMeta.ResourceVersion,
 	}
@@ -348,7 +378,7 @@ func (c Converter) k8sRuleToCalico(rPeers []extensions.NetworkPolicyPeer, rPorts
 		ports = []*extensions.NetworkPolicyPort{nil}
 	}
 
-	// Combine desintations with sources to generate rules.
+	// Combine destinations with sources to generate rules.
 	// TODO: This currently creates a lot of rules by making every combination of from / ports
 	// into a rule.  We can combine these so that we don't need as many rules!
 	for _, port := range ports {

--- a/lib/backend/k8s/resources/node_conversion_test.go
+++ b/lib/backend/k8s/resources/node_conversion_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -24,7 +38,7 @@ var _ = Describe("Test Node conversion", func() {
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4CidrAnnotation: "172.17.17.10/24",
-					nodeBgpAsnAnnotation:    "2546",
+					nodeBgpAsnAnnotation:      "2546",
 				},
 			},
 			Status: k8sapi.NodeStatus{
@@ -90,7 +104,7 @@ var _ = Describe("Test Node conversion", func() {
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4CidrAnnotation: "172.17.17.10/24",
-					nodeBgpAsnAnnotation:    "2546",
+					nodeBgpAsnAnnotation:      "2546",
 				},
 			},
 			Spec: k8sapi.NodeSpec{},
@@ -111,7 +125,7 @@ var _ = Describe("Test Node conversion", func() {
 				Name:            "TestNode",
 				Labels:          l,
 				ResourceVersion: "1234",
-				Annotations: make(map[string]string),
+				Annotations:     make(map[string]string),
 			},
 			Spec: k8sapi.NodeSpec{},
 		}
@@ -120,8 +134,8 @@ var _ = Describe("Test Node conversion", func() {
 		asn, _ := numorstring.ASNumberFromString("2456")
 
 		calicoNode := &model.Node{
-			BGPIPv4Net: cidr,
-			FelixIPv4: ip,
+			BGPIPv4Net:  cidr,
+			FelixIPv4:   ip,
 			BGPIPv4Addr: ip,
 			BGPASNumber: &asn,
 		}
@@ -132,4 +146,3 @@ var _ = Describe("Test Node conversion", func() {
 		Expect(newK8sNode.Annotations).To(HaveKeyWithValue(nodeBgpAsnAnnotation, "2456"))
 	})
 })
-

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,4 +108,5 @@ type HostEndpoint struct {
 	ExpectedIPv6Addrs []net.IP          `json:"expected_ipv6_addrs,omitempty" validate:"omitempty,dive,ipv6"`
 	Labels            map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
 	ProfileIDs        []string          `json:"profile_ids,omitempty" validate:"omitempty,dive,name"`
+	Ports             []EndpointPort    `json:"ports,omitempty" validate:"dive"`
 }

--- a/lib/backend/model/rule.go
+++ b/lib/backend/model/rule.go
@@ -40,23 +40,23 @@ type Rule struct {
 	SrcNet      *net.IPNet         `json:"src_net,omitempty" validate:"omitempty"`
 	SrcNets     []*net.IPNet       `json:"src_nets,omitempty" validate:"omitempty"`
 	SrcSelector string             `json:"src_selector,omitempty" validate:"omitempty,selector"`
-	SrcPorts    []numorstring.Port `json:"src_ports,omitempty" validate:"omitempty"`
+	SrcPorts    []numorstring.Port `json:"src_ports,omitempty" validate:"omitempty,dive"`
 	DstTag      string             `json:"dst_tag,omitempty" validate:"omitempty,tag"`
 	DstSelector string             `json:"dst_selector,omitempty" validate:"omitempty,selector"`
 	DstNet      *net.IPNet         `json:"dst_net,omitempty" validate:"omitempty"`
 	DstNets     []*net.IPNet       `json:"dst_nets,omitempty" validate:"omitempty"`
-	DstPorts    []numorstring.Port `json:"dst_ports,omitempty" validate:"omitempty"`
+	DstPorts    []numorstring.Port `json:"dst_ports,omitempty" validate:"omitempty,dive"`
 
 	NotSrcTag      string             `json:"!src_tag,omitempty" validate:"omitempty,tag"`
 	NotSrcNet      *net.IPNet         `json:"!src_net,omitempty" validate:"omitempty"`
 	NotSrcNets     []*net.IPNet       `json:"!src_nets,omitempty" validate:"omitempty"`
 	NotSrcSelector string             `json:"!src_selector,omitempty" validate:"omitempty,selector"`
-	NotSrcPorts    []numorstring.Port `json:"!src_ports,omitempty" validate:"omitempty"`
+	NotSrcPorts    []numorstring.Port `json:"!src_ports,omitempty" validate:"omitempty,dive"`
 	NotDstTag      string             `json:"!dst_tag,omitempty" validate:"omitempty"`
 	NotDstSelector string             `json:"!dst_selector,omitempty" validate:"omitempty,selector"`
 	NotDstNet      *net.IPNet         `json:"!dst_net,omitempty" validate:"omitempty"`
 	NotDstNets     []*net.IPNet       `json:"!dst_nets,omitempty" validate:"omitempty"`
-	NotDstPorts    []numorstring.Port `json:"!dst_ports,omitempty" validate:"omitempty"`
+	NotDstPorts    []numorstring.Port `json:"!dst_ports,omitempty" validate:"omitempty,dive"`
 
 	LogPrefix string `json:"log_prefix,omitempty" validate:"omitempty"`
 }

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -147,7 +148,6 @@ func (options WorkloadEndpointListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type WorkloadEndpoint struct {
-	// TODO: Validation for workload endpoint.
 	State            string            `json:"state"`
 	Name             string            `json:"name"`
 	ActiveInstanceID string            `json:"active_instance_id"`
@@ -160,6 +160,13 @@ type WorkloadEndpoint struct {
 	Labels           map[string]string `json:"labels,omitempty"`
 	IPv4Gateway      *net.IP           `json:"ipv4_gateway,omitempty" validate:"omitempty,ipv4"`
 	IPv6Gateway      *net.IP           `json:"ipv6_gateway,omitempty" validate:"omitempty,ipv6"`
+	Ports            []EndpointPort    `json:"ports,omitempty" validate:"dive"`
+}
+
+type EndpointPort struct {
+	Name     string               `json:"name" validate:"name"`
+	Protocol numorstring.Protocol `json:"protocol"`
+	Port     uint16               `json:"port" validate:"gt=0"`
 }
 
 // IPNat contains a single NAT mapping for a WorkloadEndpoint resource.

--- a/lib/client/hostendpoint.go
+++ b/lib/client/hostendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -140,6 +140,15 @@ func (h *hostEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.KVPai
 		}
 	}
 
+	var ports []model.EndpointPort
+	for _, port := range ah.Spec.Ports {
+		ports = append(ports, model.EndpointPort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     port.Port,
+		})
+	}
+
 	d := model.KVPair{
 		Key: k,
 		Value: &model.HostEndpoint{
@@ -149,6 +158,7 @@ func (h *hostEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.KVPai
 			ProfileIDs:        ah.Spec.Profiles,
 			ExpectedIPv4Addrs: ipv4Addrs,
 			ExpectedIPv6Addrs: ipv6Addrs,
+			Ports:             ports,
 		},
 	}
 
@@ -172,6 +182,16 @@ func (h *hostEndpoints) convertKVPairToAPI(d *model.KVPair) (unversioned.Resourc
 	ah.Spec.InterfaceName = bh.Name
 	ah.Spec.Profiles = bh.ProfileIDs
 	ah.Spec.ExpectedIPs = ips
+
+	var ports []api.EndpointPort
+	for _, port := range bh.Ports {
+		ports = append(ports, api.EndpointPort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     port.Port,
+		})
+	}
+	ah.Spec.Ports = ports
 
 	return ah, nil
 }

--- a/lib/client/hostendpoint_e2e_test.go
+++ b/lib/client/hostendpoint_e2e_test.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/api"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -183,11 +184,30 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 				InterfaceName: "eth0",
 				ExpectedIPs:   []cnet.IP{cnet.MustParseIP("10.0.0.0"), cnet.MustParseIP("20.0.0.0")},
 				Profiles:      []string{"profile1", "profile2"},
+				Ports: []api.EndpointPort{
+					{
+						Port:     1234,
+						Name:     "foobar",
+						Protocol: numorstring.ProtocolFromString("tcp"),
+					},
+					{
+						Port:     5432,
+						Name:     "bop",
+						Protocol: numorstring.ProtocolFromString("tcp"),
+					},
+				},
 			},
 			api.HostEndpointSpec{
 				InterfaceName: "eth1",
 				ExpectedIPs:   []cnet.IP{cnet.MustParseIP("192.168.0.0"), cnet.MustParseIP("192.168.1.1")},
 				Profiles:      []string{"profile3", "profile4"},
+				Ports: []api.EndpointPort{
+					{
+						Port:     5678,
+						Name:     "bazzbiff",
+						Protocol: numorstring.ProtocolFromString("udp"),
+					},
+				},
 			}),
 
 		// Test 2: Pass one partially populated HostEndpointSpec and another fully populated HostEndpointSpec and expect the series of operations to succeed.

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/client/workloadendpoint_e2e_test.go
+++ b/lib/client/workloadendpoint_e2e_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/api"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -186,6 +187,13 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				Profiles:      []string{"profile1", "profile2"},
 				InterfaceName: "eth0",
 				MAC:           &cnet.MAC{mac1},
+				Ports: []api.EndpointPort{
+					{
+						Port:     1234,
+						Name:     "foobar",
+						Protocol: numorstring.ProtocolFromString("tcp"),
+					},
+				},
 			},
 			api.WorkloadEndpointSpec{
 				IPNetworks: []cnet.IPNet{cidr3, cidr4},
@@ -201,6 +209,13 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				Profiles:      []string{"profile3", "profile4"},
 				InterfaceName: "eth1",
 				MAC:           &cnet.MAC{mac2},
+				Ports: []api.EndpointPort{
+					{
+						Port:     5678,
+						Name:     "bazzbiff",
+						Protocol: numorstring.ProtocolFromString("udp"),
+					},
+				},
 			}),
 
 		// Test 2: Pass one partially populated WorkloadEndpointSpec and another fully populated WorkloadEndpointSpec and expect the series of operations to succeed.

--- a/lib/converter/workloadendpoint.go
+++ b/lib/converter/workloadendpoint.go
@@ -71,6 +71,15 @@ func (w *WorkloadEndpointConverter) ConvertAPIToKVPair(a unversioned.Resource) (
 		}
 	}
 
+	var ports []model.EndpointPort
+	for _, port := range ah.Spec.Ports {
+		ports = append(ports, model.EndpointPort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     port.Port,
+		})
+	}
+
 	d := model.KVPair{
 		Key: k,
 		Value: &model.WorkloadEndpoint{
@@ -86,6 +95,7 @@ func (w *WorkloadEndpointConverter) ConvertAPIToKVPair(a unversioned.Resource) (
 			IPv6NAT:          ipv6NAT,
 			IPv4Gateway:      ah.Spec.IPv4Gateway,
 			IPv6Gateway:      ah.Spec.IPv6Gateway,
+			Ports:            ports,
 		},
 		Revision: ah.Metadata.Revision,
 	}
@@ -132,6 +142,17 @@ func (w *WorkloadEndpointConverter) ConvertKVPairToAPI(d *model.KVPair) (unversi
 	}
 	ah.Spec.IPv4Gateway = bh.IPv4Gateway
 	ah.Spec.IPv6Gateway = bh.IPv6Gateway
+
+	var ports []api.EndpointPort
+	for _, port := range bh.Ports {
+		ports = append(ports, api.EndpointPort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     port.Port,
+		})
+	}
+	ah.Spec.Ports = ports
+
 	ah.Metadata.Revision = d.Revision
 
 	return ah, nil

--- a/lib/numorstring/numorstring_test.go
+++ b/lib/numorstring/numorstring_test.go
@@ -116,6 +116,7 @@ func init() {
 		Entry("should marshal port of 10", portFromString("10"), "10"),
 		Entry("should marshal port range of 10:20", portFromRange(10, 20), "\"10:20\""),
 		Entry("should marshal port range of 20:30", portFromRange(20, 30), "\"20:30\""),
+		Entry("should marshal named port", numorstring.NamedPort("foobar"), `"foobar"`),
 
 		// Protocol tests.
 		Entry("should marshal protocol of 0", numorstring.ProtocolFromInt(0), "0"),

--- a/lib/numorstring/numorstring_test.go
+++ b/lib/numorstring/numorstring_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,12 +71,14 @@ func init() {
 		Entry("should accept 65535 port as int", "65535", portType, numorstring.SinglePort(65535)),
 		Entry("should accept 0:65535 port range as string", "\"0:65535\"", portType, portFromRange(0, 65535)),
 		Entry("should accept 1:10 port range as string", "\"1:10\"", portType, portFromRange(1, 10)),
+		Entry("should accept foo-bar as named port", "\"foo-bar\"", portType, numorstring.NamedPort("foo-bar")),
 		Entry("should reject -1 port as int", "-1", portType, nil),
 		Entry("should reject 65536 port as int", "65536", portType, nil),
 		Entry("should reject 0:65536 port range as string", "\"0:65536\"", portType, nil),
 		Entry("should reject -1:65535 port range as string", "\"-1:65535\"", portType, nil),
 		Entry("should reject 10:1 port range as string", "\"10:1\"", portType, nil),
 		Entry("should reject 1:2:3 port range as string", "\"1:2:3\"", portType, nil),
+		Entry("should reject bad named port string", "\"*\"", portType, nil),
 		Entry("should reject bad port string", "\"1:2", portType, nil),
 
 		// Protocol tests.  Invalid integer values will be stored as strings.

--- a/lib/numorstring/port.go
+++ b/lib/numorstring/port.go
@@ -121,7 +121,9 @@ func (p *Port) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface.
 func (p Port) MarshalJSON() ([]byte, error) {
-	if p.MinPort == p.MaxPort {
+	if p.PortName != "" {
+		return json.Marshal(p.PortName)
+	} else if p.MinPort == p.MaxPort {
 		return json.Marshal(p.MinPort)
 	} else {
 		return json.Marshal(p.String())
@@ -132,7 +134,9 @@ func (p Port) MarshalJSON() ([]byte, error) {
 // this returns a single string representation of the port number, otherwise
 // if returns a colon separated range of ports.
 func (p Port) String() string {
-	if p.MinPort == p.MaxPort {
+	if p.PortName != "" {
+		return p.PortName
+	} else if p.MinPort == p.MaxPort {
 		return strconv.FormatUint(uint64(p.MinPort), 10)
 	} else {
 		return fmt.Sprintf("%d:%d", p.MinPort, p.MaxPort)

--- a/lib/numorstring/port.go
+++ b/lib/numorstring/port.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,23 +18,34 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
-	"strings"
 )
 
+// Port represents either a range of numeric ports or a named port.
+//
+//     - For a named port, set the PortName, leaving MinPort and MaxPort as 0.
+//     - For a port range, set MinPort and MaxPort to the (inclusive) port numbers.  Set
+//       PortName to "".
+//     - For a single port, set MinPort = MaxPort and PortName = "".
 type Port struct {
-	MinPort uint16
-	MaxPort uint16
+	MinPort  uint16
+	MaxPort  uint16
+	PortName string
 }
 
 // SinglePort creates a Port struct representing a single port.
 func SinglePort(port uint16) Port {
-	return Port{port, port}
+	return Port{MinPort: port, MaxPort: port}
+}
+
+func NamedPort(name string) Port {
+	return Port{PortName: name}
 }
 
 // PortFromRange creates a Port struct representing a range of ports.
 func PortFromRange(minPort, maxPort uint16) (Port, error) {
-	port := Port{minPort, maxPort}
+	port := Port{MinPort: minPort, MaxPort: maxPort}
 	if minPort > maxPort {
 		msg := fmt.Sprintf("minimum port number (%d) is greater than maximum port number (%d) in port range", minPort, maxPort)
 		return port, errors.New(msg)
@@ -42,28 +53,44 @@ func PortFromRange(minPort, maxPort uint16) (Port, error) {
 	return port, nil
 }
 
+var (
+	allDigits = regexp.MustCompile(`^\d+$`)
+	portRange = regexp.MustCompile(`^(\d+):(\d+)$`)
+	nameRegex = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
+)
+
 // PortFromString creates a Port struct from its string representation.  A port
-// may either be single value "1234" or a range of values "100:200".
+// may either be single value "1234", a range of values "100:200" or a named port: "name".
 func PortFromString(s string) (Port, error) {
-	if num, err := strconv.ParseUint(s, 10, 16); err == nil {
+	if allDigits.MatchString(s) {
+		// Port is all digits, it should parse as a single port.
+		num, err := strconv.ParseUint(s, 10, 16)
+		if err != nil {
+			msg := fmt.Sprintf("invalid port format (%s)", s)
+			return Port{}, errors.New(msg)
+		}
 		return SinglePort(uint16(num)), nil
 	}
 
-	parts := strings.Split(s, ":")
-	if len(parts) != 2 {
-		msg := fmt.Sprintf("invalid port format (%s)", s)
+	if groups := portRange.FindStringSubmatch(s); len(groups) > 0 {
+		// Port matches <digits>:<digits>, it should parse as a range of ports.
+		if pmin, err := strconv.ParseUint(groups[1], 10, 16); err != nil {
+			msg := fmt.Sprintf("invalid minimum port number in range (%s)", s)
+			return Port{}, errors.New(msg)
+		} else if pmax, err := strconv.ParseUint(groups[2], 10, 16); err != nil {
+			msg := fmt.Sprintf("invalid maximum port number in range (%s)", s)
+			return Port{}, errors.New(msg)
+		} else {
+			return PortFromRange(uint16(pmin), uint16(pmax))
+		}
+	}
+
+	if !nameRegex.MatchString(s) {
+		msg := fmt.Sprintf("invalid name for named port (%s)", s)
 		return Port{}, errors.New(msg)
 	}
 
-	if pmin, err := strconv.ParseUint(parts[0], 10, 16); err != nil {
-		msg := fmt.Sprintf("invalid minimum port number in range (%s)", s)
-		return Port{}, errors.New(msg)
-	} else if pmax, err := strconv.ParseUint(parts[1], 10, 16); err != nil {
-		msg := fmt.Sprintf("invalid maximum port number in range (%s)", s)
-		return Port{}, errors.New(msg)
-	} else {
-		return PortFromRange(uint16(pmin), uint16(pmax))
-	}
+	return NamedPort(s), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -103,18 +103,27 @@ func init() {
 	registerFieldValidator("policytype", validatePolicyType)
 
 	// Register struct validators.
+	// Shared types.
 	registerStructValidator(validateProtocol, numorstring.Protocol{})
 	registerStructValidator(validatePort, numorstring.Port{})
+
+	// Frontend API types.
 	registerStructValidator(validateIPNAT, api.IPNAT{})
 	registerStructValidator(validateWorkloadEndpointSpec, api.WorkloadEndpointSpec{})
 	registerStructValidator(validateHostEndpointSpec, api.HostEndpointSpec{})
 	registerStructValidator(validateIPPool, api.IPPool{})
 	registerStructValidator(validateICMPFields, api.ICMPFields{})
 	registerStructValidator(validateRule, api.Rule{})
-	registerStructValidator(validateBackendRule, model.Rule{})
+	registerStructValidator(validateEndpointPort, api.EndpointPort{})
 	registerStructValidator(validateNodeSpec, api.NodeSpec{})
 	registerStructValidator(validateBGPPeerMeta, api.BGPPeerMetadata{})
 	registerStructValidator(validatePolicySpec, api.PolicySpec{})
+
+	// Backend model types.
+	registerStructValidator(validateBackendRule, model.Rule{})
+	registerStructValidator(validateBackendEndpointPort, model.EndpointPort{})
+	registerStructValidator(validateBackendWorkloadEndpoint, model.WorkloadEndpoint{})
+	registerStructValidator(validateBackendHostEndpoint, model.HostEndpoint{})
 }
 
 // reason returns the provided error reason prefixed with an identifier that
@@ -259,8 +268,12 @@ func validatePort(v *validator.Validate, structLevel *validator.StructLevel) {
 			"Port", "", reason("port range invalid"))
 	}
 
-	// No need to check for the upperbound (65536) because we use uint16.
-	if p.MinPort < 1 || p.MaxPort < 1 {
+	if p.PortName != "" {
+		if p.MinPort != 0 || p.MaxPort != 0 {
+			structLevel.ReportError(reflect.ValueOf(p.PortName),
+				"Port", "", reason("named port invalid, if name is specified, min and max should be 0"))
+		}
+	} else if p.MinPort < 1 || p.MaxPort < 1 {
 		structLevel.ReportError(reflect.ValueOf(p.MaxPort),
 			"Port", "", reason("port range invalid, port number must be between 0 and 65536"))
 	}
@@ -323,6 +336,20 @@ func validateWorkloadEndpointSpec(v *validator.Validate, structLevel *validator.
 				"IPNATs", "", reason("NAT is not in the endpoint networks"))
 		}
 	}
+
+	// Check for duplicate named ports.
+	seenPortNames := map[string]bool{}
+	for _, port := range w.Ports {
+		if seenPortNames[port.Name] {
+			structLevel.ReportError(
+				reflect.ValueOf(port.Name),
+				"Ports",
+				"",
+				reason("Ports list contains duplicate named port."),
+			)
+		}
+		seenPortNames[port.Name] = true
+	}
 }
 
 func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.StructLevel) {
@@ -332,6 +359,20 @@ func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.Stru
 	if h.InterfaceName == "" && len(h.ExpectedIPs) == 0 {
 		structLevel.ReportError(reflect.ValueOf(h.InterfaceName),
 			"InterfaceName", "", reason("no interface or expected IPs have been specified"))
+	}
+
+	// Check for duplicate named ports.
+	seenPortNames := map[string]bool{}
+	for _, port := range h.Ports {
+		if seenPortNames[port.Name] {
+			structLevel.ReportError(
+				reflect.ValueOf(port.Name),
+				"Ports",
+				"",
+				reason("Ports list contains duplicate named port."),
+			)
+		}
+		seenPortNames[port.Name] = true
 	}
 }
 
@@ -517,6 +558,66 @@ func validateBGPPeerMeta(v *validator.Validate, structLevel *validator.StructLev
 	if m.Scope == scope.Global && m.Node != "" {
 		structLevel.ReportError(reflect.ValueOf(m.Node),
 			"Metadata.Node", "", reason("no BGP Peer node name should be specified when scope is global"))
+	}
+}
+
+func validateBackendEndpointPort(v *validator.Validate, structLevel *validator.StructLevel) {
+	port := structLevel.CurrentStruct.Interface().(model.EndpointPort)
+
+	if port.Protocol.String() != "tcp" && port.Protocol.String() != "udp" {
+		structLevel.ReportError(
+			reflect.ValueOf(port.Protocol),
+			"EndpointPort.Protocol",
+			"",
+			reason("EndpointPort protocol must be 'tcp' or 'udp'."),
+		)
+	}
+}
+
+func validateEndpointPort(v *validator.Validate, structLevel *validator.StructLevel) {
+	port := structLevel.CurrentStruct.Interface().(api.EndpointPort)
+
+	if port.Protocol.String() != "tcp" && port.Protocol.String() != "udp" {
+		structLevel.ReportError(
+			reflect.ValueOf(port.Protocol),
+			"EndpointPort.Protocol",
+			"",
+			reason("EndpointPort protocol must be 'tcp' or 'udp'."),
+		)
+	}
+}
+
+func validateBackendWorkloadEndpoint(v *validator.Validate, structLevel *validator.StructLevel) {
+	ep := structLevel.CurrentStruct.Interface().(model.WorkloadEndpoint)
+
+	seenPortNames := map[string]bool{}
+	for _, port := range ep.Ports {
+		if seenPortNames[port.Name] {
+			structLevel.ReportError(
+				reflect.ValueOf(port.Name),
+				"WorkloadEndpoint.Ports",
+				"",
+				reason("Ports list contains duplicate named port."),
+			)
+		}
+		seenPortNames[port.Name] = true
+	}
+}
+
+func validateBackendHostEndpoint(v *validator.Validate, structLevel *validator.StructLevel) {
+	ep := structLevel.CurrentStruct.Interface().(model.HostEndpoint)
+
+	seenPortNames := map[string]bool{}
+	for _, port := range ep.Ports {
+		if seenPortNames[port.Name] {
+			structLevel.ReportError(
+				reflect.ValueOf(port.Name),
+				"HostEndpoint.Ports",
+				"",
+				reason("Ports list contains duplicate named port."),
+			)
+		}
+		seenPortNames[port.Name] = true
 	}
 }
 

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -262,7 +262,7 @@ func validatePort(v *validator.Validate, structLevel *validator.StructLevel) {
 
 	// Check that the port range is in the correct order.  The YAML parsing also checks this,
 	// but this protects against misuse of the programmatic API.
-	log.Debugf("Validate port: %s")
+	log.Debugf("Validate port: %v", p)
 	if p.MinPort > p.MaxPort {
 		structLevel.ReportError(reflect.ValueOf(p.MaxPort),
 			"Port", "", reason("port range invalid"))


### PR DESCRIPTION
## Description
This PR restores the named ports feature, which was backed out under #519. 

I found some bugs while FV testing the feature, this PR also closes those up.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
