### PR TITLE
Completes support for Calico policy when using KDD client

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -257,6 +257,8 @@ func (c *KubeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
 func (c *KubeClient) Create(d *model.KVPair) (*model.KVPair, error) {
 	log.Debugf("Performing 'Create' for %+v", d)
 	switch d.Key.(type) {
+	case model.PolicyKey:
+		return c.gnpClient.Create(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Create(d)
 	case model.IPPoolKey:
@@ -285,6 +287,8 @@ func (c *KubeClient) Create(d *model.KVPair) (*model.KVPair, error) {
 func (c *KubeClient) Update(d *model.KVPair) (*model.KVPair, error) {
 	log.Debugf("Performing 'Update' for %+v", d)
 	switch d.Key.(type) {
+	case model.PolicyKey:
+		return c.gnpClient.Update(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Update(d)
 	case model.IPPoolKey:
@@ -315,6 +319,8 @@ func (c *KubeClient) Apply(d *model.KVPair) (*model.KVPair, error) {
 	switch d.Key.(type) {
 	case model.WorkloadEndpointKey:
 		return c.applyWorkloadEndpoint(d)
+	case model.PolicyKey:
+		return c.gnpClient.Apply(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Apply(d)
 	case model.IPPoolKey:
@@ -344,10 +350,12 @@ func (c *KubeClient) Apply(d *model.KVPair) (*model.KVPair, error) {
 	}
 }
 
-// Delete an entry in the datastore. This is a no-op when using the k8s backend.
+// Delete an entry in the datastore. Returns an error if the entry does not exist.
 func (c *KubeClient) Delete(d *model.KVPair) error {
 	log.Debugf("Performing 'Delete' for %+v", d)
 	switch d.Key.(type) {
+	case model.PolicyKey:
+		return c.gnpClient.Delete(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Delete(d)
 	case model.IPPoolKey:

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -518,8 +518,8 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// Make sure we clean up after ourselves.  We allow this to fail because
 		// part of our explicit testing below is to delete the resource.
 		defer func() {
-			c.gnpClient.Delete(kvp1a)
-			c.gnpClient.Delete(kvp2a)
+			c.Delete(kvp1a)
+			c.Delete(kvp2a)
 		}()
 
 		// Check our syncer has the correct GNP entries for the two
@@ -531,7 +531,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Creating a Global Network Policy", func() {
-			_, err := c.gnpClient.Create(kvp1a)
+			_, err := c.Create(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -547,12 +547,12 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Attempting to recreate an existing Global Network Policy", func() {
-			_, err := c.gnpClient.Create(kvp1a)
+			_, err := c.Create(kvp1a)
 			Expect(err).To(HaveOccurred())
 		})
 
 		By("Updating an existing Global Network Policy", func() {
-			_, err := c.gnpClient.Update(kvp1b)
+			_, err := c.Update(kvp1b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -568,7 +568,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Applying a non-existent Global Network Policy", func() {
-			_, err := c.gnpClient.Apply(kvp2a)
+			_, err := c.Apply(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -578,7 +578,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Updating the Global Network Policy created by Apply", func() {
-			_, err := c.gnpClient.Apply(kvp2b)
+			_, err := c.Apply(kvp2b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -588,7 +588,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleted the Global Network Policy created by Apply", func() {
-			err := c.gnpClient.Delete(kvp2a)
+			err := c.Delete(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -600,7 +600,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// Perform Get operations directly on the main client - this
 		// will fan out requests to the appropriate Policy client
 		// (including the Global Network Policy client).
-		By("Getting a Global Network Policy that does noe exist", func() {
+		By("Getting a Global Network Policy that does not exist", func() {
 			_, err := c.Get(model.PolicyKey{Name: "my-non-existent-test-gnp"})
 			Expect(err).To(HaveOccurred())
 		})
@@ -629,7 +629,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleting an existing Global Network Policy", func() {
-			err := c.gnpClient.Delete(kvp1a)
+			err := c.Delete(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
## Description
Adds support for creating, updating and deleting Calico policy when using `KubeClient`.

Tested by running through the [Advanced Policy Demo](https://docs.projectcalico.org/v2.5/getting-started/kubernetes/tutorials/advanced-policy) and confirmed that it works as expected when using KDD backend.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
