### PR TITLE
Handle the case where namespace is specified in the resource only

### DIFF
--- a/lib/clientv2/resources.go
+++ b/lib/clientv2/resources.go
@@ -264,11 +264,15 @@ func (c *resources) handleNamespace(ns, kind string, in resource) error {
 		// client then use that namespace.
 		// If the namespace is specified in both the resource and the resource-specific client
 		// then check that they are the same.
-		if in.GetObjectMeta().GetNamespace() == "" && ns == "" {
+		resNS := in.GetObjectMeta().GetNamespace()
+		switch {
+		case resNS == "" && ns == "":
 			in.GetObjectMeta().SetNamespace(defaultNamespace)
-		} else if in.GetObjectMeta().GetNamespace() == "" {
+		case resNS == "" && ns != "":
 			in.GetObjectMeta().SetNamespace(ns)
-		} else if in.GetObjectMeta().GetNamespace() != ns {
+		case resNS != "" && ns == "":
+			// Use the namespace specified in the resource, which is already set.
+		case resNS != ns:
 			return cerrors.ErrorValidation{
 				ErroredFields: []cerrors.ErroredField{{
 					Name:   "Metadata.Namespace",


### PR DESCRIPTION

## Description
we weren't handling the case where namespace was defined in the resource but not in the client

Before:
```
go run calicoctl/calicoctl.go  create -f pol2
Failed to create 'NetworkPolicy' resource: error with field Metadata.Namespace = 'yournamespace' (Namespace does not match client namespace)
exit status 1
```

After:
```
go run calicoctl/calicoctl.go  create -f pol2
Successfully created 1 'NetworkPolicy' resource(s)
```

Where `pol2` is:
```yaml
apiVersion: projectcalico.org/v2
kind: NetworkPolicy
metadata:
 name: meep.123
 namespace: yournamespace
spec:
...
...
```

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
