### PR TITLE
Make validation of policy types more permissive.

### DIFF
--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -552,21 +552,4 @@ func validatePolicySpec(v *validator.Validate, structLevel *validator.StructLeve
 			mp[t] = true
 		}
 	}
-
-	// When Types is explicitly specified:
-	if len(m.Types) > 0 {
-		var exists bool
-		// 'ingress' type must be there if Policy has any ingress rules.
-		_, exists = mp[api.PolicyTypeIngress]
-		if len(m.IngressRules) > 0 && !exists {
-			structLevel.ReportError(reflect.ValueOf(m.Types),
-				"PolicySpec.Types", "", reason("'ingress' must be specified when policy has ingress rules"))
-		}
-		// 'egress' type must be there if Policy has any egress rules.
-		_, exists = mp[api.PolicyTypeEgress]
-		if len(m.EgressRules) > 0 && !exists {
-			structLevel.ReportError(reflect.ValueOf(m.Types),
-				"PolicySpec.Types", "", reason("'egress' must be specified when policy has egress rules"))
-		}
-	}
 }

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -674,16 +674,22 @@ func init() {
 		Entry("allow ingress+egress Types", api.PolicySpec{Types: []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress}}, true),
 		Entry("disallow repeated egress Types", api.PolicySpec{Types: []api.PolicyType{api.PolicyTypeEgress, api.PolicyTypeEgress}}, false),
 		Entry("disallow unexpected value", api.PolicySpec{Types: []api.PolicyType{"unexpected"}}, false),
-		Entry("disallow Types without ingress when IngressRules present",
+
+		// In the initial implementation, we validated against the following two cases but we found
+		// that prevented us from doing a smooth upgrade from type-less to typed policy since we
+		// couldn't write a policy that would work for back-level Felix instances while also
+		// specifying the type for up-level Felix instances.
+		Entry("allow Types without ingress when IngressRules present",
 			api.PolicySpec{
 				IngressRules: []api.Rule{{Action: "allow"}},
 				Types:        []api.PolicyType{api.PolicyTypeEgress},
-			}, false),
-		Entry("disallow Types without egress when EgressRules present",
+			}, true),
+		Entry("allow Types without egress when EgressRules present",
 			api.PolicySpec{
 				EgressRules: []api.Rule{{Action: "allow"}},
 				Types:       []api.PolicyType{api.PolicyTypeIngress},
-			}, false),
+			}, true),
+
 		Entry("allow Types with ingress when IngressRules present",
 			api.PolicySpec{
 				IngressRules: []api.Rule{{Action: "allow"}},


### PR DESCRIPTION
## Description

Allow ingress/egress rules to be specified even if the corresponding Type isn't enabled.

This allows for smoother upgrades since we can have policy that works for old and new Felix versions.

## Todos
- [x] Tests
- [x] Documentation (no change needed, text didn't cover this case)
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
