### PR TITLE
Add remaining resources to v2 client for CRUD and Watch

### DIFF
--- a/lib/apiv2/ippool.go
+++ b/lib/apiv2/ippool.go
@@ -56,11 +56,11 @@ type IPIPConfiguration struct {
 type IPIPMode string
 
 const (
-	Off         IPIPMode = "Off"
-	Always               = "Always"
-	CrossSubnet          = "CrossSubnet"
+	IPIPModeOff         IPIPMode = "Off"
+	IPIPModeAlways               = "Always"
+	IPIPModeCrossSubnet          = "CrossSubnet"
 )
-const DefaultMode = Always
+const DefaultMode = IPIPModeAlways
 
 // IPPoolList contains a list of IPPool resources.
 type IPPoolList struct {

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -31,11 +31,12 @@ var (
 	matchNamespacedResource = regexp.MustCompile("^/calico/resources/v2/([^/]+)/([^/]+)/([^/]+)$")
 	kindToType              = map[string]reflect.Type{
 		strings.ToLower(apiv2.KindBGPPeer):             reflect.TypeOf(apiv2.BGPPeer{}),
-		strings.ToLower(apiv2.KindIPPool):              reflect.TypeOf(apiv2.IPPool{}),
-		strings.ToLower(apiv2.KindNode):                reflect.TypeOf(apiv2.Node{}),
-		strings.ToLower(apiv2.KindHostEndpoint):        reflect.TypeOf(apiv2.HostEndpoint{}),
-		strings.ToLower(apiv2.KindNetworkPolicy):       reflect.TypeOf(apiv2.NetworkPolicy{}),
 		strings.ToLower(apiv2.KindGlobalNetworkPolicy): reflect.TypeOf(apiv2.GlobalNetworkPolicy{}),
+		strings.ToLower(apiv2.KindHostEndpoint):        reflect.TypeOf(apiv2.HostEndpoint{}),
+		strings.ToLower(apiv2.KindIPPool):              reflect.TypeOf(apiv2.IPPool{}),
+		strings.ToLower(apiv2.KindNetworkPolicy):       reflect.TypeOf(apiv2.NetworkPolicy{}),
+		strings.ToLower(apiv2.KindNode):                reflect.TypeOf(apiv2.Node{}),
+		strings.ToLower(apiv2.KindProfile):             reflect.TypeOf(apiv2.Profile{}),
 		strings.ToLower(apiv2.KindWorkloadEndpoint):    reflect.TypeOf(apiv2.WorkloadEndpoint{}),
 	}
 )

--- a/lib/clientv2/bgppeer_e2e_test.go
+++ b/lib/clientv2/bgppeer_e2e_test.go
@@ -34,11 +34,11 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/watch"
 )
 
-// Perform CRUD operations on Global and Node-specific BGP Peer Resources.
 var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
-	name1 := "bgpnode-1"
-	name2 := "bgpnode-2"
+	ctx := context.Background()
+	name1 := "bgppeer-1"
+	name2 := "bgppeer-2"
 	spec1 := apiv2.BGPPeerSpec{
 		Node:     "node1",
 		PeerIP:   "10.0.0.1",
@@ -60,7 +60,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			be.Clean()
 
 			By("Updating the BGPPeer before it is created")
-			res, outError := c.BGPPeers().Update(context.Background(), &apiv2.BGPPeer{
+			res, outError := c.BGPPeers().Update(ctx, &apiv2.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -69,7 +69,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name1 + ")"))
 
 			By("Attempting to creating a new BGPPeer with name1/spec1 and a non-empty ResourceVersion")
-			res, outError = c.BGPPeers().Create(context.Background(), &apiv2.BGPPeer{
+			res, outError = c.BGPPeers().Create(ctx, &apiv2.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -78,7 +78,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
 			By("Creating a new BGPPeer with name1/spec1")
-			res1, outError := c.BGPPeers().Create(context.Background(), &apiv2.BGPPeer{
+			res1, outError := c.BGPPeers().Create(ctx, &apiv2.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -89,7 +89,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			rv1_1 := res1.ResourceVersion
 
 			By("Attempting to create the same BGPPeer with name1 but with spec2")
-			res1, outError = c.BGPPeers().Create(context.Background(), &apiv2.BGPPeer{
+			res1, outError = c.BGPPeers().Create(ctx, &apiv2.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -100,24 +100,24 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			Expect(res1.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting BGPPeer (name1) and comparing the output against spec1")
-			res, outError = c.BGPPeers().Get(context.Background(), name1, options.GetOptions{})
+			res, outError = c.BGPPeers().Get(ctx, name1, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
 
 			By("Getting BGPPeer (name2) before it is created")
-			res, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 
 			By("Listing all the BGPPeers, expecting a single result with name1/spec1")
-			outList, outError := c.BGPPeers().List(context.Background(), options.ListOptions{})
+			outList, outError := c.BGPPeers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec1)
 
 			By("Creating a new BGPPeer with name2/spec2")
-			res2, outError := c.BGPPeers().Create(context.Background(), &apiv2.BGPPeer{
+			res2, outError := c.BGPPeers().Create(ctx, &apiv2.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -125,13 +125,13 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			testutils.ExpectResource(res2, apiv2.KindBGPPeer, clientv2.NoNamespace, name2, spec2)
 
 			By("Getting BGPPeer (name2) and comparing the output against spec2")
-			res, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res2, apiv2.KindBGPPeer, clientv2.NoNamespace, name2, spec2)
 			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
 
 			By("Listing all the BGPPeers, expecting a two results with name1/spec1 and name2/spec2")
-			outList, outError = c.BGPPeers().List(context.Background(), options.ListOptions{})
+			outList, outError = c.BGPPeers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec1)
@@ -139,7 +139,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 
 			By("Updating BGPPeer name1 with spec2")
 			res1.Spec = spec2
-			res1, outError = c.BGPPeers().Update(context.Background(), res1, options.SetOptions{})
+			res1, outError = c.BGPPeers().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec2)
 
@@ -149,7 +149,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			By("Updating BGPPeer name1 without specifying a resource version")
 			res1.Spec = spec1
 			res1.ObjectMeta.ResourceVersion = ""
-			res, outError = c.BGPPeers().Update(context.Background(), res1, options.SetOptions{})
+			res, outError = c.BGPPeers().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
 			Expect(res).To(BeNil())
@@ -157,82 +157,82 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			By("Updating BGPPeer name1 using the previous resource version")
 			res1.Spec = spec1
 			res1.ResourceVersion = rv1_1
-			res1, outError = c.BGPPeers().Update(context.Background(), res1, options.SetOptions{})
+			res1, outError = c.BGPPeers().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: BGPPeer(" + name1 + ")"))
 			Expect(res1.ResourceVersion).To(Equal(rv1_2))
 
 			By("Getting BGPPeer (name1) with the original resource version and comparing the output against spec1")
-			res, outError = c.BGPPeers().Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_1})
+			res, outError = c.BGPPeers().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting BGPPeer (name1) with the updated resource version and comparing the output against spec2")
-			res, outError = c.BGPPeers().Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_2})
+			res, outError = c.BGPPeers().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec2)
 			Expect(res.ResourceVersion).To(Equal(rv1_2))
 
 			By("Listing BGPPeers with the original resource version and checking for a single result with name1/spec1")
-			outList, outError = c.BGPPeers().List(context.Background(), options.ListOptions{ResourceVersion: rv1_1})
+			outList, outError = c.BGPPeers().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec1)
 
 			By("Listing BGPPeers with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError = c.BGPPeers().List(context.Background(), options.ListOptions{})
+			outList, outError = c.BGPPeers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPPeer, clientv2.NoNamespace, name1, spec2)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindBGPPeer, clientv2.NoNamespace, name2, spec2)
 
 			By("Deleting BGPPeer (name1) with the old resource version")
-			outError = c.BGPPeers().Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			outError = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: BGPPeer(" + name1 + ")"))
 
 			By("Deleting BGPPeer (name1) with the new resource version")
-			outError = c.BGPPeers().Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			outError = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 
 			By("Updating BGPPeer name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.BGPPeers().Update(context.Background(), res2, options.SetOptions{TTL: 2 * time.Second})
+			_, outError = c.BGPPeers().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 
 			By("Creating BGPPeer name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.BGPPeers().Create(context.Background(), &apiv2.BGPPeer{
+			_, outError = c.BGPPeers().Create(ctx, &apiv2.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 
 			By("Attempting to deleting BGPPeer (name2) again")
-			outError = c.BGPPeers().Delete(context.Background(), name2, options.DeleteOptions{})
+			outError = c.BGPPeers().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 
 			By("Listing all BGPPeers and expecting no items")
-			outList, outError = c.BGPPeers().List(context.Background(), options.ListOptions{})
+			outList, outError = c.BGPPeers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 
 			By("Getting BGPPeer (name2) and expecting an error")
-			res, outError = c.BGPPeers().Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 		},
@@ -251,14 +251,14 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			be.Clean()
 
 			By("Listing BGPPeers with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError := c.BGPPeers().List(context.Background(), options.ListOptions{})
+			outList, outError := c.BGPPeers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
 			By("Configuring a BGPPeer name1/spec1 and storing the response")
 			outRes1, err := c.BGPPeers().Create(
-				context.Background(),
+				ctx,
 				&apiv2.BGPPeer{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
@@ -269,7 +269,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 
 			By("Configuring a BGPPeer name2/spec2 and storing the response")
 			outRes2, err := c.BGPPeers().Create(
-				context.Background(),
+				ctx,
 				&apiv2.BGPPeer{
 					ObjectMeta: metav1.ObjectMeta{Name: name2},
 					Spec:       spec2,
@@ -278,13 +278,13 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
-			w, err := c.BGPPeers().Watch(context.Background(), options.ListOptions{ResourceVersion: rev1})
+			w, err := c.BGPPeers().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher1 := testutils.TestResourceWatch(w)
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.BGPPeers().Delete(context.Background(), name1, options.DeleteOptions{})
+			err = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -301,14 +301,14 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			testWatcher1.Stop()
 
 			By("Starting a watcher from rev0 - this should get all events")
-			w, err = c.BGPPeers().Watch(context.Background(), options.ListOptions{ResourceVersion: rev0})
+			w, err = c.BGPPeers().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher2 := testutils.TestResourceWatch(w)
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
 			outRes3, err := c.BGPPeers().Update(
-				context.Background(),
+				ctx,
 				&apiv2.BGPPeer{
 					ObjectMeta: outRes2.ObjectMeta,
 					Spec:       spec1,
@@ -338,7 +338,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			testWatcher2.Stop()
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.BGPPeers().Watch(context.Background(), options.ListOptions{})
+			w, err = c.BGPPeers().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher3 := testutils.TestResourceWatch(w)
 			defer testWatcher3.Stop()
@@ -352,7 +352,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 
 			By("Configuring BGPPeer name1/spec1 again and storing the response")
 			outRes1, err = c.BGPPeers().Create(
-				context.Background(),
+				ctx,
 				&apiv2.BGPPeer{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
@@ -361,7 +361,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			)
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.BGPPeers().Watch(context.Background(), options.ListOptions{})
+			w, err = c.BGPPeers().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher4 := testutils.TestResourceWatch(w)
 			defer testWatcher4.Stop()

--- a/lib/clientv2/globalnetworkpolicy.go
+++ b/lib/clientv2/globalnetworkpolicy.go
@@ -40,39 +40,50 @@ type globalnetworkpolicies struct {
 // Create takes the representation of a GlobalNetworkPolicy and creates it.  Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
 func (r globalnetworkpolicies) Create(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error) {
-	panic("Create not implemented for GlobalNetworkPolicyInterface")
-	return nil, nil
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindGlobalNetworkPolicy, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.GlobalNetworkPolicy), err
+	}
+	return nil, err
 }
 
 // Update takes the representation of a GlobalNetworkPolicy and updates it. Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
 func (r globalnetworkpolicies) Update(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error) {
-	panic("Update not implemented for GlobalNetworkPolicyInterface")
-	return nil, nil
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindGlobalNetworkPolicy, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.GlobalNetworkPolicy), err
+	}
+	return nil, err
 }
 
 // Delete takes name of the GlobalNetworkPolicy and deletes it. Returns an error if one occurs.
 func (r globalnetworkpolicies) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	panic("Delete not implemented for GlobalNetworkPolicyInterface")
-	return nil
+	err := r.client.resources.Delete(ctx, opts, apiv2.KindGlobalNetworkPolicy, NoNamespace, name)
+	return err
 }
 
 // Get takes name of the GlobalNetworkPolicy, and returns the corresponding GlobalNetworkPolicy object,
 // and an error if there is any.
 func (r globalnetworkpolicies) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.GlobalNetworkPolicy, error) {
-	panic("Get not implemented for GlobalNetworkPolicyInterface")
-	return nil, nil
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindGlobalNetworkPolicy, NoNamespace, name)
+	if out != nil {
+		return out.(*apiv2.GlobalNetworkPolicy), err
+	}
+	return nil, err
 }
 
 // List returns the list of GlobalNetworkPolicy objects that match the supplied options.
 func (r globalnetworkpolicies) List(ctx context.Context, opts options.ListOptions) (*apiv2.GlobalNetworkPolicyList, error) {
-	panic("List not implemented for GlobalNetworkPolicyInterface")
-	return nil, nil
+	res := &apiv2.GlobalNetworkPolicyList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindGlobalNetworkPolicy, apiv2.KindGlobalNetworkPolicyList, NoNamespace, AllNames, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
-// Watch returns a watch.Interface that watches the GlobalNetworkPolicys that match the
+// Watch returns a watch.Interface that watches the globalnetworkpolicies that match the
 // supplied options.
 func (r globalnetworkpolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	panic("Watch not implemented for GlobalNetworkPolicyInterface")
-	return nil, nil
+	return r.client.resources.Watch(ctx, opts, apiv2.KindGlobalNetworkPolicy, NoNamespace, AllNames)
 }

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	order1 := 99.999
+	order2 := 22.222
+	name1 := "globalnetworkp-1"
+	name2 := "globalnetworkp-2"
+	spec1 := apiv2.PolicySpec{
+		Order:        &order1,
+		IngressRules: []apiv2.Rule{testutils.InRule1, testutils.InRule2},
+		EgressRules:  []apiv2.Rule{testutils.EgressRule1, testutils.EgressRule2},
+		Selector:     "thing == 'value'",
+	}
+	spec2 := apiv2.PolicySpec{
+		Order:        &order2,
+		IngressRules: []apiv2.Rule{testutils.InRule2, testutils.InRule1},
+		EgressRules:  []apiv2.Rule{testutils.EgressRule2, testutils.EgressRule1},
+		Selector:     "thing2 == 'value2'",
+		DoNotTrack:   true,
+	}
+
+	DescribeTable("GlobalNetworkPolicy e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv2.PolicySpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the GlobalNetworkPolicy before it is created")
+			res, outError := c.GlobalNetworkPolicies().Update(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name1 + ")"))
+
+			By("Attempting to creating a new GlobalNetworkPolicy with name1/spec1 and a non-empty ResourceVersion")
+			res, outError = c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new GlobalNetworkPolicy with name1/spec1")
+			res1, outError := c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same GlobalNetworkPolicy with name1 but with spec2")
+			res1, outError = c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: GlobalNetworkPolicy(" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting GlobalNetworkPolicy (name1) and comparing the output against spec1")
+			res, outError = c.GlobalNetworkPolicies().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting GlobalNetworkPolicy (name2) before it is created")
+			res, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+
+			By("Listing all the GlobalNetworkPolicies, expecting a single result with name1/spec1")
+			outList, outError := c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+
+			By("Creating a new GlobalNetworkPolicy with name2/spec2")
+			res2, outError := c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name2, spec2)
+
+			By("Getting GlobalNetworkPolicy (name2) and comparing the output against spec2")
+			res, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name2, spec2)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the GlobalNetworkPolicies, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name2, spec2)
+
+			By("Updating GlobalNetworkPolicy name1 with spec2")
+			res1.Spec = spec2
+			res1, outError = c.GlobalNetworkPolicies().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec2)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating GlobalNetworkPolicy name1 without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.GlobalNetworkPolicies().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating GlobalNetworkPolicy name1 using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.GlobalNetworkPolicies().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting GlobalNetworkPolicy (name1) with the original resource version and comparing the output against spec1")
+			res, outError = c.GlobalNetworkPolicies().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting GlobalNetworkPolicy (name1) with the updated resource version and comparing the output against spec2")
+			res, outError = c.GlobalNetworkPolicies().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing GlobalNetworkPolicies with the original resource version and checking for a single result with name1/spec1")
+			outList, outError = c.GlobalNetworkPolicies().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec1)
+
+			By("Listing GlobalNetworkPolicies with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name1, spec2)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindGlobalNetworkPolicy, clientv2.NoNamespace, name2, spec2)
+
+			By("Deleting GlobalNetworkPolicy (name1) with the old resource version")
+			outError = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(" + name1 + ")"))
+
+			By("Deleting GlobalNetworkPolicy (name1) with the new resource version")
+			outError = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			By("Updating GlobalNetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.GlobalNetworkPolicies().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+
+			By("Creating GlobalNetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+
+			By("Attempting to deleting GlobalNetworkPolicy (name2) again")
+			outError = c.GlobalNetworkPolicies().Delete(ctx, name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+
+			By("Listing all GlobalNetworkPolicies and expecting no items")
+			outList, outError = c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting GlobalNetworkPolicy (name2) and expecting an error")
+			res, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+		},
+
+		// Test 1: Pass two fully populated GlobalNetworkPolicySpecs and expect the series of operations to succeed.
+		Entry("Two fully populated GlobalNetworkPolicySpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("GlobalNetworkPolicy watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing GlobalNetworkPolicies with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError := c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a GlobalNetworkPolicy name1/spec1 and storing the response")
+			outRes1, err := c.GlobalNetworkPolicies().Create(
+				ctx,
+				&apiv2.GlobalNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a GlobalNetworkPolicy name2/spec2 and storing the response")
+			outRes2, err := c.GlobalNetworkPolicies().Create(
+				ctx,
+				&apiv2.GlobalNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			err = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.GlobalNetworkPolicies().Update(
+				ctx,
+				&apiv2.GlobalNetworkPolicy{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Configuring GlobalNetworkPolicy name1/spec1 again and storing the response")
+			outRes1, err = c.GlobalNetworkPolicies().Create(
+				ctx,
+				&apiv2.GlobalNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher4.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})

--- a/lib/clientv2/hostendpoint.go
+++ b/lib/clientv2/hostendpoint.go
@@ -40,39 +40,50 @@ type hostEndpoints struct {
 // Create takes the representation of a HostEndpoint and creates it.  Returns the stored
 // representation of the HostEndpoint, and an error, if there is any.
 func (r hostEndpoints) Create(ctx context.Context, res *apiv2.HostEndpoint, opts options.SetOptions) (*apiv2.HostEndpoint, error) {
-	panic("Create not implemented for HostEndpointInterface")
-	return nil, nil
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindHostEndpoint, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.HostEndpoint), err
+	}
+	return nil, err
 }
 
 // Update takes the representation of a HostEndpoint and updates it. Returns the stored
 // representation of the HostEndpoint, and an error, if there is any.
 func (r hostEndpoints) Update(ctx context.Context, res *apiv2.HostEndpoint, opts options.SetOptions) (*apiv2.HostEndpoint, error) {
-	panic("Update not implemented for HostEndpointInterface")
-	return nil, nil
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindHostEndpoint, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.HostEndpoint), err
+	}
+	return nil, err
 }
 
 // Delete takes name of the HostEndpoint and deletes it. Returns an error if one occurs.
 func (r hostEndpoints) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	panic("Delete not implemented for HostEndpointInterface")
-	return nil
+	err := r.client.resources.Delete(ctx, opts, apiv2.KindHostEndpoint, NoNamespace, name)
+	return err
 }
 
 // Get takes name of the HostEndpoint, and returns the corresponding HostEndpoint object,
 // and an error if there is any.
 func (r hostEndpoints) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.HostEndpoint, error) {
-	panic("Get not implemented for HostEndpointInterface")
-	return nil, nil
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindHostEndpoint, NoNamespace, name)
+	if out != nil {
+		return out.(*apiv2.HostEndpoint), err
+	}
+	return nil, err
 }
 
 // List returns the list of HostEndpoint objects that match the supplied options.
 func (r hostEndpoints) List(ctx context.Context, opts options.ListOptions) (*apiv2.HostEndpointList, error) {
-	panic("List not implemented for HostEndpointInterface")
-	return nil, nil
+	res := &apiv2.HostEndpointList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindHostEndpoint, apiv2.KindHostEndpointList, NoNamespace, AllNames, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Watch returns a watch.Interface that watches the HostEndpoints that match the
 // supplied options.
 func (r hostEndpoints) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	panic("Watch not implemented for HostEndpointInterface")
-	return nil, nil
+	return r.client.resources.Watch(ctx, opts, apiv2.KindHostEndpoint, NoNamespace, AllNames)
 }

--- a/lib/clientv2/hostendpoint_e2e_test.go
+++ b/lib/clientv2/hostendpoint_e2e_test.go
@@ -1,0 +1,391 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "hep-1"
+	name2 := "hep-2"
+	spec1 := apiv2.HostEndpointSpec{
+		Node:     "node1",
+		InterfaceName: "eth0",
+	}
+	spec2 := apiv2.HostEndpointSpec{
+		Node:     "node2",
+		InterfaceName: "eth1",
+	}
+
+	DescribeTable("HostEndpoint e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv2.HostEndpointSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the HostEndpoint before it is created")
+			res, outError := c.HostEndpoints().Update(ctx, &apiv2.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name1 + ")"))
+
+			By("Attempting to creating a new HostEndpoint with name1/spec1 and a non-empty ResourceVersion")
+			res, outError = c.HostEndpoints().Create(ctx, &apiv2.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new HostEndpoint with name1/spec1")
+			res1, outError := c.HostEndpoints().Create(ctx, &apiv2.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same HostEndpoint with name1 but with spec2")
+			res1, outError = c.HostEndpoints().Create(ctx, &apiv2.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: HostEndpoint(" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting HostEndpoint (name1) and comparing the output against spec1")
+			res, outError = c.HostEndpoints().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting HostEndpoint (name2) before it is created")
+			res, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+
+			By("Listing all the HostEndpoints, expecting a single result with name1/spec1")
+			outList, outError := c.HostEndpoints().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+
+			By("Creating a new HostEndpoint with name2/spec2")
+			res2, outError := c.HostEndpoints().Create(ctx, &apiv2.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindHostEndpoint, clientv2.NoNamespace, name2, spec2)
+
+			By("Getting HostEndpoint (name2) and comparing the output against spec2")
+			res, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindHostEndpoint, clientv2.NoNamespace, name2, spec2)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the HostEndpoints, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = c.HostEndpoints().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindHostEndpoint, clientv2.NoNamespace, name2, spec2)
+
+			By("Updating HostEndpoint name1 with spec2")
+			res1.Spec = spec2
+			res1, outError = c.HostEndpoints().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec2)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating HostEndpoint name1 without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.HostEndpoints().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating HostEndpoint name1 using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.HostEndpoints().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: HostEndpoint(" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting HostEndpoint (name1) with the original resource version and comparing the output against spec1")
+			res, outError = c.HostEndpoints().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting HostEndpoint (name1) with the updated resource version and comparing the output against spec2")
+			res, outError = c.HostEndpoints().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing HostEndpoints with the original resource version and checking for a single result with name1/spec1")
+			outList, outError = c.HostEndpoints().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec1)
+
+			By("Listing HostEndpoints with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = c.HostEndpoints().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindHostEndpoint, clientv2.NoNamespace, name1, spec2)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindHostEndpoint, clientv2.NoNamespace, name2, spec2)
+
+			By("Deleting HostEndpoint (name1) with the old resource version")
+			outError = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: HostEndpoint(" + name1 + ")"))
+
+			By("Deleting HostEndpoint (name1) with the new resource version")
+			outError = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			By("Updating HostEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.HostEndpoints().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+
+			By("Creating HostEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.HostEndpoints().Create(ctx, &apiv2.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+
+			By("Attempting to deleting HostEndpoint (name2) again")
+			outError = c.HostEndpoints().Delete(ctx, name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+
+			By("Listing all HostEndpoints and expecting no items")
+			outList, outError = c.HostEndpoints().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting HostEndpoint (name2) and expecting an error")
+			res, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+		},
+
+		// Test 1: Pass two fully populated HostEndpointSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated HostEndpointSpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("HostEndpoint watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing HostEndpoints with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError := c.HostEndpoints().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a HostEndpoint name1/spec1 and storing the response")
+			outRes1, err := c.HostEndpoints().Create(
+				ctx,
+				&apiv2.HostEndpoint{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a HostEndpoint name2/spec2 and storing the response")
+			outRes2, err := c.HostEndpoints().Create(
+				ctx,
+				&apiv2.HostEndpoint{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.HostEndpoints().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			err = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindHostEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.HostEndpoints().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.HostEndpoints().Update(
+				ctx,
+				&apiv2.HostEndpoint{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindHostEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.HostEndpoints().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindHostEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Configuring HostEndpoint name1/spec1 again and storing the response")
+			outRes1, err = c.HostEndpoints().Create(
+				ctx,
+				&apiv2.HostEndpoint{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.HostEndpoints().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindHostEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher4.ExpectEvents(apiv2.KindHostEndpoint, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})

--- a/lib/clientv2/ippool.go
+++ b/lib/clientv2/ippool.go
@@ -40,39 +40,50 @@ type ipPools struct {
 // Create takes the representation of a IPPool and creates it.  Returns the stored
 // representation of the IPPool, and an error, if there is any.
 func (r ipPools) Create(ctx context.Context, res *apiv2.IPPool, opts options.SetOptions) (*apiv2.IPPool, error) {
-	panic("Create not implemented for IPPoolInterface")
-	return nil, nil
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindIPPool, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.IPPool), err
+	}
+	return nil, err
 }
 
 // Update takes the representation of a IPPool and updates it. Returns the stored
 // representation of the IPPool, and an error, if there is any.
 func (r ipPools) Update(ctx context.Context, res *apiv2.IPPool, opts options.SetOptions) (*apiv2.IPPool, error) {
-	panic("Update not implemented for IPPoolInterface")
-	return nil, nil
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindIPPool, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.IPPool), err
+	}
+	return nil, err
 }
 
 // Delete takes name of the IPPool and deletes it. Returns an error if one occurs.
 func (r ipPools) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	panic("Delete not implemented for IPPoolInterface")
-	return nil
+	err := r.client.resources.Delete(ctx, opts, apiv2.KindIPPool, NoNamespace, name)
+	return err
 }
 
 // Get takes name of the IPPool, and returns the corresponding IPPool object,
 // and an error if there is any.
 func (r ipPools) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.IPPool, error) {
-	panic("Get not implemented for IPPoolInterface")
-	return nil, nil
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindIPPool, NoNamespace, name)
+	if out != nil {
+		return out.(*apiv2.IPPool), err
+	}
+	return nil, err
 }
 
 // List returns the list of IPPool objects that match the supplied options.
 func (r ipPools) List(ctx context.Context, opts options.ListOptions) (*apiv2.IPPoolList, error) {
-	panic("List not implemented for IPPoolInterface")
-	return nil, nil
+	res := &apiv2.IPPoolList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindIPPool, apiv2.KindIPPoolList, NoNamespace, AllNames, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Watch returns a watch.Interface that watches the IPPools that match the
 // supplied options.
 func (r ipPools) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	panic("Watch not implemented for IPPoolInterface")
-	return nil, nil
+	return r.client.resources.Watch(ctx, opts, apiv2.KindIPPool, NoNamespace, AllNames)
 }

--- a/lib/clientv2/ippool_e2e_test.go
+++ b/lib/clientv2/ippool_e2e_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "ippool-1"
+	name2 := "ippool-2"
+	spec1 := apiv2.IPPoolSpec{
+		CIDR:   "1.2.3.0/24",
+		IPIP:   &apiv2.IPIPConfiguration{
+			Mode: apiv2.IPIPModeAlways,
+		},
+	}
+	spec2 := apiv2.IPPoolSpec{
+		CIDR:   "aa:bb:cc/120",
+		IPIP:   &apiv2.IPIPConfiguration{
+			Mode: apiv2.IPIPModeCrossSubnet,
+		},
+	}
+
+	DescribeTable("IPPool e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv2.IPPoolSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the IPPool before it is created")
+			res, outError := c.IPPools().Update(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name1 + ")"))
+
+			By("Attempting to creating a new IPPool with name1/spec1 and a non-empty ResourceVersion")
+			res, outError = c.IPPools().Create(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new IPPool with name1/spec1")
+			res1, outError := c.IPPools().Create(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same IPPool with name1 but with spec2")
+			res1, outError = c.IPPools().Create(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: IPPool(" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting IPPool (name1) and comparing the output against spec1")
+			res, outError = c.IPPools().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting IPPool (name2) before it is created")
+			res, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+
+			By("Listing all the IPPools, expecting a single result with name1/spec1")
+			outList, outError := c.IPPools().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+
+			By("Creating a new IPPool with name2/spec2")
+			res2, outError := c.IPPools().Create(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindIPPool, clientv2.NoNamespace, name2, spec2)
+
+			By("Getting IPPool (name2) and comparing the output against spec2")
+			res, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindIPPool, clientv2.NoNamespace, name2, spec2)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the IPPools, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = c.IPPools().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindIPPool, clientv2.NoNamespace, name2, spec2)
+
+			By("Updating IPPool name1 with spec2")
+			res1.Spec = spec2
+			res1, outError = c.IPPools().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindIPPool, clientv2.NoNamespace, name1, spec2)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating IPPool name1 without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.IPPools().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating IPPool name1 using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.IPPools().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: IPPool(" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting IPPool (name1) with the original resource version and comparing the output against spec1")
+			res, outError = c.IPPools().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting IPPool (name1) with the updated resource version and comparing the output against spec2")
+			res, outError = c.IPPools().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindIPPool, clientv2.NoNamespace, name1, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing IPPools with the original resource version and checking for a single result with name1/spec1")
+			outList, outError = c.IPPools().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindIPPool, clientv2.NoNamespace, name1, spec1)
+
+			By("Listing IPPools with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = c.IPPools().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindIPPool, clientv2.NoNamespace, name1, spec2)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindIPPool, clientv2.NoNamespace, name2, spec2)
+
+			By("Deleting IPPool (name1) with the old resource version")
+			outError = c.IPPools().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: IPPool(" + name1 + ")"))
+
+			By("Deleting IPPool (name1) with the new resource version")
+			outError = c.IPPools().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			By("Updating IPPool name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.IPPools().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+
+			By("Creating IPPool name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.IPPools().Create(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+
+			By("Attempting to deleting IPPool (name2) again")
+			outError = c.IPPools().Delete(ctx, name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+
+			By("Listing all IPPools and expecting no items")
+			outList, outError = c.IPPools().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting IPPool (name2) and expecting an error")
+			res, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+		},
+
+		// Test 1: Pass two fully populated IPPoolSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated IPPoolSpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("IPPool watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing IPPools with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError := c.IPPools().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a IPPool name1/spec1 and storing the response")
+			outRes1, err := c.IPPools().Create(
+				ctx,
+				&apiv2.IPPool{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a IPPool name2/spec2 and storing the response")
+			outRes2, err := c.IPPools().Create(
+				ctx,
+				&apiv2.IPPool{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.IPPools().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			err = c.IPPools().Delete(ctx, name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindIPPool, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.IPPools().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.IPPools().Update(
+				ctx,
+				&apiv2.IPPool{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindIPPool, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.IPPools().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindIPPool, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Configuring IPPool name1/spec1 again and storing the response")
+			outRes1, err = c.IPPools().Create(
+				ctx,
+				&apiv2.IPPool{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.IPPools().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindIPPool, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher4.ExpectEvents(apiv2.KindIPPool, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})

--- a/lib/clientv2/networkpolicy.go
+++ b/lib/clientv2/networkpolicy.go
@@ -24,8 +24,8 @@ import (
 
 // NetworkPolicyInterface has methods to work with NetworkPolicy resources.
 type NetworkPolicyInterface interface {
-	Create(ctx context.Context, peer *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error)
-	Update(ctx context.Context, peer *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error)
+	Create(ctx context.Context, res *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error)
+	Update(ctx context.Context, res *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error)
 	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.NetworkPolicy, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.NetworkPolicyList, error)

--- a/lib/clientv2/networkpolicy_e2e_test.go
+++ b/lib/clientv2/networkpolicy_e2e_test.go
@@ -33,12 +33,11 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/watch"
 )
 
-var order1 = 99.999
-var order2 = 22.222
-
-// Perform CRUD operations on Global and Node-specific BGP Peer Resources.
 var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
+	ctx := context.Background()
+	order1 := 99.999
+	order2 := 22.222
 	namespace1 := "namespace-1"
 	namespace2 := "namespace-2"
 	name1 := "networkp-1"
@@ -67,7 +66,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			be.Clean()
 
 			By("Updating the NetworkPolicy before it is created")
-			res, outError := c.NetworkPolicies(namespace1).Update(context.Background(), &apiv2.NetworkPolicy{
+			res, outError := c.NetworkPolicies(namespace1).Update(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -76,7 +75,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace1 + "/" + name1 + ")"))
 
 			By("Attempting to creating a new NetworkPolicy with name1/spec1 and a non-empty ResourceVersion")
-			res, outError = c.NetworkPolicies(namespace1).Create(context.Background(), &apiv2.NetworkPolicy{
+			res, outError = c.NetworkPolicies(namespace1).Create(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -85,7 +84,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
 			By("Creating a new NetworkPolicy with namespace1/name1/spec1")
-			res1, outError := c.NetworkPolicies(namespace1).Create(context.Background(), &apiv2.NetworkPolicy{
+			res1, outError := c.NetworkPolicies(namespace1).Create(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -96,7 +95,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			rv1_1 := res1.ResourceVersion
 
 			By("Attempting to create the same NetworkPolicy with name1 but with spec2")
-			res1, outError = c.NetworkPolicies(namespace1).Create(context.Background(), &apiv2.NetworkPolicy{
+			res1, outError = c.NetworkPolicies(namespace1).Create(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -107,24 +106,24 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			Expect(res1.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting NetworkPolicy (name1) and comparing the output against spec1")
-			res, outError = c.NetworkPolicies(namespace1).Get(context.Background(), name1, options.GetOptions{})
+			res, outError = c.NetworkPolicies(namespace1).Get(ctx, name1, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
 
 			By("Getting NetworkPolicy (name2) before it is created")
-			res, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Listing all the NetworkPolicies in namespace1, expecting a single result with name1/spec1")
-			outList, outError := c.NetworkPolicies(namespace1).List(context.Background(), options.ListOptions{})
+			outList, outError := c.NetworkPolicies(namespace1).List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 
 			By("Creating a new NetworkPolicy with name2/spec2")
-			res2, outError := c.NetworkPolicies(namespace2).Create(context.Background(), &apiv2.NetworkPolicy{
+			res2, outError := c.NetworkPolicies(namespace2).Create(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name2, Namespace: namespace2},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -132,27 +131,27 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			testutils.ExpectResource(res2, apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Getting NetworkPolicy (name2) and comparing the output against spec2")
-			res, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
 
 			By("Listing all the NetworkPolicies using an empty namespace (all-namespaces), expecting a two results with name1/spec1 and name2/spec2")
-			outList, outError = c.NetworkPolicies("").List(context.Background(), options.ListOptions{})
+			outList, outError = c.NetworkPolicies("").List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Listing all the NetworkPolicies in namespace2, expecting a one results with name2/spec2")
-			outList, outError = c.NetworkPolicies(namespace2).List(context.Background(), options.ListOptions{})
+			outList, outError = c.NetworkPolicies(namespace2).List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Updating NetworkPolicy name1 with spec2")
 			res1.Spec = spec2
-			res1, outError = c.NetworkPolicies(namespace1).Update(context.Background(), res1, options.SetOptions{})
+			res1, outError = c.NetworkPolicies(namespace1).Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 
@@ -162,7 +161,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Updating BGPPeer name1 without specifying a resource version")
 			res1.Spec = spec1
 			res1.ObjectMeta.ResourceVersion = ""
-			res, outError = c.NetworkPolicies(namespace1).Update(context.Background(), res1, options.SetOptions{})
+			res, outError = c.NetworkPolicies(namespace1).Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
 			Expect(res).To(BeNil())
@@ -170,82 +169,82 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Updating NetworkPolicy name1 using the previous resource version")
 			res1.Spec = spec1
 			res1.ResourceVersion = rv1_1
-			res1, outError = c.NetworkPolicies(namespace1).Update(context.Background(), res1, options.SetOptions{})
+			res1, outError = c.NetworkPolicies(namespace1).Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: NetworkPolicy(" + namespace1 + "/" + name1 + ")"))
 			Expect(res1.ResourceVersion).To(Equal(rv1_2))
 
 			By("Getting NetworkPolicy (name1) with the original resource version and comparing the output against spec1")
-			res, outError = c.NetworkPolicies(namespace1).Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_1})
+			res, outError = c.NetworkPolicies(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting NetworkPolicy (name1) with the updated resource version and comparing the output against spec2")
-			res, outError = c.NetworkPolicies(namespace1).Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_2})
+			res, outError = c.NetworkPolicies(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 			Expect(res.ResourceVersion).To(Equal(rv1_2))
 
 			By("Listing NetworkPolicies with the original resource version and checking for a single result with name1/spec1")
-			outList, outError = c.NetworkPolicies(namespace1).List(context.Background(), options.ListOptions{ResourceVersion: rv1_1})
+			outList, outError = c.NetworkPolicies(namespace1).List(ctx, options.ListOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 
 			By("Listing NetworkPolicies (all namespaces) with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError = c.NetworkPolicies("").List(context.Background(), options.ListOptions{})
+			outList, outError = c.NetworkPolicies("").List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Deleting NetworkPolicy (name1) with the old resource version")
-			outError = c.NetworkPolicies(namespace1).Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			outError = c.NetworkPolicies(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: NetworkPolicy(" + namespace1 + "/" + name1 + ")"))
 
 			By("Deleting NetworkPolicy (name1) with the new resource version")
-			outError = c.NetworkPolicies(namespace1).Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			outError = c.NetworkPolicies(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 
 			By("Updating NetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.NetworkPolicies(namespace2).Update(context.Background(), res2, options.SetOptions{TTL: 2 * time.Second})
+			_, outError = c.NetworkPolicies(namespace2).Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Creating NetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.NetworkPolicies(namespace2).Create(context.Background(), &apiv2.NetworkPolicy{
+			_, outError = c.NetworkPolicies(namespace2).Create(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Attempting to deleting NetworkPolicy (name2) again")
-			outError = c.NetworkPolicies(namespace2).Delete(context.Background(), name2, options.DeleteOptions{})
+			outError = c.NetworkPolicies(namespace2).Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Listing all NetworkPolicies and expecting no items")
-			outList, outError = c.NetworkPolicies("").List(context.Background(), options.ListOptions{})
+			outList, outError = c.NetworkPolicies("").List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 
 			By("Getting NetworkPolicy (name2) and expecting an error")
-			res, outError = c.NetworkPolicies(namespace2).Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 		},
@@ -268,14 +267,14 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			be.Clean()
 
 			By("Listing NetworkPolicies with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError := c.NetworkPolicies(clientv2.AllNamespaces).List(context.Background(), options.ListOptions{})
+			outList, outError := c.NetworkPolicies(clientv2.AllNamespaces).List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
 			By("Configuring a NetworkPolicy namespace1/name1/spec1 and storing the response")
 			outRes1, err := c.NetworkPolicies(namespace1).Create(
-				context.Background(),
+				ctx,
 				&apiv2.NetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
@@ -286,7 +285,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 
 			By("Configuring a NetworkPolicy namespace2/name2/spec2 and storing the response")
 			outRes2, err := c.NetworkPolicies(namespace2).Create(
-				context.Background(),
+				ctx,
 				&apiv2.NetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{Name: name2},
 					Spec:       spec2,
@@ -295,13 +294,13 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
-			w, err := c.NetworkPolicies(clientv2.AllNamespaces).Watch(context.Background(), options.ListOptions{ResourceVersion: rev1})
+			w, err := c.NetworkPolicies(clientv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev1})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher1 := testutils.TestResourceWatch(w)
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.NetworkPolicies(namespace1).Delete(context.Background(), name1, options.DeleteOptions{})
+			err = c.NetworkPolicies(namespace1).Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -318,14 +317,14 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			testWatcher1.Stop()
 
 			By("Starting a watcher from rev0 - this should get all events")
-			w, err = c.NetworkPolicies(clientv2.AllNamespaces).Watch(context.Background(), options.ListOptions{ResourceVersion: rev0})
+			w, err = c.NetworkPolicies(clientv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher2 := testutils.TestResourceWatch(w)
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
 			outRes3, err := c.NetworkPolicies(namespace2).Update(
-				context.Background(),
+				ctx,
 				&apiv2.NetworkPolicy{
 					ObjectMeta: outRes2.ObjectMeta,
 					Spec:       spec1,
@@ -355,7 +354,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			testWatcher2.Stop()
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.NetworkPolicies(clientv2.AllNamespaces).Watch(context.Background(), options.ListOptions{})
+			w, err = c.NetworkPolicies(clientv2.AllNamespaces).Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher3 := testutils.TestResourceWatch(w)
 			defer testWatcher3.Stop()
@@ -368,7 +367,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			testWatcher3.Stop()
 
 			By("Starting a watcher at rev0 in namespace1 - expect the events for policy in namespace1")
-			w, err = c.NetworkPolicies(namespace1).Watch(context.Background(), options.ListOptions{ResourceVersion: rev0})
+			w, err = c.NetworkPolicies(namespace1).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher4 := testutils.TestResourceWatch(w)
 			defer testWatcher4.Stop()

--- a/lib/clientv2/node.go
+++ b/lib/clientv2/node.go
@@ -40,39 +40,50 @@ type nodes struct {
 // Create takes the representation of a Node and creates it.  Returns the stored
 // representation of the Node, and an error, if there is any.
 func (r nodes) Create(ctx context.Context, res *apiv2.Node, opts options.SetOptions) (*apiv2.Node, error) {
-	panic("Create not implemented for NodeInterface")
-	return nil, nil
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindNode, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.Node), err
+	}
+	return nil, err
 }
 
 // Update takes the representation of a Node and updates it. Returns the stored
 // representation of the Node, and an error, if there is any.
 func (r nodes) Update(ctx context.Context, res *apiv2.Node, opts options.SetOptions) (*apiv2.Node, error) {
-	panic("Update not implemented for NodeInterface")
-	return nil, nil
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindNode, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.Node), err
+	}
+	return nil, err
 }
 
 // Delete takes name of the Node and deletes it. Returns an error if one occurs.
 func (r nodes) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	panic("Delete not implemented for NodeInterface")
-	return nil
+	err := r.client.resources.Delete(ctx, opts, apiv2.KindNode, NoNamespace, name)
+	return err
 }
 
 // Get takes name of the Node, and returns the corresponding Node object,
 // and an error if there is any.
 func (r nodes) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.Node, error) {
-	panic("Get not implemented for NodeInterface")
-	return nil, nil
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindNode, NoNamespace, name)
+	if out != nil {
+		return out.(*apiv2.Node), err
+	}
+	return nil, err
 }
 
 // List returns the list of Node objects that match the supplied options.
 func (r nodes) List(ctx context.Context, opts options.ListOptions) (*apiv2.NodeList, error) {
-	panic("List not implemented for NodeInterface")
-	return nil, nil
+	res := &apiv2.NodeList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindNode, apiv2.KindNodeList, NoNamespace, AllNames, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Watch returns a watch.Interface that watches the Nodes that match the
 // supplied options.
 func (r nodes) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	panic("Watch not implemented for NodeInterface")
-	return nil, nil
+	return r.client.resources.Watch(ctx, opts, apiv2.KindNode, NoNamespace, AllNames)
 }

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -1,0 +1,394 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "node-1"
+	name2 := "node-2"
+	spec1 := apiv2.NodeSpec{
+		BGP: &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4",
+		},
+	}
+	spec2 := apiv2.NodeSpec{
+		BGP: &apiv2.NodeBGPSpec{
+			IPv4Address: "10.20.30.40",
+			IPv6Address: "aa:bb:cc::ff",
+		},
+	}
+
+	DescribeTable("Node e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv2.NodeSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the Node before it is created")
+			res, outError := c.Nodes().Update(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name1 + ")"))
+
+			By("Attempting to creating a new Node with name1/spec1 and a non-empty ResourceVersion")
+			res, outError = c.Nodes().Create(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new Node with name1/spec1")
+			res1, outError := c.Nodes().Create(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same Node with name1 but with spec2")
+			res1, outError = c.Nodes().Create(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: Node(" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting Node (name1) and comparing the output against spec1")
+			res, outError = c.Nodes().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting Node (name2) before it is created")
+			res, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+
+			By("Listing all the Nodes, expecting a single result with name1/spec1")
+			outList, outError := c.Nodes().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+
+			By("Creating a new Node with name2/spec2")
+			res2, outError := c.Nodes().Create(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindNode, clientv2.NoNamespace, name2, spec2)
+
+			By("Getting Node (name2) and comparing the output against spec2")
+			res, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindNode, clientv2.NoNamespace, name2, spec2)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the Nodes, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = c.Nodes().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindNode, clientv2.NoNamespace, name2, spec2)
+
+			By("Updating Node name1 with spec2")
+			res1.Spec = spec2
+			res1, outError = c.Nodes().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindNode, clientv2.NoNamespace, name1, spec2)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating Node name1 without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.Nodes().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating Node name1 using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.Nodes().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: Node(" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting Node (name1) with the original resource version and comparing the output against spec1")
+			res, outError = c.Nodes().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting Node (name1) with the updated resource version and comparing the output against spec2")
+			res, outError = c.Nodes().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindNode, clientv2.NoNamespace, name1, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing Nodes with the original resource version and checking for a single result with name1/spec1")
+			outList, outError = c.Nodes().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindNode, clientv2.NoNamespace, name1, spec1)
+
+			By("Listing Nodes with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = c.Nodes().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindNode, clientv2.NoNamespace, name1, spec2)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindNode, clientv2.NoNamespace, name2, spec2)
+
+			By("Deleting Node (name1) with the old resource version")
+			outError = c.Nodes().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: Node(" + name1 + ")"))
+
+			By("Deleting Node (name1) with the new resource version")
+			outError = c.Nodes().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			By("Updating Node name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.Nodes().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+
+			By("Creating Node name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.Nodes().Create(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+
+			By("Attempting to deleting Node (name2) again")
+			outError = c.Nodes().Delete(ctx, name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+
+			By("Listing all Nodes and expecting no items")
+			outList, outError = c.Nodes().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting Node (name2) and expecting an error")
+			res, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+		},
+
+		// Test 1: Pass two fully populated NodeSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated NodeSpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("Node watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing Nodes with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError := c.Nodes().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a Node name1/spec1 and storing the response")
+			outRes1, err := c.Nodes().Create(
+				ctx,
+				&apiv2.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a Node name2/spec2 and storing the response")
+			outRes2, err := c.Nodes().Create(
+				ctx,
+				&apiv2.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.Nodes().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			err = c.Nodes().Delete(ctx, name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindNode, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.Nodes().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.Nodes().Update(
+				ctx,
+				&apiv2.Node{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindNode, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.Nodes().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindNode, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Configuring Node name1/spec1 again and storing the response")
+			outRes1, err = c.Nodes().Create(
+				ctx,
+				&apiv2.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.Nodes().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindNode, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher4.ExpectEvents(apiv2.KindNode, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})

--- a/lib/clientv2/prefixdeletewatch_e2e_test.go
+++ b/lib/clientv2/prefixdeletewatch_e2e_test.go
@@ -35,6 +35,7 @@ import (
 // Perform CRUD operations on Global and Node-specific BGP Peer Resources.
 var _ = testutils.E2eDatastoreDescribe("Prefix deletion watch test", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
 
+	ctx := context.Background()
 	numEvents := 10000
 
 	Describe("Test prefix deletion of the datastore", func() {
@@ -57,7 +58,7 @@ var _ = testutils.E2eDatastoreDescribe("Prefix deletion watch test", testutils.D
 						ASNumber: numorstring.ASNumber(ii),
 					},
 				}
-				_, outError := c.BGPPeers().Create(context.Background(), peer, options.SetOptions{})
+				_, outError := c.BGPPeers().Create(ctx, peer, options.SetOptions{})
 				Expect(outError).NotTo(HaveOccurred())
 				deleteEvents = append(deleteEvents, watch.Event{
 					Type:     watch.Deleted,
@@ -66,12 +67,12 @@ var _ = testutils.E2eDatastoreDescribe("Prefix deletion watch test", testutils.D
 			}
 
 			By("Listing all the resources")
-			outList, outError := c.BGPPeers().List(context.Background(), options.ListOptions{})
+			outList, outError := c.BGPPeers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(numEvents))
 
 			By("Creating a watcher, watching the current resource version")
-			w, _ := c.BGPPeers().Watch(context.Background(), options.ListOptions{ResourceVersion: outList.ResourceVersion})
+			w, _ := c.BGPPeers().Watch(ctx, options.ListOptions{ResourceVersion: outList.ResourceVersion})
 			testWatcher := testutils.TestResourceWatch(w)
 			defer testWatcher.Stop()
 

--- a/lib/clientv2/profile.go
+++ b/lib/clientv2/profile.go
@@ -40,39 +40,50 @@ type profiles struct {
 // Create takes the representation of a Profile and creates it.  Returns the stored
 // representation of the Profile, and an error, if there is any.
 func (r profiles) Create(ctx context.Context, res *apiv2.Profile, opts options.SetOptions) (*apiv2.Profile, error) {
-	panic("Create not implemented for ProfileInterface")
-	return nil, nil
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindProfile, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.Profile), err
+	}
+	return nil, err
 }
 
 // Update takes the representation of a Profile and updates it. Returns the stored
 // representation of the Profile, and an error, if there is any.
 func (r profiles) Update(ctx context.Context, res *apiv2.Profile, opts options.SetOptions) (*apiv2.Profile, error) {
-	panic("Update not implemented for ProfileInterface")
-	return nil, nil
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindProfile, NoNamespace, res)
+	if out != nil {
+		return out.(*apiv2.Profile), err
+	}
+	return nil, err
 }
 
 // Delete takes name of the Profile and deletes it. Returns an error if one occurs.
 func (r profiles) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	panic("Delete not implemented for ProfileInterface")
-	return nil
+	err := r.client.resources.Delete(ctx, opts, apiv2.KindProfile, NoNamespace, name)
+	return err
 }
 
 // Get takes name of the Profile, and returns the corresponding Profile object,
 // and an error if there is any.
 func (r profiles) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.Profile, error) {
-	panic("Get not implemented for ProfileInterface")
-	return nil, nil
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindProfile, NoNamespace, name)
+	if out != nil {
+		return out.(*apiv2.Profile), err
+	}
+	return nil, err
 }
 
 // List returns the list of Profile objects that match the supplied options.
 func (r profiles) List(ctx context.Context, opts options.ListOptions) (*apiv2.ProfileList, error) {
-	panic("List not implemented for ProfileInterface")
-	return nil, nil
+	res := &apiv2.ProfileList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindProfile, apiv2.KindProfileList, NoNamespace, AllNames, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Watch returns a watch.Interface that watches the Profiles that match the
 // supplied options.
 func (r profiles) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	panic("Watch not implemented for ProfileInterface")
-	return nil, nil
+	return r.client.resources.Watch(ctx, opts, apiv2.KindProfile, NoNamespace, AllNames)
 }

--- a/lib/clientv2/profile_e2e_test.go
+++ b/lib/clientv2/profile_e2e_test.go
@@ -1,0 +1,392 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	name1 := "profile-1"
+	name2 := "profile-2"
+	spec1 := apiv2.ProfileSpec{
+		LabelsToApply: map[string]string {
+			"aa": "bb",
+		},
+	}
+	spec2 := apiv2.ProfileSpec{
+		LabelsToApply: map[string]string {
+			"bb": "cc",
+		},
+	}
+
+	DescribeTable("Profile e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv2.ProfileSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the Profile before it is created")
+			res, outError := c.Profiles().Update(context.Background(), &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name1 + ")"))
+
+			By("Attempting to creating a new Profile with name1/spec1 and a non-empty ResourceVersion")
+			res, outError = c.Profiles().Create(context.Background(), &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new Profile with name1/spec1")
+			res1, outError := c.Profiles().Create(context.Background(), &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same Profile with name1 but with spec2")
+			res1, outError = c.Profiles().Create(context.Background(), &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: Profile(" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting Profile (name1) and comparing the output against spec1")
+			res, outError = c.Profiles().Get(context.Background(), name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting Profile (name2) before it is created")
+			res, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+
+			By("Listing all the Profiles, expecting a single result with name1/spec1")
+			outList, outError := c.Profiles().List(context.Background(), options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+
+			By("Creating a new Profile with name2/spec2")
+			res2, outError := c.Profiles().Create(context.Background(), &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindProfile, clientv2.NoNamespace, name2, spec2)
+
+			By("Getting Profile (name2) and comparing the output against spec2")
+			res, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindProfile, clientv2.NoNamespace, name2, spec2)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the Profiles, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindProfile, clientv2.NoNamespace, name2, spec2)
+
+			By("Updating Profile name1 with spec2")
+			res1.Spec = spec2
+			res1, outError = c.Profiles().Update(context.Background(), res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindProfile, clientv2.NoNamespace, name1, spec2)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating Profile name1 without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.Profiles().Update(context.Background(), res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating Profile name1 using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.Profiles().Update(context.Background(), res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: Profile(" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting Profile (name1) with the original resource version and comparing the output against spec1")
+			res, outError = c.Profiles().Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting Profile (name1) with the updated resource version and comparing the output against spec2")
+			res, outError = c.Profiles().Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindProfile, clientv2.NoNamespace, name1, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing Profiles with the original resource version and checking for a single result with name1/spec1")
+			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, clientv2.NoNamespace, name1, spec1)
+
+			By("Listing Profiles with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, clientv2.NoNamespace, name1, spec2)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindProfile, clientv2.NoNamespace, name2, spec2)
+
+			By("Deleting Profile (name1) with the old resource version")
+			outError = c.Profiles().Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: Profile(" + name1 + ")"))
+
+			By("Deleting Profile (name1) with the new resource version")
+			outError = c.Profiles().Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			By("Updating Profile name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.Profiles().Update(context.Background(), res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+
+			By("Creating Profile name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.Profiles().Create(context.Background(), &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+
+			By("Attempting to deleting Profile (name2) again")
+			outError = c.Profiles().Delete(context.Background(), name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+
+			By("Listing all Profiles and expecting no items")
+			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting Profile (name2) and expecting an error")
+			res, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+		},
+
+		// Test 1: Pass two fully populated ProfileSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated ProfileSpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("Profile watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing Profiles with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError := c.Profiles().List(context.Background(), options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a Profile name1/spec1 and storing the response")
+			outRes1, err := c.Profiles().Create(
+				context.Background(),
+				&apiv2.Profile{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a Profile name2/spec2 and storing the response")
+			outRes2, err := c.Profiles().Create(
+				context.Background(),
+				&apiv2.Profile{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.Profiles().Watch(context.Background(), options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			err = c.Profiles().Delete(context.Background(), name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindProfile, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.Profiles().Watch(context.Background(), options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.Profiles().Update(
+				context.Background(),
+				&apiv2.Profile{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindProfile, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.Profiles().Watch(context.Background(), options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindProfile, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Configuring Profile name1/spec1 again and storing the response")
+			outRes1, err = c.Profiles().Create(
+				context.Background(),
+				&apiv2.Profile{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.Profiles().Watch(context.Background(), options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindProfile, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher4.ExpectEvents(apiv2.KindProfile, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})

--- a/lib/clientv2/workloadendpoint.go
+++ b/lib/clientv2/workloadendpoint.go
@@ -41,39 +41,50 @@ type workloadEndpoints struct {
 // Create takes the representation of a WorkloadEndpoint and creates it.  Returns the stored
 // representation of the WorkloadEndpoint, and an error, if there is any.
 func (r workloadEndpoints) Create(ctx context.Context, res *apiv2.WorkloadEndpoint, opts options.SetOptions) (*apiv2.WorkloadEndpoint, error) {
-	panic("Create not implemented for WorkloadEndpointInterface")
-	return nil, nil
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, res)
+	if out != nil {
+		return out.(*apiv2.WorkloadEndpoint), err
+	}
+	return nil, err
 }
 
 // Update takes the representation of a WorkloadEndpoint and updates it. Returns the stored
 // representation of the WorkloadEndpoint, and an error, if there is any.
 func (r workloadEndpoints) Update(ctx context.Context, res *apiv2.WorkloadEndpoint, opts options.SetOptions) (*apiv2.WorkloadEndpoint, error) {
-	panic("Update not implemented for WorkloadEndpointInterface")
-	return nil, nil
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, res)
+	if out != nil {
+		return out.(*apiv2.WorkloadEndpoint), err
+	}
+	return nil, err
 }
 
 // Delete takes name of the WorkloadEndpoint and deletes it. Returns an error if one occurs.
 func (r workloadEndpoints) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	panic("Delete not implemented for WorkloadEndpointInterface")
-	return nil
+	err := r.client.resources.Delete(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, name)
+	return err
 }
 
 // Get takes name of the WorkloadEndpoint, and returns the corresponding WorkloadEndpoint object,
 // and an error if there is any.
 func (r workloadEndpoints) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.WorkloadEndpoint, error) {
-	panic("Get not implemented for WorkloadEndpointInterface")
-	return nil, nil
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, name)
+	if out != nil {
+		return out.(*apiv2.WorkloadEndpoint), err
+	}
+	return nil, err
 }
 
 // List returns the list of WorkloadEndpoint objects that match the supplied options.
 func (r workloadEndpoints) List(ctx context.Context, opts options.ListOptions) (*apiv2.WorkloadEndpointList, error) {
-	panic("List not implemented for WorkloadEndpointInterface")
-	return nil, nil
+	res := &apiv2.WorkloadEndpointList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindWorkloadEndpoint, apiv2.KindWorkloadEndpointList, r.namespace, AllNames, res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
-// Watch returns a watch.Interface that watches the WorkloadEndpoints that match the
+// Watch returns a watch.Interface that watches the NetworkPolicies that match the
 // supplied options.
 func (r workloadEndpoints) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	panic("Watch not implemented for WorkloadEndpointInterface")
-	return nil, nil
+	return r.client.resources.Watch(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, AllNames)
 }

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -1,0 +1,382 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	namespace1 := "namespace-1"
+	namespace2 := "namespace-2"
+	name1 := "wep-1"
+	name2 := "wep-2"
+	spec1 := apiv2.WorkloadEndpointSpec{
+		Pod: "abcdef",
+		ContainerID: "12345",
+		InterfaceName: "cali09123",
+	}
+	spec2 := apiv2.WorkloadEndpointSpec{
+		Pod: "defgh",
+		ContainerID: "232323",
+		InterfaceName: "cali09122",
+	}
+
+	DescribeTable("WorkloadEndpoint e2e CRUD tests",
+		func(namespace1, namespace2, name1, name2 string, spec1, spec2 apiv2.WorkloadEndpointSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the WorkloadEndpoint before it is created")
+			res, outError := c.WorkloadEndpoints(namespace1).Update(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
+
+			By("Attempting to creating a new WorkloadEndpoint with name1/spec1 and a non-empty ResourceVersion")
+			res, outError = c.WorkloadEndpoints(namespace1).Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new WorkloadEndpoint with namespace1/name1/spec1")
+			res1, outError := c.WorkloadEndpoints(namespace1).Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same WorkloadEndpoint with name1 but with spec2")
+			res1, outError = c.WorkloadEndpoints(namespace1).Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting WorkloadEndpoint (name1) and comparing the output against spec1")
+			res, outError = c.WorkloadEndpoints(namespace1).Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting WorkloadEndpoint (name2) before it is created")
+			res, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+
+			By("Listing all the WorkloadEndpoints in namespace1, expecting a single result with name1/spec1")
+			outList, outError := c.WorkloadEndpoints(namespace1).List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+
+			By("Creating a new WorkloadEndpoint with name2/spec2")
+			res2, outError := c.WorkloadEndpoints(namespace2).Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name2, Namespace: namespace2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
+
+			By("Getting WorkloadEndpoint (name2) and comparing the output against spec2")
+			res, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the WorkloadEndpoints using an empty namespace (all-namespaces), expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = c.WorkloadEndpoints("").List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
+
+			By("Listing all the WorkloadEndpoints in namespace2, expecting a one results with name2/spec2")
+			outList, outError = c.WorkloadEndpoints(namespace2).List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
+
+			By("Updating WorkloadEndpoint name1 with spec2")
+			res1.Spec = spec2
+			res1, outError = c.WorkloadEndpoints(namespace1).Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating BGPPeer name1 without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.WorkloadEndpoints(namespace1).Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating WorkloadEndpoint name1 using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.WorkloadEndpoints(namespace1).Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting WorkloadEndpoint (name1) with the original resource version and comparing the output against spec1")
+			res, outError = c.WorkloadEndpoints(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting WorkloadEndpoint (name1) with the updated resource version and comparing the output against spec2")
+			res, outError = c.WorkloadEndpoints(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing WorkloadEndpoints with the original resource version and checking for a single result with name1/spec1")
+			outList, outError = c.WorkloadEndpoints(namespace1).List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
+
+			By("Listing WorkloadEndpoints (all namespaces) with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = c.WorkloadEndpoints("").List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
+
+			By("Deleting WorkloadEndpoint (name1) with the old resource version")
+			outError = c.WorkloadEndpoints(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
+
+			By("Deleting WorkloadEndpoint (name1) with the new resource version")
+			outError = c.WorkloadEndpoints(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+
+			By("Updating WorkloadEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.WorkloadEndpoints(namespace2).Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+
+			By("Creating WorkloadEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.WorkloadEndpoints(namespace2).Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+
+			By("Attempting to deleting WorkloadEndpoint (name2) again")
+			outError = c.WorkloadEndpoints(namespace2).Delete(ctx, name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+
+			By("Listing all WorkloadEndpoints and expecting no items")
+			outList, outError = c.WorkloadEndpoints("").List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting WorkloadEndpoint (name2) and expecting an error")
+			res, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+		},
+
+		// Test 1: Pass two fully populated PolicySpecs and expect the series of operations to succeed.
+		Entry("Two fully populated PolicySpecs",
+			namespace1, namespace2,
+			name1, name2,
+			spec1, spec2,
+		),
+	)
+
+	Describe("WorkloadEndpoint watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing WorkloadEndpoints with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError := c.WorkloadEndpoints(clientv2.AllNamespaces).List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a WorkloadEndpoint namespace1/name1/spec1 and storing the response")
+			outRes1, err := c.WorkloadEndpoints(namespace1).Create(
+				ctx,
+				&apiv2.WorkloadEndpoint{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a WorkloadEndpoint namespace2/name2/spec2 and storing the response")
+			outRes2, err := c.WorkloadEndpoints(namespace2).Create(
+				ctx,
+				&apiv2.WorkloadEndpoint{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.WorkloadEndpoints(clientv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			err = c.WorkloadEndpoints(namespace1).Delete(ctx, name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindWorkloadEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.WorkloadEndpoints(clientv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.WorkloadEndpoints(namespace2).Update(
+				ctx,
+				&apiv2.WorkloadEndpoint{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindWorkloadEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.WorkloadEndpoints(clientv2.AllNamespaces).Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindWorkloadEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Starting a watcher at rev0 in namespace1 - expect the events for policy in namespace1")
+			w, err = c.WorkloadEndpoints(namespace1).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindWorkloadEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})


### PR DESCRIPTION
This PR builds on PR #527, and should only be reviewed once that PR is merged.

This adds remaining resource types into the v2 client for basic CRUD and Watch support.
