### PR TITLE
backend/k8s: add reflector and subnet labels

### DIFF
--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -80,6 +80,9 @@ type NodeBGPSpec struct {
 	// IPv6Address is the IPv6 address and network of this node.  At least
 	// one of the IPv4 and IPv6 addresses should be specified.
 	IPv6Address *net.IPNet `json:"ipv6Address,omitempty" validate:"omitempty"`
+
+	// Reflector mode: supported values = ["subnet"]
+	Reflector string `json:"reflector,omitempty" validate:"omitempty"`
 }
 
 // NewNode creates a new (zeroed) NodeList struct with the TypeMetadata initialised to the current

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -486,6 +486,15 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
+	if component, err = c.client.Get(model.NodeBGPConfigKey{Nodename: nk.Hostname, Name: "reflector"}); err == nil {
+		strval = component.Value.(string)
+		if strval != "" {
+			nv.BGPReflector = strval
+		}
+	} else if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
+		return err
+	}
+
 	return nil
 }
 
@@ -647,6 +656,14 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 		})
 	}
 
+	optional = append(optional, &model.KVPair{
+		Key: model.NodeBGPConfigKey{
+			Nodename: nk.Hostname,
+			Name:     "reflector",
+		},
+		Value: n.BGPReflector,
+	})
+
 	return primary, optional
 }
 
@@ -691,6 +708,12 @@ func toNodeDeleteComponents(d *model.KVPair) (primary *model.KVPair, optional []
 			Key: model.NodeBGPConfigKey{
 				Nodename: nk.Hostname,
 				Name:     "network_v6",
+			},
+		},
+		&model.KVPair{
+			Key: model.NodeBGPConfigKey{
+				Nodename: nk.Hostname,
+				Name:     "reflector",
 			},
 		},
 	}

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -28,6 +28,8 @@ import (
 const (
 	nodeBgpIpv4CidrAnnotation = "projectcalico.org/IPv4Address"
 	nodeBgpAsnAnnotation      = "projectcalico.org/ASNumber"
+	NodeBgpReflectorLabel     = "projectcalico.org/reflector"
+	NodeBgpIpv4NetworkLabel   = "projectcalico.org/ipv4-network"
 )
 
 func NewNodeClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -48,6 +48,7 @@ type Node struct {
 	BGPIPv4Net  *net.IPNet
 	BGPIPv6Net  *net.IPNet
 	BGPASNumber *numorstring.ASNumber
+	BGPReflector string
 }
 
 type NodeKey struct {

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -177,6 +177,7 @@ func (h *nodes) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 			v.BGPIPv6Net = an.Spec.BGP.IPv6Address.Network()
 		}
 		v.BGPASNumber = an.Spec.BGP.ASNumber
+		v.BGPReflector = an.Spec.BGP.Reflector
 	}
 
 	return &model.KVPair{Key: k, Value: &v}, nil
@@ -224,6 +225,10 @@ func (h *nodes) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error
 				apiNode.Spec.BGP.IPv6Address = bv.BGPIPv6Addr.Network()
 			}
 		}
+	}
+
+	if bv.BGPReflector != "" {
+		apiNode.Spec.BGP.Reflector = bv.BGPReflector
 	}
 
 	return apiNode, nil


### PR DESCRIPTION
## Description
This PR introduces two node labels which are managed by the kubernetes backend.

* `projectcalico.org/ipv4-network=10.10.0.0-24`
ipv4 network for calico host interface. Backed by existing field `model.Node.BGPIPv4Net`

* `projectcalico.org/reflector=<reflector-mode>`

  If present and non-empty, indicates this node should be acting as a route reflector. Backed by new field `model.Node.BGPReflector`

  The value indicates the reflector mode. The library does no validation of the value, leaving that behavior entirely up to the confd templating pipeline consuming the node metadata.

Motivations for exposing this information as labels:
* Easy to query: 
   - nodes in a specific subnet
   - all reflector nodes
   - reflector nodes in a specific subnet

* Can schedule workloads using subnet or reflector as topology key
   - Spread pods across networks
   - co-locate pods on hosts in the same network
   - Don't run this pod on a reflector

## Todos
- [X] Tests
- [ ] `ipv6-network` label
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
