### PR TITLE
Revert "Merge pull request #504 from fasaxc/named-ports"

### DIFF
--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,9 +77,6 @@ type HostEndpointSpec struct {
 	// profile is applied in the order that they appear in this list.  Profile rules are applied
 	// after the selector-based security policy.
 	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,namespacedname"`
-
-	// Ports contains the endpoint's named ports, which may be referenced in security policy rules.
-	Ports []EndpointPort `json:"ports,omitempty" validate:"omitempty,dive"`
 }
 
 // NewHostEndpoint creates a new (zeroed) HostEndpoint struct with the TypeMetadata initialised to the current

--- a/lib/api/workloadendpoint.go
+++ b/lib/api/workloadendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
 type WorkloadEndpoint struct {
@@ -105,9 +104,6 @@ type WorkloadEndpointSpec struct {
 
 	// MAC is the MAC address of the endpoint interface.
 	MAC *net.MAC `json:"mac,omitempty" validate:"omitempty,mac"`
-
-	// Ports contains the endpoint's named ports, which may be referenced in security policy rules.
-	Ports []EndpointPort `json:"ports,omitempty" validate:"omitempty,dive"`
 }
 
 // IPNat contains a single NAT mapping for a WorkloadEndpoint resource.
@@ -118,12 +114,6 @@ type IPNAT struct {
 
 	// The external IP address.
 	ExternalIP net.IP `json:"externalIP"`
-}
-
-type EndpointPort struct {
-	Name     string               `json:"name" validate:"name"`
-	Protocol numorstring.Protocol `json:"protocol"`
-	Port     uint16               `json:"port" validate:"gt=0"`
 }
 
 // String returns a friendly form of an IPNAT.

--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -167,35 +167,6 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 	}
 	labels["calico/k8s_ns"] = pod.ObjectMeta.Namespace
 
-	// Map any named ports through.
-	var endpointPorts []model.EndpointPort
-	for _, container := range pod.Spec.Containers {
-		for _, containerPort := range container.Ports {
-			if containerPort.Name != "" && containerPort.ContainerPort != 0 {
-				var modelProto numorstring.Protocol
-				switch containerPort.Protocol {
-				case kapiv1.ProtocolUDP:
-					modelProto = numorstring.ProtocolFromString("udp")
-				case kapiv1.ProtocolTCP, kapiv1.Protocol("") /* K8s default is TCP. */ :
-					modelProto = numorstring.ProtocolFromString("tcp")
-				default:
-					log.WithFields(log.Fields{
-						"protocol": containerPort.Protocol,
-						"pod":      pod,
-						"port":     containerPort,
-					}).Debug("Ignoring named port with unknown protocol")
-					continue
-				}
-
-				endpointPorts = append(endpointPorts, model.EndpointPort{
-					Name:     containerPort.Name,
-					Protocol: modelProto,
-					Port:     uint16(containerPort.ContainerPort),
-				})
-			}
-		}
-	}
-
 	// Create the key / value pair to return.
 	kvp := model.KVPair{
 		Key: model.WorkloadEndpointKey{
@@ -211,7 +182,6 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 			IPv4Nets:   ipNets,
 			IPv6Nets:   []cnet.IPNet{},
 			Labels:     labels,
-			Ports:      endpointPorts,
 		},
 		Revision: pod.ObjectMeta.ResourceVersion,
 	}
@@ -339,7 +309,7 @@ func (c Converter) k8sIngressRuleToCalico(r extensions.NetworkPolicyIngressRule,
 		ports = []*extensions.NetworkPolicyPort{nil}
 	}
 
-	// Combine destinations with sources to generate rules.
+	// Combine desintations with sources to generate rules.
 	// TODO: This currently creates a lot of rules by making every combination of from / ports
 	// into a rule.  We can combine these so that we don't need as many rules!
 	for _, port := range ports {

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -94,44 +94,6 @@ var _ = Describe("Test Pod conversion", func() {
 			},
 			Spec: k8sapi.PodSpec{
 				NodeName: "nodeA",
-				Containers: []k8sapi.Container{
-					{
-						Ports: []k8sapi.ContainerPort{
-							{
-								ContainerPort: 5678,
-							},
-							{
-								Name:          "no-proto",
-								ContainerPort: 1234,
-							},
-						},
-					},
-					{
-						Ports: []k8sapi.ContainerPort{
-							{
-								Name:          "tcp-proto",
-								Protocol:      k8sapi.ProtocolTCP,
-								ContainerPort: 1024,
-							},
-							{
-								Name:          "tcp-proto-with-host-port",
-								Protocol:      k8sapi.ProtocolTCP,
-								ContainerPort: 8080,
-								HostPort:      5678,
-							},
-							{
-								Name:          "udp-proto",
-								Protocol:      k8sapi.ProtocolUDP,
-								ContainerPort: 432,
-							},
-							{
-								Name:          "unkn-proto",
-								Protocol:      k8sapi.Protocol("unknown"),
-								ContainerPort: 567,
-							},
-						},
-					},
-				},
 			},
 			Status: k8sapi.PodStatus{
 				PodIP: "192.168.0.1",
@@ -154,20 +116,6 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(wep.Value.(*model.WorkloadEndpoint).State).To(Equal("active"))
 		expectedLabels := map[string]string{"labelA": "valueA", "labelB": "valueB", "calico/k8s_ns": "default"}
 		Expect(wep.Value.(*model.WorkloadEndpoint).Labels).To(Equal(expectedLabels))
-
-		nsProtoTCP := numorstring.ProtocolFromString("tcp")
-		nsProtoUDP := numorstring.ProtocolFromString("udp")
-		Expect(wep.Value.(*model.WorkloadEndpoint).Ports).To(ConsistOf(
-			// No proto defaults to TCP (as defined in k8s API spec)
-			model.EndpointPort{Name: "no-proto", Port: 1234, Protocol: nsProtoTCP},
-			// Explicit TCP proto is OK too.
-			model.EndpointPort{Name: "tcp-proto", Port: 1024, Protocol: nsProtoTCP},
-			// Host port should be ignored.
-			model.EndpointPort{Name: "tcp-proto-with-host-port", Port: 8080, Protocol: nsProtoTCP},
-			// UDP is also an option.
-			model.EndpointPort{Name: "udp-proto", Port: 432, Protocol: nsProtoUDP},
-			// Unknown protocol port is ignored.
-		))
 
 		// Assert ResourceVersion is present.
 		Expect(wep.Revision.(string)).To(Equal("1234"))
@@ -251,7 +199,6 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 
 	It("should parse a basic NetworkPolicy to a Policy", func() {
 		port80 := intstr.FromInt(80)
-		portFoo := intstr.FromString("foo")
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
@@ -268,7 +215,6 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 					{
 						Ports: []extensions.NetworkPolicyPort{
 							{Port: &port80},
-							{Port: &portFoo},
 						},
 						From: []extensions.NetworkPolicyPeer{
 							{
@@ -298,20 +244,12 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		Expect(pol.Value.(*model.Policy).Selector).To(Equal(
 			"calico/k8s_ns == 'default' && label == 'value' && label2 == 'value2'"))
 		protoTCP := numorstring.ProtocolFromString("tcp")
-		Expect(pol.Value.(*model.Policy).InboundRules).To(ConsistOf(
-			model.Rule{
-				Action:      "allow",
-				Protocol:    &protoTCP, // Defaulted to TCP.
-				SrcSelector: "calico/k8s_ns == 'default' && k == 'v' && k2 == 'v2'",
-				DstPorts:    []numorstring.Port{numorstring.SinglePort(80)},
-			},
-			model.Rule{
-				Action:      "allow",
-				Protocol:    &protoTCP, // Defaulted to TCP.
-				SrcSelector: "calico/k8s_ns == 'default' && k == 'v' && k2 == 'v2'",
-				DstPorts:    []numorstring.Port{numorstring.NamedPort("foo")},
-			},
-		))
+		Expect(pol.Value.(*model.Policy).InboundRules).To(ConsistOf(model.Rule{
+			Action:      "allow",
+			Protocol:    &protoTCP, // Defaulted to TCP.
+			SrcSelector: "calico/k8s_ns == 'default' && k == 'v' && k2 == 'v2'",
+			DstPorts:    []numorstring.Port{numorstring.SinglePort(80)},
+		}))
 
 		// There should be no OutboundRules
 		Expect(len(pol.Value.(*model.Policy).OutboundRules)).To(Equal(0))

--- a/lib/backend/k8s/resources/node_conversion_test.go
+++ b/lib/backend/k8s/resources/node_conversion_test.go
@@ -1,17 +1,3 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package resources
 
 import (
@@ -38,7 +24,7 @@ var _ = Describe("Test Node conversion", func() {
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4CidrAnnotation: "172.17.17.10/24",
-					nodeBgpAsnAnnotation:      "2546",
+					nodeBgpAsnAnnotation:    "2546",
 				},
 			},
 			Status: k8sapi.NodeStatus{
@@ -104,7 +90,7 @@ var _ = Describe("Test Node conversion", func() {
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4CidrAnnotation: "172.17.17.10/24",
-					nodeBgpAsnAnnotation:      "2546",
+					nodeBgpAsnAnnotation:    "2546",
 				},
 			},
 			Spec: k8sapi.NodeSpec{},
@@ -125,7 +111,7 @@ var _ = Describe("Test Node conversion", func() {
 				Name:            "TestNode",
 				Labels:          l,
 				ResourceVersion: "1234",
-				Annotations:     make(map[string]string),
+				Annotations: make(map[string]string),
 			},
 			Spec: k8sapi.NodeSpec{},
 		}
@@ -134,8 +120,8 @@ var _ = Describe("Test Node conversion", func() {
 		asn, _ := numorstring.ASNumberFromString("2456")
 
 		calicoNode := &model.Node{
-			BGPIPv4Net:  cidr,
-			FelixIPv4:   ip,
+			BGPIPv4Net: cidr,
+			FelixIPv4: ip,
 			BGPIPv4Addr: ip,
 			BGPASNumber: &asn,
 		}
@@ -146,3 +132,4 @@ var _ = Describe("Test Node conversion", func() {
 		Expect(newK8sNode.Annotations).To(HaveKeyWithValue(nodeBgpAsnAnnotation, "2456"))
 	})
 })
+

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,5 +108,4 @@ type HostEndpoint struct {
 	ExpectedIPv6Addrs []net.IP          `json:"expected_ipv6_addrs,omitempty" validate:"omitempty,dive,ipv6"`
 	Labels            map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
 	ProfileIDs        []string          `json:"profile_ids,omitempty" validate:"omitempty,dive,name"`
-	Ports             []EndpointPort    `json:"ports,omitempty" validate:"dive"`
 }

--- a/lib/backend/model/rule.go
+++ b/lib/backend/model/rule.go
@@ -40,23 +40,23 @@ type Rule struct {
 	SrcNet      *net.IPNet         `json:"src_net,omitempty" validate:"omitempty"`
 	SrcNets     []*net.IPNet       `json:"src_nets,omitempty" validate:"omitempty"`
 	SrcSelector string             `json:"src_selector,omitempty" validate:"omitempty,selector"`
-	SrcPorts    []numorstring.Port `json:"src_ports,omitempty" validate:"omitempty,dive"`
+	SrcPorts    []numorstring.Port `json:"src_ports,omitempty" validate:"omitempty"`
 	DstTag      string             `json:"dst_tag,omitempty" validate:"omitempty,tag"`
 	DstSelector string             `json:"dst_selector,omitempty" validate:"omitempty,selector"`
 	DstNet      *net.IPNet         `json:"dst_net,omitempty" validate:"omitempty"`
 	DstNets     []*net.IPNet       `json:"dst_nets,omitempty" validate:"omitempty"`
-	DstPorts    []numorstring.Port `json:"dst_ports,omitempty" validate:"omitempty,dive"`
+	DstPorts    []numorstring.Port `json:"dst_ports,omitempty" validate:"omitempty"`
 
 	NotSrcTag      string             `json:"!src_tag,omitempty" validate:"omitempty,tag"`
 	NotSrcNet      *net.IPNet         `json:"!src_net,omitempty" validate:"omitempty"`
 	NotSrcNets     []*net.IPNet       `json:"!src_nets,omitempty" validate:"omitempty"`
 	NotSrcSelector string             `json:"!src_selector,omitempty" validate:"omitempty,selector"`
-	NotSrcPorts    []numorstring.Port `json:"!src_ports,omitempty" validate:"omitempty,dive"`
+	NotSrcPorts    []numorstring.Port `json:"!src_ports,omitempty" validate:"omitempty"`
 	NotDstTag      string             `json:"!dst_tag,omitempty" validate:"omitempty"`
 	NotDstSelector string             `json:"!dst_selector,omitempty" validate:"omitempty,selector"`
 	NotDstNet      *net.IPNet         `json:"!dst_net,omitempty" validate:"omitempty"`
 	NotDstNets     []*net.IPNet       `json:"!dst_nets,omitempty" validate:"omitempty"`
-	NotDstPorts    []numorstring.Port `json:"!dst_ports,omitempty" validate:"omitempty,dive"`
+	NotDstPorts    []numorstring.Port `json:"!dst_ports,omitempty" validate:"omitempty"`
 
 	LogPrefix string `json:"log_prefix,omitempty" validate:"omitempty"`
 }

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -148,6 +147,7 @@ func (options WorkloadEndpointListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type WorkloadEndpoint struct {
+	// TODO: Validation for workload endpoint.
 	State            string            `json:"state"`
 	Name             string            `json:"name"`
 	ActiveInstanceID string            `json:"active_instance_id"`
@@ -160,13 +160,6 @@ type WorkloadEndpoint struct {
 	Labels           map[string]string `json:"labels,omitempty"`
 	IPv4Gateway      *net.IP           `json:"ipv4_gateway,omitempty" validate:"omitempty,ipv4"`
 	IPv6Gateway      *net.IP           `json:"ipv6_gateway,omitempty" validate:"omitempty,ipv6"`
-	Ports            []EndpointPort    `json:"ports,omitempty" validate:"dive"`
-}
-
-type EndpointPort struct {
-	Name     string               `json:"name" validate:"name"`
-	Protocol numorstring.Protocol `json:"protocol"`
-	Port     uint16               `json:"port" validate:"gt=0"`
 }
 
 // IPNat contains a single NAT mapping for a WorkloadEndpoint resource.

--- a/lib/numorstring/numorstring_test.go
+++ b/lib/numorstring/numorstring_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,14 +71,12 @@ func init() {
 		Entry("should accept 65535 port as int", "65535", portType, numorstring.SinglePort(65535)),
 		Entry("should accept 0:65535 port range as string", "\"0:65535\"", portType, portFromRange(0, 65535)),
 		Entry("should accept 1:10 port range as string", "\"1:10\"", portType, portFromRange(1, 10)),
-		Entry("should accept foo-bar as named port", "\"foo-bar\"", portType, numorstring.NamedPort("foo-bar")),
 		Entry("should reject -1 port as int", "-1", portType, nil),
 		Entry("should reject 65536 port as int", "65536", portType, nil),
 		Entry("should reject 0:65536 port range as string", "\"0:65536\"", portType, nil),
 		Entry("should reject -1:65535 port range as string", "\"-1:65535\"", portType, nil),
 		Entry("should reject 10:1 port range as string", "\"10:1\"", portType, nil),
 		Entry("should reject 1:2:3 port range as string", "\"1:2:3\"", portType, nil),
-		Entry("should reject bad named port string", "\"*\"", portType, nil),
 		Entry("should reject bad port string", "\"1:2", portType, nil),
 
 		// Protocol tests.  Invalid integer values will be stored as strings.

--- a/lib/numorstring/port.go
+++ b/lib/numorstring/port.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,34 +18,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
+	"strings"
 )
 
-// Port represents either a range of numeric ports or a named port.
-//
-//     - For a named port, set the PortName, leaving MinPort and MaxPort as 0.
-//     - For a port range, set MinPort and MaxPort to the (inclusive) port numbers.  Set
-//       PortName to "".
-//     - For a single port, set MinPort = MaxPort and PortName = "".
 type Port struct {
-	MinPort  uint16
-	MaxPort  uint16
-	PortName string
+	MinPort uint16
+	MaxPort uint16
 }
 
 // SinglePort creates a Port struct representing a single port.
 func SinglePort(port uint16) Port {
-	return Port{MinPort: port, MaxPort: port}
-}
-
-func NamedPort(name string) Port {
-	return Port{PortName: name}
+	return Port{port, port}
 }
 
 // PortFromRange creates a Port struct representing a range of ports.
 func PortFromRange(minPort, maxPort uint16) (Port, error) {
-	port := Port{MinPort: minPort, MaxPort: maxPort}
+	port := Port{minPort, maxPort}
 	if minPort > maxPort {
 		msg := fmt.Sprintf("minimum port number (%d) is greater than maximum port number (%d) in port range", minPort, maxPort)
 		return port, errors.New(msg)
@@ -53,44 +42,28 @@ func PortFromRange(minPort, maxPort uint16) (Port, error) {
 	return port, nil
 }
 
-var (
-	allDigits = regexp.MustCompile(`^\d+$`)
-	portRange = regexp.MustCompile(`^(\d+):(\d+)$`)
-	nameRegex = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
-)
-
 // PortFromString creates a Port struct from its string representation.  A port
-// may either be single value "1234", a range of values "100:200" or a named port: "name".
+// may either be single value "1234" or a range of values "100:200".
 func PortFromString(s string) (Port, error) {
-	if allDigits.MatchString(s) {
-		// Port is all digits, it should parse as a single port.
-		num, err := strconv.ParseUint(s, 10, 16)
-		if err != nil {
-			msg := fmt.Sprintf("invalid port format (%s)", s)
-			return Port{}, errors.New(msg)
-		}
+	if num, err := strconv.ParseUint(s, 10, 16); err == nil {
 		return SinglePort(uint16(num)), nil
 	}
 
-	if groups := portRange.FindStringSubmatch(s); len(groups) > 0 {
-		// Port matches <digits>:<digits>, it should parse as a range of ports.
-		if pmin, err := strconv.ParseUint(groups[1], 10, 16); err != nil {
-			msg := fmt.Sprintf("invalid minimum port number in range (%s)", s)
-			return Port{}, errors.New(msg)
-		} else if pmax, err := strconv.ParseUint(groups[2], 10, 16); err != nil {
-			msg := fmt.Sprintf("invalid maximum port number in range (%s)", s)
-			return Port{}, errors.New(msg)
-		} else {
-			return PortFromRange(uint16(pmin), uint16(pmax))
-		}
-	}
-
-	if !nameRegex.MatchString(s) {
-		msg := fmt.Sprintf("invalid name for named port (%s)", s)
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		msg := fmt.Sprintf("invalid port format (%s)", s)
 		return Port{}, errors.New(msg)
 	}
 
-	return NamedPort(s), nil
+	if pmin, err := strconv.ParseUint(parts[0], 10, 16); err != nil {
+		msg := fmt.Sprintf("invalid minimum port number in range (%s)", s)
+		return Port{}, errors.New(msg)
+	} else if pmax, err := strconv.ParseUint(parts[1], 10, 16); err != nil {
+		msg := fmt.Sprintf("invalid maximum port number in range (%s)", s)
+		return Port{}, errors.New(msg)
+	} else {
+		return PortFromRange(uint16(pmin), uint16(pmax))
+	}
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -103,27 +103,18 @@ func init() {
 	registerFieldValidator("policytype", validatePolicyType)
 
 	// Register struct validators.
-	// Shared types.
 	registerStructValidator(validateProtocol, numorstring.Protocol{})
 	registerStructValidator(validatePort, numorstring.Port{})
-
-	// Frontend API types.
 	registerStructValidator(validateIPNAT, api.IPNAT{})
 	registerStructValidator(validateWorkloadEndpointSpec, api.WorkloadEndpointSpec{})
 	registerStructValidator(validateHostEndpointSpec, api.HostEndpointSpec{})
 	registerStructValidator(validateIPPool, api.IPPool{})
 	registerStructValidator(validateICMPFields, api.ICMPFields{})
 	registerStructValidator(validateRule, api.Rule{})
-	registerStructValidator(validateEndpointPort, api.EndpointPort{})
+	registerStructValidator(validateBackendRule, model.Rule{})
 	registerStructValidator(validateNodeSpec, api.NodeSpec{})
 	registerStructValidator(validateBGPPeerMeta, api.BGPPeerMetadata{})
 	registerStructValidator(validatePolicySpec, api.PolicySpec{})
-
-	// Backend model types.
-	registerStructValidator(validateBackendRule, model.Rule{})
-	registerStructValidator(validateBackendEndpointPort, model.EndpointPort{})
-	registerStructValidator(validateBackendWorkloadEndpoint, model.WorkloadEndpoint{})
-	registerStructValidator(validateBackendHostEndpoint, model.HostEndpoint{})
 }
 
 // reason returns the provided error reason prefixed with an identifier that
@@ -268,12 +259,8 @@ func validatePort(v *validator.Validate, structLevel *validator.StructLevel) {
 			"Port", "", reason("port range invalid"))
 	}
 
-	if p.PortName != "" {
-		if p.MinPort != 0 || p.MaxPort != 0 {
-			structLevel.ReportError(reflect.ValueOf(p.PortName),
-				"Port", "", reason("named port invalid, if name is specified, min and max should be 0"))
-		}
-	} else if p.MinPort < 1 || p.MaxPort < 1 {
+	// No need to check for the upperbound (65536) because we use uint16.
+	if p.MinPort < 1 || p.MaxPort < 1 {
 		structLevel.ReportError(reflect.ValueOf(p.MaxPort),
 			"Port", "", reason("port range invalid, port number must be between 0 and 65536"))
 	}
@@ -336,20 +323,6 @@ func validateWorkloadEndpointSpec(v *validator.Validate, structLevel *validator.
 				"IPNATs", "", reason("NAT is not in the endpoint networks"))
 		}
 	}
-
-	// Check for duplicate named ports.
-	seenPortNames := map[string]bool{}
-	for _, port := range w.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
-	}
 }
 
 func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.StructLevel) {
@@ -359,20 +332,6 @@ func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.Stru
 	if h.InterfaceName == "" && len(h.ExpectedIPs) == 0 {
 		structLevel.ReportError(reflect.ValueOf(h.InterfaceName),
 			"InterfaceName", "", reason("no interface or expected IPs have been specified"))
-	}
-
-	// Check for duplicate named ports.
-	seenPortNames := map[string]bool{}
-	for _, port := range h.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
 	}
 }
 
@@ -558,66 +517,6 @@ func validateBGPPeerMeta(v *validator.Validate, structLevel *validator.StructLev
 	if m.Scope == scope.Global && m.Node != "" {
 		structLevel.ReportError(reflect.ValueOf(m.Node),
 			"Metadata.Node", "", reason("no BGP Peer node name should be specified when scope is global"))
-	}
-}
-
-func validateBackendEndpointPort(v *validator.Validate, structLevel *validator.StructLevel) {
-	port := structLevel.CurrentStruct.Interface().(model.EndpointPort)
-
-	if port.Protocol.String() != "tcp" && port.Protocol.String() != "udp" {
-		structLevel.ReportError(
-			reflect.ValueOf(port.Protocol),
-			"EndpointPort.Protocol",
-			"",
-			reason("EndpointPort protocol must be 'tcp' or 'udp'."),
-		)
-	}
-}
-
-func validateEndpointPort(v *validator.Validate, structLevel *validator.StructLevel) {
-	port := structLevel.CurrentStruct.Interface().(api.EndpointPort)
-
-	if port.Protocol.String() != "tcp" && port.Protocol.String() != "udp" {
-		structLevel.ReportError(
-			reflect.ValueOf(port.Protocol),
-			"EndpointPort.Protocol",
-			"",
-			reason("EndpointPort protocol must be 'tcp' or 'udp'."),
-		)
-	}
-}
-
-func validateBackendWorkloadEndpoint(v *validator.Validate, structLevel *validator.StructLevel) {
-	ep := structLevel.CurrentStruct.Interface().(model.WorkloadEndpoint)
-
-	seenPortNames := map[string]bool{}
-	for _, port := range ep.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"WorkloadEndpoint.Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
-	}
-}
-
-func validateBackendHostEndpoint(v *validator.Validate, structLevel *validator.StructLevel) {
-	ep := structLevel.CurrentStruct.Interface().(model.HostEndpoint)
-
-	seenPortNames := map[string]bool{}
-	for _, port := range ep.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"HostEndpoint.Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
 	}
 }
 

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -52,16 +52,6 @@ func init() {
 	netv6_4 := net.MustParseNetwork("aabb:aabb::ffff/10")
 
 	protoTCP := numorstring.ProtocolFromString("tcp")
-	protoUDP := numorstring.ProtocolFromString("udp")
-	protoNumeric := numorstring.ProtocolFromInt(123)
-
-	// badPorts contains a port that should fail validation because it mixes named and numeric
-	// ports.
-	badPorts := []numorstring.Port{{
-		PortName: "foo",
-		MinPort:  1,
-		MaxPort:  123,
-	}}
 
 	// Perform basic validation of different fields and structures to test simple valid/invalid
 	// scenarios.  This does not test precise error strings - but does cover a lot of the validation
@@ -116,285 +106,6 @@ func init() {
 		Entry("should reject !dst ports with no protocol (m)", model.Rule{
 			NotDstPorts: []numorstring.Port{numorstring.SinglePort(80)},
 		}, false),
-		Entry("should accept src named ports with tcp protocol (m)", model.Rule{
-			Protocol: &protoTCP,
-			SrcPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, true),
-		Entry("should accept dst named ports with tcp protocol (m)", model.Rule{
-			Protocol: &protoTCP,
-			DstPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, true),
-		Entry("should accept !src named ports with tcp protocol (m)", model.Rule{
-			Protocol:    &protoTCP,
-			NotSrcPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, true),
-		Entry("should accept !dst named ports with tcp protocol (m)", model.Rule{
-			Protocol:    &protoTCP,
-			NotDstPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, true),
-		Entry("should reject src named ports with no protocol (m)", model.Rule{
-			SrcPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, false),
-		Entry("should reject dst named ports with no protocol (m)", model.Rule{
-			DstPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, false),
-		Entry("should reject !src named ports with no protocol (m)", model.Rule{
-			NotSrcPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, false),
-		Entry("should reject !dst named ports with no protocol (m)", model.Rule{
-			NotDstPorts: []numorstring.Port{numorstring.NamedPort("foo")},
-		}, false),
-		// Check that we tell the validator to "dive" and validate the port too.
-		Entry("should reject src named ports with min and max (m)", model.Rule{
-			Protocol: &protoTCP,
-			SrcPorts: badPorts,
-		}, false),
-		Entry("should reject !src named ports with min and max (m)", model.Rule{
-			Protocol:    &protoTCP,
-			NotSrcPorts: badPorts,
-		}, false),
-		Entry("should reject dst named ports with min and max (m)", model.Rule{
-			Protocol: &protoTCP,
-			DstPorts: badPorts,
-		}, false),
-		Entry("should reject !dst named ports with min and max (m)", model.Rule{
-			Protocol:    &protoTCP,
-			NotDstPorts: badPorts,
-		}, false),
-
-		// (Backend model) EndpointPorts.
-		Entry("should accept EndpointPort with tcp protocol (m)", model.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoTCP,
-			Port:     1234,
-		}, true),
-		Entry("should accept EndpointPort with udp protocol (m)", model.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoUDP,
-			Port:     1234,
-		}, true),
-		Entry("should reject EndpointPort with empty name (m)", model.EndpointPort{
-			Name:     "",
-			Protocol: protoUDP,
-			Port:     1234,
-		}, false),
-		Entry("should reject EndpointPort with no protocol (m)", model.EndpointPort{
-			Name: "a_Jolly-port",
-			Port: 1234,
-		}, false),
-		Entry("should reject EndpointPort with numeric protocol (m)", model.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoNumeric,
-			Port:     1234,
-		}, false),
-		Entry("should reject EndpointPort with no port (m)", model.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoTCP,
-		}, false),
-
-		// (API model) EndpointPorts.
-		Entry("should accept EndpointPort with tcp protocol", api.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoTCP,
-			Port:     1234,
-		}, true),
-		Entry("should accept EndpointPort with udp protocol", api.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoUDP,
-			Port:     1234,
-		}, true),
-		Entry("should reject EndpointPort with empty name", api.EndpointPort{
-			Name:     "",
-			Protocol: protoUDP,
-			Port:     1234,
-		}, false),
-		Entry("should reject EndpointPort with no protocol", api.EndpointPort{
-			Name: "a_Jolly-port",
-			Port: 1234,
-		}, false),
-		Entry("should reject EndpointPort with numeric protocol", api.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoNumeric,
-			Port:     1234,
-		}, false),
-		Entry("should reject EndpointPort with no port", api.EndpointPort{
-			Name:     "a_Jolly-port",
-			Protocol: protoTCP,
-		}, false),
-
-		// (Backend model) WorkloadEndpoint.
-		Entry("should accept WorkloadEndpoint with a port (m)",
-			model.WorkloadEndpoint{
-				Ports: []model.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			true,
-		),
-		Entry("should reject WorkloadEndpoint with an unnamed port (m)",
-			model.WorkloadEndpoint{
-				Ports: []model.EndpointPort{
-					{
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			false,
-		),
-		Entry("should reject WorkloadEndpoint with name-clashing ports (m)",
-			model.WorkloadEndpoint{
-				Ports: []model.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoUDP,
-						Port:     5456,
-					},
-				},
-			},
-			false,
-		),
-
-		// (API) WorkloadEndpointSpec.
-		Entry("should accept WorkloadEndpointSpec with a port (m)",
-			api.WorkloadEndpointSpec{
-				InterfaceName: "eth0",
-				Ports: []api.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			true,
-		),
-		Entry("should reject WorkloadEndpointSpec with an unnamed port (m)",
-			api.WorkloadEndpointSpec{
-				InterfaceName: "eth0",
-				Ports: []api.EndpointPort{
-					{
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			false,
-		),
-		Entry("should reject WorkloadEndpointSpec with name-clashing ports (m)",
-			api.WorkloadEndpointSpec{
-				InterfaceName: "eth0",
-				Ports: []api.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoUDP,
-						Port:     5456,
-					},
-				},
-			},
-			false,
-		),
-
-		// (Backend model) HostEndpoint.
-		Entry("should accept HostEndpoint with a port (m)",
-			model.HostEndpoint{
-				Ports: []model.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			true,
-		),
-		Entry("should reject HostEndpoint with an unnamed port (m)",
-			model.HostEndpoint{
-				Ports: []model.EndpointPort{
-					{
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			false,
-		),
-		Entry("should reject HostEndpoint with name-clashing ports (m)",
-			model.HostEndpoint{
-				Ports: []model.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoUDP,
-						Port:     5456,
-					},
-				},
-			},
-			false,
-		),
-
-		// (API) HostEndpointSpec.
-		Entry("should accept HostEndpointSpec with a port (m)",
-			api.HostEndpointSpec{
-				InterfaceName: "eth0",
-				Ports: []api.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			true,
-		),
-		Entry("should reject HostEndpointSpec with an unnamed port (m)",
-			api.HostEndpointSpec{
-				InterfaceName: "eth0",
-				Ports: []api.EndpointPort{
-					{
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-				},
-			},
-			false,
-		),
-		Entry("should reject HostEndpointSpec with name-clashing ports (m)",
-			api.HostEndpointSpec{
-				InterfaceName: "eth0",
-				Ports: []api.EndpointPort{
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoTCP,
-						Port:     1234,
-					},
-					{
-						Name:     "a_Jolly-port",
-						Protocol: protoUDP,
-						Port:     5456,
-					},
-				},
-			},
-			false,
-		),
 
 		// (API) IP version.
 		Entry("should accept IP version 4", api.Rule{Action: "allow", IPVersion: &V4}, true),
@@ -631,30 +342,6 @@ func init() {
 					Ports: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, true),
-		Entry("should accept Rule with source named ports and protocol type 6",
-			api.Rule{
-				Action:   "allow",
-				Protocol: protocolFromInt(6),
-				Source: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.NamedPort("foo")},
-				},
-			}, true),
-		Entry("should accept Rule with source named ports and protocol type tcp",
-			api.Rule{
-				Action:   "allow",
-				Protocol: protocolFromString("tcp"),
-				Source: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.NamedPort("foo")},
-				},
-			}, true),
-		Entry("should accept Rule with source named ports and protocol type udp",
-			api.Rule{
-				Action:   "allow",
-				Protocol: protocolFromString("udp"),
-				Source: api.EntityRule{
-					Ports: []numorstring.Port{numorstring.NamedPort("foo")},
-				},
-			}, true),
 		Entry("should accept Rule with empty source ports and protocol type 7",
 			api.Rule{
 				Action:   "allow",
@@ -700,26 +387,6 @@ func init() {
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
 					NotPorts: []numorstring.Port{numorstring.SinglePort(0)},
-				},
-			}, false),
-		Entry("should reject Rule with invalid port (name + number)",
-			api.Rule{
-				Action:   "allow",
-				Protocol: protocolFromString("tcp"),
-				Destination: api.EntityRule{
-					NotPorts: []numorstring.Port{{
-						PortName: "foo",
-						MinPort:  123,
-						MaxPort:  456,
-					}},
-				},
-			}, false),
-		Entry("should reject named port Rule with invalid protocol",
-			api.Rule{
-				Action:   "allow",
-				Protocol: protocolFromString("unknown"),
-				Destination: api.EntityRule{
-					NotPorts: []numorstring.Port{numorstring.NamedPort("foo")},
 				},
 			}, false),
 		Entry("should accept Rule with empty dest ports and protocol type sctp",
@@ -775,7 +442,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Source: api.EntityRule{
-					Ports: []numorstring.Port{{MinPort: 200, MaxPort: 100}},
+					Ports: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with invalid source !ports and protocol type tcp",
@@ -783,7 +450,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Source: api.EntityRule{
-					NotPorts: []numorstring.Port{{MinPort: 200, MaxPort: 100}},
+					NotPorts: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with invalid dest ports and protocol type tcp",
@@ -791,7 +458,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
-					Ports: []numorstring.Port{{MinPort: 200, MaxPort: 100}},
+					Ports: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with invalid dest !ports and protocol type tcp",
@@ -799,7 +466,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
-					NotPorts: []numorstring.Port{{MinPort: 200, MaxPort: 100}},
+					NotPorts: []numorstring.Port{numorstring.Port{MinPort: 200, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject Rule with one invalid port in the port range (MinPort 0)",
@@ -807,7 +474,7 @@ func init() {
 				Action:   "allow",
 				Protocol: protocolFromString("tcp"),
 				Destination: api.EntityRule{
-					NotPorts: []numorstring.Port{{MinPort: 0, MaxPort: 100}},
+					NotPorts: []numorstring.Port{numorstring.Port{MinPort: 0, MaxPort: 100}},
 				},
 			}, false),
 		Entry("should reject rule mixed IPv4 (src) and IPv6 (dest)",


### PR DESCRIPTION
This reverts commit d35203732b06668677dc71c01ced0731c5839afa, reversing
changes made to 52ada4f5d18767b02a67eaa7af80bbbcf156de84.

## Description

Back out named ports since we've decided to push them out to v2.7.0 and the code that was checked in needed fixes in any case.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
