### PR TITLE
IPAM updates for v2 client interface and etcdv3

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -106,7 +106,7 @@ func (c *Client) BGPPeers() BGPPeerInterface {
 
 // IPAM returns an interface for managing IP address assignment and releasing.
 func (c *Client) IPAM() ipam.Interface {
-	return ipam.NewIPAM(c.Backend, poolAccessor{})
+	return ipam.NewIPAMClient(c.Backend, poolAccessor{})
 }
 
 type poolAccessor struct {

--- a/lib/clientv2/client.go
+++ b/lib/clientv2/client.go
@@ -109,7 +109,7 @@ func (c client) BGPPeers() BGPPeerInterface {
 
 // IPAM returns an interface for managing IP address assignment and releasing.
 func (c client) IPAM() ipam.Interface {
-	return ipam.NewIPAM(c.Backend, poolAccessor{})
+	return ipam.NewIPAMClient(c.Backend, poolAccessor{})
 }
 
 type poolAccessor struct {

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -14,7 +14,7 @@
 
 package ipam
 
-import "github.com/projectcalico/libcalico-go/lib/net"
+import cnet "github.com/projectcalico/libcalico-go/lib/net"
 
 // ipam.Interface has methods to perform IP address management.
 type Interface interface {
@@ -28,19 +28,19 @@ type Interface interface {
 	// AutoAssign automatically assigns one or more IP addresses as specified by the
 	// provided AutoAssignArgs.  AutoAssign returns the list of the assigned IPv4 addresses,
 	// and the list of the assigned IPv6 addresses.
-	AutoAssign(args AutoAssignArgs) ([]net.IP, []net.IP, error)
+	AutoAssign(args AutoAssignArgs) ([]cnet.IP, []cnet.IP, error)
 
 	// ReleaseIPs releases any of the given IP addresses that are currently assigned,
 	// so that they are available to be used in another assignment.
-	ReleaseIPs(ips []net.IP) ([]net.IP, error)
+	ReleaseIPs(ips []cnet.IP) ([]cnet.IP, error)
 
 	// GetAssignmentAttributes returns the attributes stored with the given IP address
 	// upon assignment.
-	GetAssignmentAttributes(addr net.IP) (map[string]string, error)
+	GetAssignmentAttributes(addr cnet.IP) (map[string]string, error)
 
-	// IpsByHandle returns a list of all IP addresses that have been
+	// IPsByHandle returns a list of all IP addresses that have been
 	// assigned using the provided handle.
-	IPsByHandle(handleID string) ([]net.IP, error)
+	IPsByHandle(handleID string) ([]cnet.IP, error)
 
 	// ReleaseByHandle releases all IP addresses that have been assigned
 	// using the provided handle.  Returns an error if no addresses
@@ -50,12 +50,12 @@ type Interface interface {
 	// ClaimAffinity claims affinity to the given host for all blocks
 	// within the given CIDR.  The given CIDR must fall within a configured
 	// pool. If an empty string is passed as the host, then the value returned by os.Hostname is used.
-	ClaimAffinity(cidr net.IPNet, host string) ([]net.IPNet, []net.IPNet, error)
+	ClaimAffinity(cidr cnet.IPNet, host string) ([]cnet.IPNet, []cnet.IPNet, error)
 
 	// ReleaseAffinity releases affinity for all blocks within the given CIDR
 	// on the given host.  If an empty string is passed as the host, then the
 	// value returned by os.Hostname will be used.
-	ReleaseAffinity(cidr net.IPNet, host string) error
+	ReleaseAffinity(cidr cnet.IPNet, host string) error
 
 	// ReleaseHostAffinities releases affinity for all blocks that are affine
 	// to the given host.  If an empty string is passed as the host, the value returned by
@@ -64,7 +64,7 @@ type Interface interface {
 
 	// ReleasePoolAffinities releases affinity for all blocks within
 	// the specified pool across all hosts.
-	ReleasePoolAffinities(pool net.IPNet) error
+	ReleasePoolAffinities(pool cnet.IPNet) error
 
 	// GetIPAMConfig returns the global IPAM configuration.  If no IPAM configuration
 	// has been set, returns a default configuration with StrictAffinity disabled

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -80,13 +80,13 @@ func (rw blockReaderWriter) claimNewAffineBlock(host string, version ipVersion, 
 	pools := []cnet.IPNet{}
 
 	// Get all the configured pools.
-	allPools, err := rw.pools.GetEnabledPools(version.Number)
+	enabledPools, err := rw.pools.GetEnabledPools(version.Number)
 	if err != nil {
 		log.Errorf("Error reading configured pools: %s", err)
 		return nil, err
 	}
 
-	for _, p := range allPools {
+	for _, p := range enabledPools {
 		if isPoolInRequestedPools(p, requestedPools) {
 			pools = append(pools, p)
 		}
@@ -94,7 +94,7 @@ func (rw blockReaderWriter) claimNewAffineBlock(host string, version ipVersion, 
 
 	// Build a map so we can lookup existing pools.
 	pm := map[string]bool{}
-	for _, p := range allPools {
+	for _, p := range enabledPools {
 		pm[p.String()] = true
 	}
 
@@ -290,8 +290,8 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR cnet.IPN
 // withinConfiguredPools returns true if the given IP is within a configured
 // Calico pool, and false otherwise.
 func (rw blockReaderWriter) withinConfiguredPools(ip cnet.IP) bool {
-	allPools, _ := rw.pools.GetEnabledPools(ip.Version())
-	for _, p := range allPools {
+	enabledPools, _ := rw.pools.GetEnabledPools(ip.Version())
+	for _, p := range enabledPools {
 		// Compare any enabled pools.
 		if p.Contains(ip.IP) {
 			return true

--- a/lib/ipam/ipam_handle.go
+++ b/lib/ipam/ipam_handle.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/libcalico-go/lib/net"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 type allocationHandle struct {
 	*model.IPAMHandle
 }
 
-func (h allocationHandle) incrementBlock(blockCidr net.IPNet, num int) int {
+func (h allocationHandle) incrementBlock(blockCidr cnet.IPNet, num int) int {
 	blockId := blockCidr.String()
 	newNum := num
 	if val, ok := h.Block[blockId]; ok {
@@ -38,7 +38,7 @@ func (h allocationHandle) incrementBlock(blockCidr net.IPNet, num int) int {
 	return newNum
 }
 
-func (h allocationHandle) decrementBlock(blockCidr net.IPNet, num int) (*int, error) {
+func (h allocationHandle) decrementBlock(blockCidr cnet.IPNet, num int) (*int, error) {
 	blockId := blockCidr.String()
 	if current, ok := h.Block[blockId]; !ok {
 		// This entry doesn't exist.

--- a/lib/ipam/ipam_types.go
+++ b/lib/ipam/ipam_types.go
@@ -15,13 +15,13 @@
 package ipam
 
 import (
-	"github.com/projectcalico/libcalico-go/lib/net"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // AssignIPArgs defines the set of arguments for assigning a specific IP address.
 type AssignIPArgs struct {
 	// The IP address to assign.
-	IP net.IP
+	IP cnet.IP
 
 	// If specified, a handle which can be used to retrieve / release
 	// the allocated IP addresses in the future.
@@ -59,11 +59,11 @@ type AutoAssignArgs struct {
 
 	// If specified, the previously configured IPv4 pools from which
 	// to assign IPv4 addresses.  If not specified, this defaults to all IPv4 pools.
-	IPv4Pools []net.IPNet
+	IPv4Pools []cnet.IPNet
 
 	// If specified, the previously configured IPv6 pools from which
 	// to assign IPv6 addresses.  If not specified, this defaults to all IPv6 pools.
-	IPv6Pools []net.IPNet
+	IPv6Pools []cnet.IPNet
 }
 
 // IPAMConfig contains global configuration options for Calico IPAM.

--- a/lib/ipam/pools.go
+++ b/lib/ipam/pools.go
@@ -13,10 +13,10 @@
 // limitations under the License.
 package ipam
 
-import "github.com/projectcalico/libcalico-go/lib/net"
+import cnet "github.com/projectcalico/libcalico-go/lib/net"
 
 // Interface used to access the enabled IPPools.
 type PoolAccessorInterface interface {
 	// Returns a list of enabled pools sorted in alphanumeric name order.
-	GetEnabledPools(ipVersion int) ([]net.IPNet, error)
+	GetEnabledPools(ipVersion int) ([]cnet.IPNet, error)
 }


### PR DESCRIPTION
@gunjan5   THIS PR MUST BE SQUASHED BEFORE MERGING

If you have time this sprint, do you think you could review the changes I made to the IPAM module for the v2 client.  Could you review these files plus the poolAccessor in the clientv2/client.go file in the current v3.0-integration branch.

So here's the thing.  The code is already checked into the v3.0-integration branch but we shelved reviewing the IPAM code because we expected that we might change the code significantly.  Current thinking is that we now will not - so I would like to get this reviewed and the task closed down (which will allow us to basically complete the CNI integration task).

Now because the code is already checked in and I didn't do a clever git move of the files I couldn't easily work out how to get a sensible PR to review.  So I've done this.  This PR has two commits.  One to back out the changes and the second to put them back in.  Could you just review the SECOND commit.

Most notable changes are:
-  I moved the IPAM into a separate package (it's not clear from the review, but it used to be in the lib/client package)
-  Removed the code which directly accessed the Calico client.  I did this for a couple of reasons:
   -  Moving IPAM into the separate package means you'd end up with circular references since client references IPAM.
   -  I'm still not sure what we need to do about upgrade/backlevel support so I wanted to abstract out the Calico client from the IPAM module.
-  Fixed up the tests since they were performing a lot of setup in a different thread to the actual tests which was causing weird issues for me.  Hopefully these are actually fixed and correct now.
-  Moved the IPAM interface definition from the ipam.go into a separate interface.go file (which seems to be what the cool kids are doing).

On the second point, I removed the direct calls to the Calico client by abstracting out the function that queries the IP Pools.  Hence I added an interface to return the pool CIDRs.