### PR TITLE
Code markups to support client requirements

### DIFF
--- a/lib/apiv2/constants.go
+++ b/lib/apiv2/constants.go
@@ -15,8 +15,16 @@
 package apiv2
 
 const (
+	// API group details for the Calico v2 API.
 	Group               = "projectcalico.org"
 	VersionCurrent      = "v2"
 	GroupVersionCurrent = Group + "/" + VersionCurrent
-	AllNamespaces       = ""
+
+	// AllNamepaces is used for client instantiation, either for when the namespace
+	// will be specified in the resource request, or for List or Watch queries across
+	// all namespaces.
+	AllNamespaces = ""
+
+	// AllNames is used for List or Watch queries to wildcard the name.
+	AllNames = ""
 )

--- a/lib/apiv2/workloadendpoint.go
+++ b/lib/apiv2/workloadendpoint.go
@@ -42,7 +42,9 @@ type WorkloadEndpointSpec struct {
 	// The container ID.
 	ContainerID string `json:"containerID,omitempty" validate:"omitempty,name"`
 	// The Pod name.
-	Pod string `json:"podID,omitempty" validate:"omitempty,name"`
+	Pod string `json:"pod,omitempty" validate:"omitempty,name"`
+	// The Endpoint name.
+	Endpoint string `json:"endpoint,omitempty" validate:"omitempty,name"`
 	// IPNetworks is a list of subnets allocated to this endpoint. IP packets will only be
 	// allowed to leave this interface if they come from an address in one of these subnets.
 	// Currently only /32 for IPv4 and /128 for IPv6 networks are supported.

--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -85,7 +85,7 @@ type Client interface {
 	// also be removed when deleting the objects that implicitly created it.
 	// For example, deleting the last WorkloadEndpoint in a Workload will
 	// also remove the Workload.
-	Delete(ctx context.Context, key model.Key, revision string) error
+	Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error)
 
 	// Get returns the object identified by the given key as a KVPair with
 	// revision information.

--- a/lib/backend/etcdv3/conversion.go
+++ b/lib/backend/etcdv3/conversion.go
@@ -29,7 +29,7 @@ import (
 // If the etcdv3 key or value does not represent the resource specified by the ListInterface,
 // or if value cannot be parsed, this method returns nil.
 func convertListResponse(ekv *mvccpb.KeyValue, l model.ListInterface) *model.KVPair {
-	log.WithField("etcdv3-etcdKey", ekv.Key).Debug("Processing etcdv3 entry")
+	log.WithField("etcdv3-etcdKey", string(ekv.Key)).Debug("Processing etcdv3 entry")
 	if k := l.KeyFromDefaultPath(string(ekv.Key)); k != nil {
 		log.WithField("model-etcdKey", k).Debug("Key is valid and converted to model-etcdKey")
 		if v, err := model.ParseValue(k, ekv.Value); err == nil {

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -117,14 +118,7 @@ func (c *etcdV3Client) Create(ctx context.Context, d *model.KVPair) (*model.KVPa
 		var existing *model.KVPair
 		getResp := (*clientv3.GetResponse)(txnResp.Responses[0].GetResponseRange())
 		if len(getResp.Kvs) != 0 {
-			if v, err := model.ParseValue(d.Key, getResp.Kvs[0].Value); err == nil {
-				logCxt.Debug("Parsed existing entry to return in response")
-				existing = &model.KVPair{
-					Key:      d.Key,
-					Value:    v,
-					Revision: strconv.FormatInt(getResp.Kvs[0].ModRevision, 10),
-				}
-			}
+			existing, _ = etcdToKVPair(d.Key, getResp.Kvs[0])
 		}
 		return existing, cerrors.ErrorResourceAlreadyExists{Identifier: d.Key}
 	}
@@ -152,9 +146,8 @@ func (c *etcdV3Client) Update(ctx context.Context, d *model.KVPair) (*model.KVPa
 	}
 
 	// ResourceVersion must be set for an Update.
-	rev, err := strconv.ParseInt(d.Revision, 10, 64)
+	rev, err := parseRevision(d.Revision)
 	if err != nil {
-		logCxt.Info("Unable to parse Revision")
 		return nil, err
 	}
 	conds := []clientv3.Cmp{clientv3.Compare(clientv3.ModRevision(key), "=", rev)}
@@ -184,15 +177,7 @@ func (c *etcdV3Client) Update(ctx context.Context, d *model.KVPair) (*model.KVPa
 		}
 
 		logCxt.Info("Update transaction failed due to resource update conflict")
-		var existing *model.KVPair
-		if v, err := model.ParseValue(d.Key, getResp.Kvs[0].Value); err == nil {
-			logCxt.Debug("Parsed current entry to return in response")
-			existing = &model.KVPair{
-				Key:      d.Key,
-				Value:    v,
-				Revision: strconv.FormatInt(getResp.Kvs[0].ModRevision, 10),
-			}
-		}
+		existing, _ := etcdToKVPair(d.Key, getResp.Kvs[0])
 		return existing, cerrors.ErrorResourceUpdateConflict{Identifier: d.Key}
 	}
 
@@ -227,21 +212,20 @@ func (c *etcdV3Client) Apply(d *model.KVPair) (*model.KVPair, error) {
 }
 
 // Delete an entry in the datastore.  This errors if the entry does not exists.
-func (c *etcdV3Client) Delete(ctx context.Context, k model.Key, revision string) error {
+func (c *etcdV3Client) Delete(ctx context.Context, k model.Key, revision string) (*model.KVPair, error) {
 	logCxt := log.WithFields(log.Fields{"model-etcdKey": k, "rev": revision})
 	logCxt.Debug("Processing Delete request")
 	key, err := model.KeyToDefaultDeletePath(k)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	logCxt = logCxt.WithField("etcdv3-etcdKey", key)
 
 	conds := []clientv3.Cmp{}
 	if len(revision) != 0 {
-		rev, err := strconv.ParseInt(revision, 10, 64)
+		rev, err := parseRevision(revision)
 		if err != nil {
-			logCxt.Info("Unable to parse Revision")
-			return err
+			return nil, err
 		}
 		conds = append(conds, clientv3.Compare(clientv3.ModRevision(key), "=", rev))
 	}
@@ -251,25 +235,43 @@ func (c *etcdV3Client) Delete(ctx context.Context, k model.Key, revision string)
 	txnResp, err := c.etcdClient.Txn(ctx).If(
 		conds...,
 	).Then(
-		clientv3.OpDelete(key),
+		clientv3.OpDelete(key, clientv3.WithPrevKV()),
+	).Else(
+		clientv3.OpGet(key),
 	).Commit()
 	if err != nil {
 		logCxt.WithError(err).Warning("Delete failed")
-		return cerrors.ErrorDatastoreError{Err: err, Identifier: k}
+		return nil, cerrors.ErrorDatastoreError{Err: err, Identifier: k}
 	}
 
+	// Transaction did not succeed - which means the ModifiedIndex check failed.  We can respond
+	// with the latest settings.
 	if !txnResp.Succeeded {
 		logCxt.Info("Delete transaction failed due to resource update conflict")
-		return cerrors.ErrorResourceUpdateConflict{Identifier: k}
+
+		getResp := txnResp.Responses[0].GetResponseRange()
+		if len(getResp.Kvs) == 0 {
+			logCxt.Info("Delete transaction failed due resource not existing")
+			return nil, cerrors.ErrorResourceDoesNotExist{Identifier: k}
+		}
+		latestValue, err := etcdToKVPair(k, getResp.Kvs[0])
+		if err != nil {
+			return nil, err
+		}
+		return latestValue, cerrors.ErrorResourceUpdateConflict{Identifier: k}
 	}
 
+	// The delete response should have succeeded since the Get response did.
 	delResp := txnResp.Responses[0].GetResponseDeleteRange()
 	if delResp.Deleted == 0 {
 		logCxt.Info("Delete transaction failed due resource not existing")
-		return cerrors.ErrorResourceDoesNotExist{Identifier: k}
+		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: k}
 	}
 
-	return nil
+	// Parse the deleted value.  Don't propagate the error in this case since the
+	// delete did succeed.
+	previousValue, _ := etcdToKVPair(k, delResp.PrevKvs[0])
+	return previousValue, nil
 }
 
 // Get an entry from the datastore.  This errors if the entry does not exist.
@@ -286,9 +288,8 @@ func (c *etcdV3Client) Get(ctx context.Context, k model.Key, revision string) (*
 
 	ops := []clientv3.OpOption{}
 	if len(revision) != 0 {
-		rev, err := strconv.ParseInt(revision, 10, 64)
+		rev, err := parseRevision(revision)
 		if err != nil {
-			logCxt.Error("Unable to parse Revision")
 			return nil, err
 		}
 		ops = append(ops, clientv3.WithRev(rev))
@@ -305,18 +306,7 @@ func (c *etcdV3Client) Get(ctx context.Context, k model.Key, revision string) (*
 		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: k}
 	}
 
-	kv := resp.Kvs[0]
-	v, err := model.ParseValue(k, kv.Value)
-	if err != nil {
-		logCxt.WithField("Value", string(kv.Value)).Error("Unable to parse Value")
-		return nil, err
-	}
-
-	return &model.KVPair{
-		Key:      k,
-		Value:    v,
-		Revision: strconv.FormatInt(kv.ModRevision, 10),
-	}, nil
+	return etcdToKVPair(k, resp.Kvs[0])
 }
 
 // List entries in the datastore.  This may return an empty list of there are
@@ -346,9 +336,8 @@ func (c *etcdV3Client) List(ctx context.Context, l model.ListInterface, revision
 
 	// We may also need to perform a get based on a particular revision.
 	if len(revision) != 0 {
-		rev, err := strconv.ParseInt(revision, 10, 64)
+		rev, err := parseRevision(revision)
 		if err != nil {
-			logCxt.Error("Unable to parse Revision")
 			return nil, err
 		}
 		ops = append(ops, clientv3.WithRev(rev))
@@ -385,6 +374,7 @@ func (c *etcdV3Client) EnsureInitialized() error {
 		Value: true,
 	}
 
+	//TODO - still need to worry about ready flag.
 	if _, err := c.Create(context.Background(), kv); err != nil {
 		if _, ok := err.(cerrors.ErrorResourceAlreadyExists); !ok {
 			log.WithError(err).Warn("Failed to set ready flag")
@@ -438,13 +428,54 @@ func getKeyValueStrings(d *model.KVPair) (string, string, error) {
 	key, err := model.KeyToDefaultPath(d.Key)
 	if err != nil {
 		logCxt.WithError(err).Error("Failed to convert model-etcdKey to etcdv3 etcdKey")
-		return "", "", err
+		return "", "", cerrors.ErrorDatastoreError{
+			Err:        err,
+			Identifier: d.Key,
+		}
 	}
 	bytes, err := model.SerializeValue(d)
 	if err != nil {
 		logCxt.WithError(err).Error("Failed to serialize value")
-		return "", "", err
+		return "", "", cerrors.ErrorDatastoreError{
+			Err:        err,
+			Identifier: d.Key,
+		}
 	}
 
 	return key, string(bytes), nil
+}
+
+// etcdToKVPair converts an etcd KeyValue in to model.KVPair.
+func etcdToKVPair(key model.Key, ekv *mvccpb.KeyValue) (*model.KVPair, error) {
+	v, err := model.ParseValue(key, ekv.Value)
+	if err != nil {
+		return nil, cerrors.ErrorDatastoreError{
+			Identifier: key,
+			Err:        err,
+		}
+	}
+
+	return &model.KVPair{
+		Key:      key,
+		Value:    v,
+		Revision: strconv.FormatInt(ekv.ModRevision, 10),
+	}, nil
+}
+
+// parseRevision parses the model.KVPair revision string and converts to the
+// equivalent etcdv3 int64 value.
+func parseRevision(revs string) (int64, error) {
+	rev, err := strconv.ParseInt(revs, 10, 64)
+	if err != nil {
+		log.WithField("Revision", revs).Info("Unable to parse Revision")
+		return 0, cerrors.ErrorValidation{
+			ErroredFields: []cerrors.ErroredField{
+				{
+					Name:  "ResourceVersion",
+					Value: revs,
+				},
+			},
+		}
+	}
+	return rev, nil
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -323,7 +323,7 @@ func (c *Client) delete(metadata unversioned.ResourceMetadata, helper conversion
 	// operations fills in the revision information.
 	if k, err := helper.convertMetadataToKey(metadata); err != nil {
 		return err
-	} else if err := c.Backend.Delete(context.Background(), k, metadata.GetObjectMetadata().Revision); err != nil {
+	} else if _, err := c.Backend.Delete(context.Background(), k, metadata.GetObjectMetadata().Revision); err != nil {
 		return err
 	} else {
 		return nil

--- a/lib/client/config.go
+++ b/lib/client/config.go
@@ -376,7 +376,7 @@ func (c *config) setLogLevel(level string, felixKey, bgpKey model.Key) error {
 
 // deleteConfig deletes a resource and ignores deleted errors.
 func (c *config) deleteConfig(key model.Key) error {
-	err := c.c.Backend.Delete(context.Background(), key, "")
+	_, err := c.c.Backend.Delete(context.Background(), key, "")
 	if err != nil {
 		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
 			return err

--- a/lib/clientv2/bgppeer.go
+++ b/lib/clientv2/bgppeer.go
@@ -26,7 +26,7 @@ import (
 type BGPPeerInterface interface {
 	Create(ctx context.Context, res *apiv2.BGPPeer, opts options.SetOptions) (*apiv2.BGPPeer, error)
 	Update(ctx context.Context, res *apiv2.BGPPeer, opts options.SetOptions) (*apiv2.BGPPeer, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.BGPPeer, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.BGPPeer, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.BGPPeerList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
@@ -40,7 +40,7 @@ type bgpPeers struct {
 // Create takes the representation of a BGPPeer and creates it.  Returns the stored
 // representation of the BGPPeer, and an error, if there is any.
 func (r bgpPeers) Create(ctx context.Context, res *apiv2.BGPPeer, opts options.SetOptions) (*apiv2.BGPPeer, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindBGPPeer, noNamespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindBGPPeer, res)
 	if out != nil {
 		return out.(*apiv2.BGPPeer), err
 	}
@@ -50,7 +50,7 @@ func (r bgpPeers) Create(ctx context.Context, res *apiv2.BGPPeer, opts options.S
 // Update takes the representation of a BGPPeer and updates it. Returns the stored
 // representation of the BGPPeer, and an error, if there is any.
 func (r bgpPeers) Update(ctx context.Context, res *apiv2.BGPPeer, opts options.SetOptions) (*apiv2.BGPPeer, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindBGPPeer, noNamespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindBGPPeer, res)
 	if out != nil {
 		return out.(*apiv2.BGPPeer), err
 	}
@@ -58,9 +58,12 @@ func (r bgpPeers) Update(ctx context.Context, res *apiv2.BGPPeer, opts options.S
 }
 
 // Delete takes name of the BGPPeer and deletes it. Returns an error if one occurs.
-func (r bgpPeers) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindBGPPeer, noNamespace, name)
-	return err
+func (r bgpPeers) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.BGPPeer, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindBGPPeer, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.BGPPeer), err
+	}
+	return nil, err
 }
 
 // Get takes name of the BGPPeer, and returns the corresponding BGPPeer object,
@@ -76,7 +79,7 @@ func (r bgpPeers) Get(ctx context.Context, name string, opts options.GetOptions)
 // List returns the list of BGPPeer objects that match the supplied options.
 func (r bgpPeers) List(ctx context.Context, opts options.ListOptions) (*apiv2.BGPPeerList, error) {
 	res := &apiv2.BGPPeerList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindBGPPeer, apiv2.KindBGPPeerList, noNamespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindBGPPeer, apiv2.KindBGPPeerList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -85,5 +88,5 @@ func (r bgpPeers) List(ctx context.Context, opts options.ListOptions) (*apiv2.BG
 // Watch returns a watch.Interface that watches the BGPPeers that match the
 // supplied options.
 func (r bgpPeers) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindBGPPeer, noNamespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindBGPPeer)
 }

--- a/lib/clientv2/bgppeer_e2e_test.go
+++ b/lib/clientv2/bgppeer_e2e_test.go
@@ -188,13 +188,14 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindBGPPeer, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Deleting BGPPeer (name1) with the old resource version")
-			outError = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: BGPPeer(" + name1 + ")"))
 
 			By("Deleting BGPPeer (name1) with the new resource version")
-			outError = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindBGPPeer, testutils.ExpectNoNamespace, name1, spec2)
 
 			By("Updating BGPPeer name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.BGPPeers().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
@@ -222,7 +223,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 
 			By("Attempting to deleting BGPPeer (name2) again")
-			outError = c.BGPPeers().Delete(ctx, name2, options.DeleteOptions{})
+			_, outError = c.BGPPeers().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
 
@@ -284,7 +285,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{})
+			_, err = c.BGPPeers().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -336,6 +337,23 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 				},
 			})
 			testWatcher2.Stop()
+
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.BGPPeers().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindBGPPeer, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.BGPPeers().Watch(ctx, options.ListOptions{})

--- a/lib/clientv2/client.go
+++ b/lib/clientv2/client.go
@@ -73,8 +73,8 @@ func (c client) Nodes() NodeInterface {
 }
 
 // Policies returns an interface for managing policy resources.
-func (c client) NetworkPolicies(namespace string) NetworkPolicyInterface {
-	return networkPolicies{client: c, namespace: namespace}
+func (c client) NetworkPolicies() NetworkPolicyInterface {
+	return networkPolicies{client: c}
 }
 
 // Policies returns an interface for managing policy resources.
@@ -98,8 +98,8 @@ func (c client) HostEndpoints() HostEndpointInterface {
 }
 
 // WorkloadEndpoints returns an interface for managing workload endpoint resources.
-func (c client) WorkloadEndpoints(namespace string) WorkloadEndpointInterface {
-	return workloadEndpoints{client: c, namespace: namespace}
+func (c client) WorkloadEndpoints() WorkloadEndpointInterface {
+	return workloadEndpoints{client: c}
 }
 
 // BGPPeers returns an interface for managing BGP peer resources.

--- a/lib/clientv2/globalnetworkpolicy.go
+++ b/lib/clientv2/globalnetworkpolicy.go
@@ -26,7 +26,7 @@ import (
 type GlobalNetworkPolicyInterface interface {
 	Create(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error)
 	Update(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.GlobalNetworkPolicy, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.GlobalNetworkPolicy, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.GlobalNetworkPolicyList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
@@ -40,7 +40,7 @@ type globalnetworkpolicies struct {
 // Create takes the representation of a GlobalNetworkPolicy and creates it.  Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
 func (r globalnetworkpolicies) Create(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindGlobalNetworkPolicy, noNamespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindGlobalNetworkPolicy, res)
 	if out != nil {
 		return out.(*apiv2.GlobalNetworkPolicy), err
 	}
@@ -50,7 +50,7 @@ func (r globalnetworkpolicies) Create(ctx context.Context, res *apiv2.GlobalNetw
 // Update takes the representation of a GlobalNetworkPolicy and updates it. Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
 func (r globalnetworkpolicies) Update(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindGlobalNetworkPolicy, noNamespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindGlobalNetworkPolicy, res)
 	if out != nil {
 		return out.(*apiv2.GlobalNetworkPolicy), err
 	}
@@ -58,9 +58,12 @@ func (r globalnetworkpolicies) Update(ctx context.Context, res *apiv2.GlobalNetw
 }
 
 // Delete takes name of the GlobalNetworkPolicy and deletes it. Returns an error if one occurs.
-func (r globalnetworkpolicies) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindGlobalNetworkPolicy, noNamespace, name)
-	return err
+func (r globalnetworkpolicies) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.GlobalNetworkPolicy, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindGlobalNetworkPolicy, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.GlobalNetworkPolicy), err
+	}
+	return nil, err
 }
 
 // Get takes name of the GlobalNetworkPolicy, and returns the corresponding GlobalNetworkPolicy object,
@@ -76,7 +79,7 @@ func (r globalnetworkpolicies) Get(ctx context.Context, name string, opts option
 // List returns the list of GlobalNetworkPolicy objects that match the supplied options.
 func (r globalnetworkpolicies) List(ctx context.Context, opts options.ListOptions) (*apiv2.GlobalNetworkPolicyList, error) {
 	res := &apiv2.GlobalNetworkPolicyList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindGlobalNetworkPolicy, apiv2.KindGlobalNetworkPolicyList, noNamespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindGlobalNetworkPolicy, apiv2.KindGlobalNetworkPolicyList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -85,5 +88,5 @@ func (r globalnetworkpolicies) List(ctx context.Context, opts options.ListOption
 // Watch returns a watch.Interface that watches the globalnetworkpolicies that match the
 // supplied options.
 func (r globalnetworkpolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindGlobalNetworkPolicy, noNamespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindGlobalNetworkPolicy)
 }

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -192,13 +192,14 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindGlobalNetworkPolicy, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Deleting GlobalNetworkPolicy (name1) with the old resource version")
-			outError = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(" + name1 + ")"))
 
 			By("Deleting GlobalNetworkPolicy (name1) with the new resource version")
-			outError = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindGlobalNetworkPolicy, testutils.ExpectNoNamespace, name1, spec2)
 
 			By("Updating GlobalNetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.GlobalNetworkPolicies().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
@@ -226,7 +227,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
 
 			By("Attempting to deleting GlobalNetworkPolicy (name2) again")
-			outError = c.GlobalNetworkPolicies().Delete(ctx, name2, options.DeleteOptions{})
+			_, outError = c.GlobalNetworkPolicies().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
 
@@ -288,7 +289,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{})
+			_, err = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -340,6 +341,23 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				},
 			})
 			testWatcher2.Stop()
+
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{})

--- a/lib/clientv2/hostendpoint.go
+++ b/lib/clientv2/hostendpoint.go
@@ -26,7 +26,7 @@ import (
 type HostEndpointInterface interface {
 	Create(ctx context.Context, res *apiv2.HostEndpoint, opts options.SetOptions) (*apiv2.HostEndpoint, error)
 	Update(ctx context.Context, res *apiv2.HostEndpoint, opts options.SetOptions) (*apiv2.HostEndpoint, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.HostEndpoint, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.HostEndpoint, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.HostEndpointList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
@@ -40,7 +40,7 @@ type hostEndpoints struct {
 // Create takes the representation of a HostEndpoint and creates it.  Returns the stored
 // representation of the HostEndpoint, and an error, if there is any.
 func (r hostEndpoints) Create(ctx context.Context, res *apiv2.HostEndpoint, opts options.SetOptions) (*apiv2.HostEndpoint, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindHostEndpoint, noNamespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindHostEndpoint, res)
 	if out != nil {
 		return out.(*apiv2.HostEndpoint), err
 	}
@@ -50,7 +50,7 @@ func (r hostEndpoints) Create(ctx context.Context, res *apiv2.HostEndpoint, opts
 // Update takes the representation of a HostEndpoint and updates it. Returns the stored
 // representation of the HostEndpoint, and an error, if there is any.
 func (r hostEndpoints) Update(ctx context.Context, res *apiv2.HostEndpoint, opts options.SetOptions) (*apiv2.HostEndpoint, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindHostEndpoint, noNamespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindHostEndpoint, res)
 	if out != nil {
 		return out.(*apiv2.HostEndpoint), err
 	}
@@ -58,9 +58,12 @@ func (r hostEndpoints) Update(ctx context.Context, res *apiv2.HostEndpoint, opts
 }
 
 // Delete takes name of the HostEndpoint and deletes it. Returns an error if one occurs.
-func (r hostEndpoints) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindHostEndpoint, noNamespace, name)
-	return err
+func (r hostEndpoints) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.HostEndpoint, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindHostEndpoint, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.HostEndpoint), err
+	}
+	return nil, err
 }
 
 // Get takes name of the HostEndpoint, and returns the corresponding HostEndpoint object,
@@ -76,7 +79,7 @@ func (r hostEndpoints) Get(ctx context.Context, name string, opts options.GetOpt
 // List returns the list of HostEndpoint objects that match the supplied options.
 func (r hostEndpoints) List(ctx context.Context, opts options.ListOptions) (*apiv2.HostEndpointList, error) {
 	res := &apiv2.HostEndpointList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindHostEndpoint, apiv2.KindHostEndpointList, noNamespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindHostEndpoint, apiv2.KindHostEndpointList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -85,5 +88,5 @@ func (r hostEndpoints) List(ctx context.Context, opts options.ListOptions) (*api
 // Watch returns a watch.Interface that watches the HostEndpoints that match the
 // supplied options.
 func (r hostEndpoints) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindHostEndpoint, noNamespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindHostEndpoint)
 }

--- a/lib/clientv2/hostendpoint_e2e_test.go
+++ b/lib/clientv2/hostendpoint_e2e_test.go
@@ -185,13 +185,14 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindHostEndpoint, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Deleting HostEndpoint (name1) with the old resource version")
-			outError = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: HostEndpoint(" + name1 + ")"))
 
 			By("Deleting HostEndpoint (name1) with the new resource version")
-			outError = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindHostEndpoint, testutils.ExpectNoNamespace, name1, spec2)
 
 			By("Updating HostEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.HostEndpoints().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
@@ -219,7 +220,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
 
 			By("Attempting to deleting HostEndpoint (name2) again")
-			outError = c.HostEndpoints().Delete(ctx, name2, options.DeleteOptions{})
+			_, outError = c.HostEndpoints().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
 
@@ -281,7 +282,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{})
+			_, err = c.HostEndpoints().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -333,6 +334,23 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 				},
 			})
 			testWatcher2.Stop()
+
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.HostEndpoints().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindHostEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.HostEndpoints().Watch(ctx, options.ListOptions{})

--- a/lib/clientv2/interface.go
+++ b/lib/clientv2/interface.go
@@ -22,7 +22,7 @@ type Interface interface {
 	// GlobalNetworkPolicies returns an interface for managing global network policy resources.
 	GlobalNetworkPolicies() GlobalNetworkPolicyInterface
 	// NetworkPolicies returns an interface for managing namespaced network policy resources.
-	NetworkPolicies(string) NetworkPolicyInterface
+	NetworkPolicies() NetworkPolicyInterface
 	// IPPools returns an interface for managing IP pool resources.
 	IPPools() IPPoolInterface
 	// Profiles returns an interface for managing profile resources.
@@ -30,7 +30,7 @@ type Interface interface {
 	// HostEndpoints returns an interface for managing host endpoint resources.
 	HostEndpoints() HostEndpointInterface
 	// WorkloadEndpoints returns an interface for managing workload endpoint resources.
-	WorkloadEndpoints(string) WorkloadEndpointInterface
+	WorkloadEndpoints() WorkloadEndpointInterface
 	// BGPPeers returns an interface for managing BGP peer resources.
 	BGPPeers() BGPPeerInterface
 	// IPAM returns an interface for managing IP address assignment and releasing.

--- a/lib/clientv2/ippool.go
+++ b/lib/clientv2/ippool.go
@@ -26,7 +26,7 @@ import (
 type IPPoolInterface interface {
 	Create(ctx context.Context, res *apiv2.IPPool, opts options.SetOptions) (*apiv2.IPPool, error)
 	Update(ctx context.Context, res *apiv2.IPPool, opts options.SetOptions) (*apiv2.IPPool, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.IPPool, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.IPPool, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.IPPoolList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
@@ -40,7 +40,7 @@ type ipPools struct {
 // Create takes the representation of a IPPool and creates it.  Returns the stored
 // representation of the IPPool, and an error, if there is any.
 func (r ipPools) Create(ctx context.Context, res *apiv2.IPPool, opts options.SetOptions) (*apiv2.IPPool, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindIPPool, noNamespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindIPPool, res)
 	if out != nil {
 		return out.(*apiv2.IPPool), err
 	}
@@ -50,7 +50,7 @@ func (r ipPools) Create(ctx context.Context, res *apiv2.IPPool, opts options.Set
 // Update takes the representation of a IPPool and updates it. Returns the stored
 // representation of the IPPool, and an error, if there is any.
 func (r ipPools) Update(ctx context.Context, res *apiv2.IPPool, opts options.SetOptions) (*apiv2.IPPool, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindIPPool, noNamespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindIPPool, res)
 	if out != nil {
 		return out.(*apiv2.IPPool), err
 	}
@@ -58,9 +58,12 @@ func (r ipPools) Update(ctx context.Context, res *apiv2.IPPool, opts options.Set
 }
 
 // Delete takes name of the IPPool and deletes it. Returns an error if one occurs.
-func (r ipPools) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindIPPool, noNamespace, name)
-	return err
+func (r ipPools) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.IPPool, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindIPPool, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.IPPool), err
+	}
+	return nil, err
 }
 
 // Get takes name of the IPPool, and returns the corresponding IPPool object,
@@ -76,7 +79,7 @@ func (r ipPools) Get(ctx context.Context, name string, opts options.GetOptions) 
 // List returns the list of IPPool objects that match the supplied options.
 func (r ipPools) List(ctx context.Context, opts options.ListOptions) (*apiv2.IPPoolList, error) {
 	res := &apiv2.IPPoolList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindIPPool, apiv2.KindIPPoolList, noNamespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindIPPool, apiv2.KindIPPoolList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -85,5 +88,5 @@ func (r ipPools) List(ctx context.Context, opts options.ListOptions) (*apiv2.IPP
 // Watch returns a watch.Interface that watches the IPPools that match the
 // supplied options.
 func (r ipPools) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindIPPool, noNamespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindIPPool)
 }

--- a/lib/clientv2/networkpolicy.go
+++ b/lib/clientv2/networkpolicy.go
@@ -26,22 +26,21 @@ import (
 type NetworkPolicyInterface interface {
 	Create(ctx context.Context, res *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error)
 	Update(ctx context.Context, res *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
-	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.NetworkPolicy, error)
+	Delete(ctx context.Context, namespace, name string, opts options.DeleteOptions) (*apiv2.NetworkPolicy, error)
+	Get(ctx context.Context, namespace, name string, opts options.GetOptions) (*apiv2.NetworkPolicy, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.NetworkPolicyList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
 }
 
 // networkPolicies implements NetworkPolicyInterface
 type networkPolicies struct {
-	client    client
-	namespace string
+	client client
 }
 
 // Create takes the representation of a NetworkPolicy and creates it.  Returns the stored
 // representation of the NetworkPolicy, and an error, if there is any.
 func (r networkPolicies) Create(ctx context.Context, res *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindNetworkPolicy, r.namespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindNetworkPolicy, res)
 	if out != nil {
 		return out.(*apiv2.NetworkPolicy), err
 	}
@@ -51,7 +50,7 @@ func (r networkPolicies) Create(ctx context.Context, res *apiv2.NetworkPolicy, o
 // Update takes the representation of a NetworkPolicy and updates it. Returns the stored
 // representation of the NetworkPolicy, and an error, if there is any.
 func (r networkPolicies) Update(ctx context.Context, res *apiv2.NetworkPolicy, opts options.SetOptions) (*apiv2.NetworkPolicy, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindNetworkPolicy, r.namespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindNetworkPolicy, res)
 	if out != nil {
 		return out.(*apiv2.NetworkPolicy), err
 	}
@@ -59,15 +58,18 @@ func (r networkPolicies) Update(ctx context.Context, res *apiv2.NetworkPolicy, o
 }
 
 // Delete takes name of the NetworkPolicy and deletes it. Returns an error if one occurs.
-func (r networkPolicies) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindNetworkPolicy, r.namespace, name)
-	return err
+func (r networkPolicies) Delete(ctx context.Context, namespace, name string, opts options.DeleteOptions) (*apiv2.NetworkPolicy, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindNetworkPolicy, namespace, name)
+	if out != nil {
+		return out.(*apiv2.NetworkPolicy), err
+	}
+	return nil, err
 }
 
 // Get takes name of the NetworkPolicy, and returns the corresponding NetworkPolicy object,
 // and an error if there is any.
-func (r networkPolicies) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.NetworkPolicy, error) {
-	out, err := r.client.resources.Get(ctx, opts, apiv2.KindNetworkPolicy, r.namespace, name)
+func (r networkPolicies) Get(ctx context.Context, namespace, name string, opts options.GetOptions) (*apiv2.NetworkPolicy, error) {
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindNetworkPolicy, namespace, name)
 	if out != nil {
 		return out.(*apiv2.NetworkPolicy), err
 	}
@@ -77,7 +79,7 @@ func (r networkPolicies) Get(ctx context.Context, name string, opts options.GetO
 // List returns the list of NetworkPolicy objects that match the supplied options.
 func (r networkPolicies) List(ctx context.Context, opts options.ListOptions) (*apiv2.NetworkPolicyList, error) {
 	res := &apiv2.NetworkPolicyList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindNetworkPolicy, apiv2.KindNetworkPolicyList, r.namespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindNetworkPolicy, apiv2.KindNetworkPolicyList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -86,5 +88,5 @@ func (r networkPolicies) List(ctx context.Context, opts options.ListOptions) (*a
 // Watch returns a watch.Interface that watches the NetworkPolicies that match the
 // supplied options.
 func (r networkPolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindNetworkPolicy, r.namespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindNetworkPolicy)
 }

--- a/lib/clientv2/networkpolicy_e2e_test.go
+++ b/lib/clientv2/networkpolicy_e2e_test.go
@@ -66,8 +66,8 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			be.Clean()
 
 			By("Updating the NetworkPolicy before it is created")
-			res, outError := c.NetworkPolicies(namespace1).Update(ctx, &apiv2.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+			res, outError := c.NetworkPolicies().Update(ctx, &apiv2.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -75,7 +75,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace1 + "/" + name1 + ")"))
 
 			By("Attempting to creating a new NetworkPolicy with name1/spec1 and a non-empty ResourceVersion")
-			res, outError = c.NetworkPolicies(namespace1).Create(ctx, &apiv2.NetworkPolicy{
+			res, outError = c.NetworkPolicies().Create(ctx, &apiv2.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -84,8 +84,8 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
 			By("Creating a new NetworkPolicy with namespace1/name1/spec1")
-			res1, outError := c.NetworkPolicies(namespace1).Create(ctx, &apiv2.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name1},
+			res1, outError := c.NetworkPolicies().Create(ctx, &apiv2.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
@@ -95,8 +95,8 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			rv1_1 := res1.ResourceVersion
 
 			By("Attempting to create the same NetworkPolicy with name1 but with spec2")
-			res1, outError = c.NetworkPolicies(namespace1).Create(ctx, &apiv2.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name1},
+			res1, outError = c.NetworkPolicies().Create(ctx, &apiv2.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1},
 				Spec:       spec2,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -106,52 +106,52 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			Expect(res1.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting NetworkPolicy (name1) and comparing the output against spec1")
-			res, outError = c.NetworkPolicies(namespace1).Get(ctx, name1, options.GetOptions{})
+			res, outError = c.NetworkPolicies().Get(ctx, namespace1, name1, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
 
 			By("Getting NetworkPolicy (name2) before it is created")
-			res, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			res, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Listing all the NetworkPolicies in namespace1, expecting a single result with name1/spec1")
-			outList, outError := c.NetworkPolicies(namespace1).List(ctx, options.ListOptions{})
+			outList, outError := c.NetworkPolicies().List(ctx, options.ListOptions{Namespace: namespace1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 
 			By("Creating a new NetworkPolicy with name2/spec2")
-			res2, outError := c.NetworkPolicies(namespace2).Create(ctx, &apiv2.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name2, Namespace: namespace2},
+			res2, outError := c.NetworkPolicies().Create(ctx, &apiv2.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace2, Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res2, apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Getting NetworkPolicy (name2) and comparing the output against spec2")
-			res, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			res, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
 
 			By("Listing all the NetworkPolicies using an empty namespace (all-namespaces), expecting a two results with name1/spec1 and name2/spec2")
-			outList, outError = c.NetworkPolicies("").List(ctx, options.ListOptions{})
+			outList, outError = c.NetworkPolicies().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Listing all the NetworkPolicies in namespace2, expecting a one results with name2/spec2")
-			outList, outError = c.NetworkPolicies(namespace2).List(ctx, options.ListOptions{})
+			outList, outError = c.NetworkPolicies().List(ctx, options.ListOptions{Namespace: namespace2})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Updating NetworkPolicy name1 with spec2")
 			res1.Spec = spec2
-			res1, outError = c.NetworkPolicies(namespace1).Update(ctx, res1, options.SetOptions{})
+			res1, outError = c.NetworkPolicies().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 
@@ -161,7 +161,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Updating BGPPeer name1 without specifying a resource version")
 			res1.Spec = spec1
 			res1.ObjectMeta.ResourceVersion = ""
-			res, outError = c.NetworkPolicies(namespace1).Update(ctx, res1, options.SetOptions{})
+			res, outError = c.NetworkPolicies().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
 			Expect(res).To(BeNil())
@@ -169,82 +169,83 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Updating NetworkPolicy name1 using the previous resource version")
 			res1.Spec = spec1
 			res1.ResourceVersion = rv1_1
-			res1, outError = c.NetworkPolicies(namespace1).Update(ctx, res1, options.SetOptions{})
+			res1, outError = c.NetworkPolicies().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: NetworkPolicy(" + namespace1 + "/" + name1 + ")"))
 			Expect(res1.ResourceVersion).To(Equal(rv1_2))
 
 			By("Getting NetworkPolicy (name1) with the original resource version and comparing the output against spec1")
-			res, outError = c.NetworkPolicies(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			res, outError = c.NetworkPolicies().Get(ctx, namespace1, name1, options.GetOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting NetworkPolicy (name1) with the updated resource version and comparing the output against spec2")
-			res, outError = c.NetworkPolicies(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			res, outError = c.NetworkPolicies().Get(ctx, namespace1, name1, options.GetOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 			Expect(res.ResourceVersion).To(Equal(rv1_2))
 
 			By("Listing NetworkPolicies with the original resource version and checking for a single result with name1/spec1")
-			outList, outError = c.NetworkPolicies(namespace1).List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			outList, outError = c.NetworkPolicies().List(ctx, options.ListOptions{Namespace: namespace1, ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec1)
 
 			By("Listing NetworkPolicies (all namespaces) with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError = c.NetworkPolicies("").List(ctx, options.ListOptions{})
+			outList, outError = c.NetworkPolicies().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindNetworkPolicy, namespace2, name2, spec2)
 
 			By("Deleting NetworkPolicy (name1) with the old resource version")
-			outError = c.NetworkPolicies(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.NetworkPolicies().Delete(ctx, namespace1, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: NetworkPolicy(" + namespace1 + "/" + name1 + ")"))
 
 			By("Deleting NetworkPolicy (name1) with the new resource version")
-			outError = c.NetworkPolicies(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.NetworkPolicies().Delete(ctx, namespace1, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindNetworkPolicy, namespace1, name1, spec2)
 
 			By("Updating NetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.NetworkPolicies(namespace2).Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			_, outError = c.NetworkPolicies().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Creating NetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.NetworkPolicies(namespace2).Create(ctx, &apiv2.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name2},
+			_, outError = c.NetworkPolicies().Create(ctx, &apiv2.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace2, Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Attempting to deleting NetworkPolicy (name2) again")
-			outError = c.NetworkPolicies(namespace2).Delete(ctx, name2, options.DeleteOptions{})
+			_, outError = c.NetworkPolicies().Delete(ctx, namespace2, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 
 			By("Listing all NetworkPolicies and expecting no items")
-			outList, outError = c.NetworkPolicies("").List(ctx, options.ListOptions{})
+			outList, outError = c.NetworkPolicies().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 
 			By("Getting NetworkPolicy (name2) and expecting an error")
-			res, outError = c.NetworkPolicies(namespace2).Get(ctx, name2, options.GetOptions{})
+			res, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/" + name2 + ")"))
 		},
@@ -267,16 +268,16 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			be.Clean()
 
 			By("Listing NetworkPolicies with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError := c.NetworkPolicies(apiv2.AllNamespaces).List(ctx, options.ListOptions{})
+			outList, outError := c.NetworkPolicies().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
 			By("Configuring a NetworkPolicy namespace1/name1/spec1 and storing the response")
-			outRes1, err := c.NetworkPolicies(namespace1).Create(
+			outRes1, err := c.NetworkPolicies().Create(
 				ctx,
 				&apiv2.NetworkPolicy{
-					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1},
 					Spec:       spec1,
 				},
 				options.SetOptions{},
@@ -284,23 +285,23 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			rev1 := outRes1.ResourceVersion
 
 			By("Configuring a NetworkPolicy namespace2/name2/spec2 and storing the response")
-			outRes2, err := c.NetworkPolicies(namespace2).Create(
+			outRes2, err := c.NetworkPolicies().Create(
 				ctx,
 				&apiv2.NetworkPolicy{
-					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace2, Name: name2},
 					Spec:       spec2,
 				},
 				options.SetOptions{},
 			)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
-			w, err := c.NetworkPolicies(apiv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			w, err := c.NetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher1 := testutils.TestResourceWatch(w)
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.NetworkPolicies(namespace1).Delete(ctx, name1, options.DeleteOptions{})
+			_, err = c.NetworkPolicies().Delete(ctx, namespace1, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -317,13 +318,13 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			testWatcher1.Stop()
 
 			By("Starting a watcher from rev0 - this should get all events")
-			w, err = c.NetworkPolicies(apiv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher2 := testutils.TestResourceWatch(w)
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
-			outRes3, err := c.NetworkPolicies(namespace2).Update(
+			outRes3, err := c.NetworkPolicies().Update(
 				ctx,
 				&apiv2.NetworkPolicy{
 					ObjectMeta: outRes2.ObjectMeta,
@@ -353,8 +354,25 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			})
 			testWatcher2.Stop()
 
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{Namespace: namespace1, Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindNetworkPolicy, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
+
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.NetworkPolicies(apiv2.AllNamespaces).Watch(ctx, options.ListOptions{})
+			w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher3 := testutils.TestResourceWatch(w)
 			defer testWatcher3.Stop()
@@ -367,7 +385,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			testWatcher3.Stop()
 
 			By("Starting a watcher at rev0 in namespace1 - expect the events for policy in namespace1")
-			w, err = c.NetworkPolicies(namespace1).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{Namespace: namespace1, ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher4 := testutils.TestResourceWatch(w)
 			defer testWatcher4.Stop()

--- a/lib/clientv2/node.go
+++ b/lib/clientv2/node.go
@@ -26,7 +26,7 @@ import (
 type NodeInterface interface {
 	Create(ctx context.Context, res *apiv2.Node, opts options.SetOptions) (*apiv2.Node, error)
 	Update(ctx context.Context, res *apiv2.Node, opts options.SetOptions) (*apiv2.Node, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.Node, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.Node, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.NodeList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
@@ -40,7 +40,7 @@ type nodes struct {
 // Create takes the representation of a Node and creates it.  Returns the stored
 // representation of the Node, and an error, if there is any.
 func (r nodes) Create(ctx context.Context, res *apiv2.Node, opts options.SetOptions) (*apiv2.Node, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindNode, noNamespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindNode, res)
 	if out != nil {
 		return out.(*apiv2.Node), err
 	}
@@ -50,7 +50,7 @@ func (r nodes) Create(ctx context.Context, res *apiv2.Node, opts options.SetOpti
 // Update takes the representation of a Node and updates it. Returns the stored
 // representation of the Node, and an error, if there is any.
 func (r nodes) Update(ctx context.Context, res *apiv2.Node, opts options.SetOptions) (*apiv2.Node, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindNode, noNamespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindNode, res)
 	if out != nil {
 		return out.(*apiv2.Node), err
 	}
@@ -58,9 +58,12 @@ func (r nodes) Update(ctx context.Context, res *apiv2.Node, opts options.SetOpti
 }
 
 // Delete takes name of the Node and deletes it. Returns an error if one occurs.
-func (r nodes) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindNode, noNamespace, name)
-	return err
+func (r nodes) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.Node, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindNode, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.Node), err
+	}
+	return nil, err
 }
 
 // Get takes name of the Node, and returns the corresponding Node object,
@@ -76,7 +79,7 @@ func (r nodes) Get(ctx context.Context, name string, opts options.GetOptions) (*
 // List returns the list of Node objects that match the supplied options.
 func (r nodes) List(ctx context.Context, opts options.ListOptions) (*apiv2.NodeList, error) {
 	res := &apiv2.NodeList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindNode, apiv2.KindNodeList, noNamespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindNode, apiv2.KindNodeList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -85,5 +88,5 @@ func (r nodes) List(ctx context.Context, opts options.ListOptions) (*apiv2.NodeL
 // Watch returns a watch.Interface that watches the Nodes that match the
 // supplied options.
 func (r nodes) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindNode, noNamespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindNode)
 }

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -188,13 +188,14 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindNode, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Deleting Node (name1) with the old resource version")
-			outError = c.Nodes().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.Nodes().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: Node(" + name1 + ")"))
 
 			By("Deleting Node (name1) with the new resource version")
-			outError = c.Nodes().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.Nodes().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindNode, testutils.ExpectNoNamespace, name1, spec2)
 
 			By("Updating Node name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.Nodes().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
@@ -222,7 +223,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
 
 			By("Attempting to deleting Node (name2) again")
-			outError = c.Nodes().Delete(ctx, name2, options.DeleteOptions{})
+			_, outError = c.Nodes().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
 
@@ -284,7 +285,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.Nodes().Delete(ctx, name1, options.DeleteOptions{})
+			_, err = c.Nodes().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -336,6 +337,23 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 				},
 			})
 			testWatcher2.Stop()
+
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.Nodes().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindNode, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.Nodes().Watch(ctx, options.ListOptions{})

--- a/lib/clientv2/profile.go
+++ b/lib/clientv2/profile.go
@@ -26,7 +26,7 @@ import (
 type ProfileInterface interface {
 	Create(ctx context.Context, res *apiv2.Profile, opts options.SetOptions) (*apiv2.Profile, error)
 	Update(ctx context.Context, res *apiv2.Profile, opts options.SetOptions) (*apiv2.Profile, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.Profile, error)
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.Profile, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.ProfileList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
@@ -40,7 +40,7 @@ type profiles struct {
 // Create takes the representation of a Profile and creates it.  Returns the stored
 // representation of the Profile, and an error, if there is any.
 func (r profiles) Create(ctx context.Context, res *apiv2.Profile, opts options.SetOptions) (*apiv2.Profile, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindProfile, noNamespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindProfile, res)
 	if out != nil {
 		return out.(*apiv2.Profile), err
 	}
@@ -50,7 +50,7 @@ func (r profiles) Create(ctx context.Context, res *apiv2.Profile, opts options.S
 // Update takes the representation of a Profile and updates it. Returns the stored
 // representation of the Profile, and an error, if there is any.
 func (r profiles) Update(ctx context.Context, res *apiv2.Profile, opts options.SetOptions) (*apiv2.Profile, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindProfile, noNamespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindProfile, res)
 	if out != nil {
 		return out.(*apiv2.Profile), err
 	}
@@ -58,9 +58,12 @@ func (r profiles) Update(ctx context.Context, res *apiv2.Profile, opts options.S
 }
 
 // Delete takes name of the Profile and deletes it. Returns an error if one occurs.
-func (r profiles) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindProfile, noNamespace, name)
-	return err
+func (r profiles) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.Profile, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindProfile, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.Profile), err
+	}
+	return nil, err
 }
 
 // Get takes name of the Profile, and returns the corresponding Profile object,
@@ -76,7 +79,7 @@ func (r profiles) Get(ctx context.Context, name string, opts options.GetOptions)
 // List returns the list of Profile objects that match the supplied options.
 func (r profiles) List(ctx context.Context, opts options.ListOptions) (*apiv2.ProfileList, error) {
 	res := &apiv2.ProfileList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindProfile, apiv2.KindProfileList, noNamespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindProfile, apiv2.KindProfileList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -85,5 +88,5 @@ func (r profiles) List(ctx context.Context, opts options.ListOptions) (*apiv2.Pr
 // Watch returns a watch.Interface that watches the Profiles that match the
 // supplied options.
 func (r profiles) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindProfile, noNamespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindProfile)
 }

--- a/lib/clientv2/profile_e2e_test.go
+++ b/lib/clientv2/profile_e2e_test.go
@@ -35,6 +35,7 @@ import (
 
 var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
+	ctx := context.Background()
 	name1 := "profile-1"
 	name2 := "profile-2"
 	spec1 := apiv2.ProfileSpec{
@@ -58,7 +59,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			be.Clean()
 
 			By("Updating the Profile before it is created")
-			res, outError := c.Profiles().Update(context.Background(), &apiv2.Profile{
+			res, outError := c.Profiles().Update(ctx, &apiv2.Profile{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -67,7 +68,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name1 + ")"))
 
 			By("Attempting to creating a new Profile with name1/spec1 and a non-empty ResourceVersion")
-			res, outError = c.Profiles().Create(context.Background(), &apiv2.Profile{
+			res, outError = c.Profiles().Create(ctx, &apiv2.Profile{
 				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -76,7 +77,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
 			By("Creating a new Profile with name1/spec1")
-			res1, outError := c.Profiles().Create(context.Background(), &apiv2.Profile{
+			res1, outError := c.Profiles().Create(ctx, &apiv2.Profile{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec1,
 			}, options.SetOptions{})
@@ -87,7 +88,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			rv1_1 := res1.ResourceVersion
 
 			By("Attempting to create the same Profile with name1 but with spec2")
-			res1, outError = c.Profiles().Create(context.Background(), &apiv2.Profile{
+			res1, outError = c.Profiles().Create(ctx, &apiv2.Profile{
 				ObjectMeta: metav1.ObjectMeta{Name: name1},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -98,24 +99,24 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			Expect(res1.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting Profile (name1) and comparing the output against spec1")
-			res, outError = c.Profiles().Get(context.Background(), name1, options.GetOptions{})
+			res, outError = c.Profiles().Get(ctx, name1, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
 
 			By("Getting Profile (name2) before it is created")
-			res, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
 
 			By("Listing all the Profiles, expecting a single result with name1/spec1")
-			outList, outError := c.Profiles().List(context.Background(), options.ListOptions{})
+			outList, outError := c.Profiles().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec1)
 
 			By("Creating a new Profile with name2/spec2")
-			res2, outError := c.Profiles().Create(context.Background(), &apiv2.Profile{
+			res2, outError := c.Profiles().Create(ctx, &apiv2.Profile{
 				ObjectMeta: metav1.ObjectMeta{Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -123,13 +124,13 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			testutils.ExpectResource(res2, apiv2.KindProfile, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Getting Profile (name2) and comparing the output against spec2")
-			res, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res2, apiv2.KindProfile, testutils.ExpectNoNamespace, name2, spec2)
 			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
 
 			By("Listing all the Profiles, expecting a two results with name1/spec1 and name2/spec2")
-			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{})
+			outList, outError = c.Profiles().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec1)
@@ -137,7 +138,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 
 			By("Updating Profile name1 with spec2")
 			res1.Spec = spec2
-			res1, outError = c.Profiles().Update(context.Background(), res1, options.SetOptions{})
+			res1, outError = c.Profiles().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec2)
 
@@ -147,7 +148,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			By("Updating Profile name1 without specifying a resource version")
 			res1.Spec = spec1
 			res1.ObjectMeta.ResourceVersion = ""
-			res, outError = c.Profiles().Update(context.Background(), res1, options.SetOptions{})
+			res, outError = c.Profiles().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
 			Expect(res).To(BeNil())
@@ -155,82 +156,83 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			By("Updating Profile name1 using the previous resource version")
 			res1.Spec = spec1
 			res1.ResourceVersion = rv1_1
-			res1, outError = c.Profiles().Update(context.Background(), res1, options.SetOptions{})
+			res1, outError = c.Profiles().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: Profile(" + name1 + ")"))
 			Expect(res1.ResourceVersion).To(Equal(rv1_2))
 
 			By("Getting Profile (name1) with the original resource version and comparing the output against spec1")
-			res, outError = c.Profiles().Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_1})
+			res, outError = c.Profiles().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting Profile (name1) with the updated resource version and comparing the output against spec2")
-			res, outError = c.Profiles().Get(context.Background(), name1, options.GetOptions{ResourceVersion: rv1_2})
+			res, outError = c.Profiles().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec2)
 			Expect(res.ResourceVersion).To(Equal(rv1_2))
 
 			By("Listing Profiles with the original resource version and checking for a single result with name1/spec1")
-			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{ResourceVersion: rv1_1})
+			outList, outError = c.Profiles().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec1)
 
 			By("Listing Profiles with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{})
+			outList, outError = c.Profiles().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec2)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindProfile, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Deleting Profile (name1) with the old resource version")
-			outError = c.Profiles().Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.Profiles().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: Profile(" + name1 + ")"))
 
 			By("Deleting Profile (name1) with the new resource version")
-			outError = c.Profiles().Delete(context.Background(), name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.Profiles().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec2)
 
 			By("Updating Profile name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.Profiles().Update(context.Background(), res2, options.SetOptions{TTL: 2 * time.Second})
+			_, outError = c.Profiles().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
 
 			By("Creating Profile name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.Profiles().Create(context.Background(), &apiv2.Profile{
+			_, outError = c.Profiles().Create(ctx, &apiv2.Profile{
 				ObjectMeta: metav1.ObjectMeta{Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
 
 			By("Attempting to deleting Profile (name2) again")
-			outError = c.Profiles().Delete(context.Background(), name2, options.DeleteOptions{})
+			_, outError = c.Profiles().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
 
 			By("Listing all Profiles and expecting no items")
-			outList, outError = c.Profiles().List(context.Background(), options.ListOptions{})
+			outList, outError = c.Profiles().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 
 			By("Getting Profile (name2) and expecting an error")
-			res, outError = c.Profiles().Get(context.Background(), name2, options.GetOptions{})
+			res, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
 		},
@@ -249,14 +251,14 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			be.Clean()
 
 			By("Listing Profiles with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError := c.Profiles().List(context.Background(), options.ListOptions{})
+			outList, outError := c.Profiles().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
 			By("Configuring a Profile name1/spec1 and storing the response")
 			outRes1, err := c.Profiles().Create(
-				context.Background(),
+				ctx,
 				&apiv2.Profile{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
@@ -267,7 +269,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 
 			By("Configuring a Profile name2/spec2 and storing the response")
 			outRes2, err := c.Profiles().Create(
-				context.Background(),
+				ctx,
 				&apiv2.Profile{
 					ObjectMeta: metav1.ObjectMeta{Name: name2},
 					Spec:       spec2,
@@ -276,13 +278,13 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
-			w, err := c.Profiles().Watch(context.Background(), options.ListOptions{ResourceVersion: rev1})
+			w, err := c.Profiles().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher1 := testutils.TestResourceWatch(w)
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.Profiles().Delete(context.Background(), name1, options.DeleteOptions{})
+			_, err = c.Profiles().Delete(ctx, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -299,14 +301,14 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			testWatcher1.Stop()
 
 			By("Starting a watcher from rev0 - this should get all events")
-			w, err = c.Profiles().Watch(context.Background(), options.ListOptions{ResourceVersion: rev0})
+			w, err = c.Profiles().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher2 := testutils.TestResourceWatch(w)
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
 			outRes3, err := c.Profiles().Update(
-				context.Background(),
+				ctx,
 				&apiv2.Profile{
 					ObjectMeta: outRes2.ObjectMeta,
 					Spec:       spec1,
@@ -335,8 +337,25 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			})
 			testWatcher2.Stop()
 
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.Profiles().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindProfile, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
+
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.Profiles().Watch(context.Background(), options.ListOptions{})
+			w, err = c.Profiles().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher3 := testutils.TestResourceWatch(w)
 			defer testWatcher3.Stop()
@@ -350,7 +369,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 
 			By("Configuring Profile name1/spec1 again and storing the response")
 			outRes1, err = c.Profiles().Create(
-				context.Background(),
+				ctx,
 				&apiv2.Profile{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
 					Spec:       spec1,
@@ -359,7 +378,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 			)
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.Profiles().Watch(context.Background(), options.ListOptions{})
+			w, err = c.Profiles().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher4 := testutils.TestResourceWatch(w)
 			defer testWatcher4.Stop()

--- a/lib/clientv2/watch_e2e_test.go
+++ b/lib/clientv2/watch_e2e_test.go
@@ -125,7 +125,7 @@ var _ = testutils.E2eDatastoreDescribe("Additional watch tests", testutils.Datas
 					_, err := c.BGPPeers().Create(ctx, bgpPeer, options.SetOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					err = c.BGPPeers().Delete(ctx, "name1", options.DeleteOptions{})
+					_, err = c.BGPPeers().Delete(ctx, "name1", options.DeleteOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
 					if finishctx.Err() != nil {

--- a/lib/clientv2/workloadendpoint.go
+++ b/lib/clientv2/workloadendpoint.go
@@ -26,22 +26,21 @@ import (
 type WorkloadEndpointInterface interface {
 	Create(ctx context.Context, res *apiv2.WorkloadEndpoint, opts options.SetOptions) (*apiv2.WorkloadEndpoint, error)
 	Update(ctx context.Context, res *apiv2.WorkloadEndpoint, opts options.SetOptions) (*apiv2.WorkloadEndpoint, error)
-	Delete(ctx context.Context, name string, opts options.DeleteOptions) error
-	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.WorkloadEndpoint, error)
+	Delete(ctx context.Context, namespace, name string, opts options.DeleteOptions) (*apiv2.WorkloadEndpoint, error)
+	Get(ctx context.Context, namespace, name string, opts options.GetOptions) (*apiv2.WorkloadEndpoint, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv2.WorkloadEndpointList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
 }
 
 // workloadEndpoints implements WorkloadEndpointInterface
 type workloadEndpoints struct {
-	client    client
-	namespace string
+	client client
 }
 
 // Create takes the representation of a WorkloadEndpoint and creates it.  Returns the stored
 // representation of the WorkloadEndpoint, and an error, if there is any.
 func (r workloadEndpoints) Create(ctx context.Context, res *apiv2.WorkloadEndpoint, opts options.SetOptions) (*apiv2.WorkloadEndpoint, error) {
-	out, err := r.client.resources.Create(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, res)
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindWorkloadEndpoint, res)
 	if out != nil {
 		return out.(*apiv2.WorkloadEndpoint), err
 	}
@@ -51,7 +50,7 @@ func (r workloadEndpoints) Create(ctx context.Context, res *apiv2.WorkloadEndpoi
 // Update takes the representation of a WorkloadEndpoint and updates it. Returns the stored
 // representation of the WorkloadEndpoint, and an error, if there is any.
 func (r workloadEndpoints) Update(ctx context.Context, res *apiv2.WorkloadEndpoint, opts options.SetOptions) (*apiv2.WorkloadEndpoint, error) {
-	out, err := r.client.resources.Update(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, res)
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindWorkloadEndpoint, res)
 	if out != nil {
 		return out.(*apiv2.WorkloadEndpoint), err
 	}
@@ -59,15 +58,18 @@ func (r workloadEndpoints) Update(ctx context.Context, res *apiv2.WorkloadEndpoi
 }
 
 // Delete takes name of the WorkloadEndpoint and deletes it. Returns an error if one occurs.
-func (r workloadEndpoints) Delete(ctx context.Context, name string, opts options.DeleteOptions) error {
-	err := r.client.resources.Delete(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, name)
-	return err
+func (r workloadEndpoints) Delete(ctx context.Context, namespace, name string, opts options.DeleteOptions) (*apiv2.WorkloadEndpoint, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindWorkloadEndpoint, namespace, name)
+	if out != nil {
+		return out.(*apiv2.WorkloadEndpoint), err
+	}
+	return nil, err
 }
 
 // Get takes name of the WorkloadEndpoint, and returns the corresponding WorkloadEndpoint object,
 // and an error if there is any.
-func (r workloadEndpoints) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.WorkloadEndpoint, error) {
-	out, err := r.client.resources.Get(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, name)
+func (r workloadEndpoints) Get(ctx context.Context, namespace, name string, opts options.GetOptions) (*apiv2.WorkloadEndpoint, error) {
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindWorkloadEndpoint, namespace, name)
 	if out != nil {
 		return out.(*apiv2.WorkloadEndpoint), err
 	}
@@ -77,7 +79,7 @@ func (r workloadEndpoints) Get(ctx context.Context, name string, opts options.Ge
 // List returns the list of WorkloadEndpoint objects that match the supplied options.
 func (r workloadEndpoints) List(ctx context.Context, opts options.ListOptions) (*apiv2.WorkloadEndpointList, error) {
 	res := &apiv2.WorkloadEndpointList{}
-	if err := r.client.resources.List(ctx, opts, apiv2.KindWorkloadEndpoint, apiv2.KindWorkloadEndpointList, r.namespace, allNames, res); err != nil {
+	if err := r.client.resources.List(ctx, opts, apiv2.KindWorkloadEndpoint, apiv2.KindWorkloadEndpointList, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -86,5 +88,5 @@ func (r workloadEndpoints) List(ctx context.Context, opts options.ListOptions) (
 // Watch returns a watch.Interface that watches the NetworkPolicies that match the
 // supplied options.
 func (r workloadEndpoints) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv2.KindWorkloadEndpoint, r.namespace, allNames)
+	return r.client.resources.Watch(ctx, opts, apiv2.KindWorkloadEndpoint)
 }

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -61,8 +61,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			be.Clean()
 
 			By("Updating the WorkloadEndpoint before it is created")
-			res, outError := c.WorkloadEndpoints(namespace1).Update(ctx, &apiv2.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+			res, outError := c.WorkloadEndpoints().Update(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -70,8 +70,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
 
 			By("Attempting to creating a new WorkloadEndpoint with name1/spec1 and a non-empty ResourceVersion")
-			res, outError = c.WorkloadEndpoints(namespace1).Create(ctx, &apiv2.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+			res, outError = c.WorkloadEndpoints().Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "12345"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(res).To(BeNil())
@@ -79,8 +79,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
 			By("Creating a new WorkloadEndpoint with namespace1/name1/spec1")
-			res1, outError := c.WorkloadEndpoints(namespace1).Create(ctx, &apiv2.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name1},
+			res1, outError := c.WorkloadEndpoints().Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
@@ -90,8 +90,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			rv1_1 := res1.ResourceVersion
 
 			By("Attempting to create the same WorkloadEndpoint with name1 but with spec2")
-			res1, outError = c.WorkloadEndpoints(namespace1).Create(ctx, &apiv2.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name1},
+			res1, outError = c.WorkloadEndpoints().Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1},
 				Spec:       spec2,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -101,24 +101,24 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			Expect(res1.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting WorkloadEndpoint (name1) and comparing the output against spec1")
-			res, outError = c.WorkloadEndpoints(namespace1).Get(ctx, name1, options.GetOptions{})
+			res, outError = c.WorkloadEndpoints().Get(ctx, namespace1, name1, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
 
 			By("Getting WorkloadEndpoint (name2) before it is created")
-			res, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			res, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
 
 			By("Listing all the WorkloadEndpoints in namespace1, expecting a single result with name1/spec1")
-			outList, outError := c.WorkloadEndpoints(namespace1).List(ctx, options.ListOptions{})
+			outList, outError := c.WorkloadEndpoints().List(ctx, options.ListOptions{Namespace: namespace1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
 
 			By("Creating a new WorkloadEndpoint with name2/spec2")
-			res2, outError := c.WorkloadEndpoints(namespace2).Create(ctx, &apiv2.WorkloadEndpoint{
+			res2, outError := c.WorkloadEndpoints().Create(ctx, &apiv2.WorkloadEndpoint{
 				ObjectMeta: metav1.ObjectMeta{Name: name2, Namespace: namespace2},
 				Spec:       spec2,
 			}, options.SetOptions{})
@@ -126,27 +126,27 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			testutils.ExpectResource(res2, apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
 
 			By("Getting WorkloadEndpoint (name2) and comparing the output against spec2")
-			res, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			res, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
 			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
 
 			By("Listing all the WorkloadEndpoints using an empty namespace (all-namespaces), expecting a two results with name1/spec1 and name2/spec2")
-			outList, outError = c.WorkloadEndpoints("").List(ctx, options.ListOptions{})
+			outList, outError = c.WorkloadEndpoints().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
 
 			By("Listing all the WorkloadEndpoints in namespace2, expecting a one results with name2/spec2")
-			outList, outError = c.WorkloadEndpoints(namespace2).List(ctx, options.ListOptions{})
+			outList, outError = c.WorkloadEndpoints().List(ctx, options.ListOptions{Namespace: namespace2})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
 
 			By("Updating WorkloadEndpoint name1 with spec2")
 			res1.Spec = spec2
-			res1, outError = c.WorkloadEndpoints(namespace1).Update(ctx, res1, options.SetOptions{})
+			res1, outError = c.WorkloadEndpoints().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
 
@@ -156,7 +156,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			By("Updating BGPPeer name1 without specifying a resource version")
 			res1.Spec = spec1
 			res1.ObjectMeta.ResourceVersion = ""
-			res, outError = c.WorkloadEndpoints(namespace1).Update(ctx, res1, options.SetOptions{})
+			res, outError = c.WorkloadEndpoints().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
 			Expect(res).To(BeNil())
@@ -164,82 +164,83 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			By("Updating WorkloadEndpoint name1 using the previous resource version")
 			res1.Spec = spec1
 			res1.ResourceVersion = rv1_1
-			res1, outError = c.WorkloadEndpoints(namespace1).Update(ctx, res1, options.SetOptions{})
+			res1, outError = c.WorkloadEndpoints().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
 			Expect(res1.ResourceVersion).To(Equal(rv1_2))
 
 			By("Getting WorkloadEndpoint (name1) with the original resource version and comparing the output against spec1")
-			res, outError = c.WorkloadEndpoints(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			res, outError = c.WorkloadEndpoints().Get(ctx, namespace1, name1, options.GetOptions{ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
 			Expect(res.ResourceVersion).To(Equal(rv1_1))
 
 			By("Getting WorkloadEndpoint (name1) with the updated resource version and comparing the output against spec2")
-			res, outError = c.WorkloadEndpoints(namespace1).Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			res, outError = c.WorkloadEndpoints().Get(ctx, namespace1, name1, options.GetOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
 			Expect(res.ResourceVersion).To(Equal(rv1_2))
 
 			By("Listing WorkloadEndpoints with the original resource version and checking for a single result with name1/spec1")
-			outList, outError = c.WorkloadEndpoints(namespace1).List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			outList, outError = c.WorkloadEndpoints().List(ctx, options.ListOptions{Namespace: namespace1, ResourceVersion: rv1_1})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1)
 
 			By("Listing WorkloadEndpoints (all namespaces) with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError = c.WorkloadEndpoints("").List(ctx, options.ListOptions{})
+			outList, outError = c.WorkloadEndpoints().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(2))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
 			testutils.ExpectResource(&outList.Items[1], apiv2.KindWorkloadEndpoint, namespace2, name2, spec2)
 
 			By("Deleting WorkloadEndpoint (name1) with the old resource version")
-			outError = c.WorkloadEndpoints(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			_, outError = c.WorkloadEndpoints().Delete(ctx, namespace1, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("update conflict: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
 
 			By("Deleting WorkloadEndpoint (name1) with the new resource version")
-			outError = c.WorkloadEndpoints(namespace1).Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			dres, outError := c.WorkloadEndpoints().Delete(ctx, namespace1, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindWorkloadEndpoint, namespace1, name1, spec2)
 
 			By("Updating WorkloadEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.WorkloadEndpoints(namespace2).Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			_, outError = c.WorkloadEndpoints().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
 
 			By("Creating WorkloadEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
-			_, outError = c.WorkloadEndpoints(namespace2).Create(ctx, &apiv2.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name2},
+			_, outError = c.WorkloadEndpoints().Create(ctx, &apiv2.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace2, Name: name2},
 				Spec:       spec2,
 			}, options.SetOptions{TTL: 2 * time.Second})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(1 * time.Second)
-			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			_, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
 
 			By("Attempting to deleting WorkloadEndpoint (name2) again")
-			outError = c.WorkloadEndpoints(namespace2).Delete(ctx, name2, options.DeleteOptions{})
+			_, outError = c.WorkloadEndpoints().Delete(ctx, namespace2, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
 
 			By("Listing all WorkloadEndpoints and expecting no items")
-			outList, outError = c.WorkloadEndpoints("").List(ctx, options.ListOptions{})
+			outList, outError = c.WorkloadEndpoints().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 
 			By("Getting WorkloadEndpoint (name2) and expecting an error")
-			res, outError = c.WorkloadEndpoints(namespace2).Get(ctx, name2, options.GetOptions{})
+			res, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
 		},
@@ -262,16 +263,16 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			be.Clean()
 
 			By("Listing WorkloadEndpoints with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
-			outList, outError := c.WorkloadEndpoints(apiv2.AllNamespaces).List(ctx, options.ListOptions{})
+			outList, outError := c.WorkloadEndpoints().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
 			By("Configuring a WorkloadEndpoint namespace1/name1/spec1 and storing the response")
-			outRes1, err := c.WorkloadEndpoints(namespace1).Create(
+			outRes1, err := c.WorkloadEndpoints().Create(
 				ctx,
 				&apiv2.WorkloadEndpoint{
-					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1},
 					Spec:       spec1,
 				},
 				options.SetOptions{},
@@ -279,23 +280,23 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			rev1 := outRes1.ResourceVersion
 
 			By("Configuring a WorkloadEndpoint namespace2/name2/spec2 and storing the response")
-			outRes2, err := c.WorkloadEndpoints(namespace2).Create(
+			outRes2, err := c.WorkloadEndpoints().Create(
 				ctx,
 				&apiv2.WorkloadEndpoint{
-					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace2, Name: name2},
 					Spec:       spec2,
 				},
 				options.SetOptions{},
 			)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
-			w, err := c.WorkloadEndpoints(apiv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			w, err := c.WorkloadEndpoints().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher1 := testutils.TestResourceWatch(w)
 			defer testWatcher1.Stop()
 
 			By("Deleting res1")
-			err = c.WorkloadEndpoints(namespace1).Delete(ctx, name1, options.DeleteOptions{})
+			_, err = c.WorkloadEndpoints().Delete(ctx, namespace1, name1, options.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for two events, create res2 and delete re1")
@@ -312,13 +313,13 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			testWatcher1.Stop()
 
 			By("Starting a watcher from rev0 - this should get all events")
-			w, err = c.WorkloadEndpoints(apiv2.AllNamespaces).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			w, err = c.WorkloadEndpoints().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher2 := testutils.TestResourceWatch(w)
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
-			outRes3, err := c.WorkloadEndpoints(namespace2).Update(
+			outRes3, err := c.WorkloadEndpoints().Update(
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: outRes2.ObjectMeta,
@@ -348,8 +349,25 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			})
 			testWatcher2.Stop()
 
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.WorkloadEndpoints().Watch(ctx, options.ListOptions{Namespace: namespace1, Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindWorkloadEndpoint, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
+
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
-			w, err = c.WorkloadEndpoints(apiv2.AllNamespaces).Watch(ctx, options.ListOptions{})
+			w, err = c.WorkloadEndpoints().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher3 := testutils.TestResourceWatch(w)
 			defer testWatcher3.Stop()
@@ -362,7 +380,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			testWatcher3.Stop()
 
 			By("Starting a watcher at rev0 in namespace1 - expect the events for policy in namespace1")
-			w, err = c.WorkloadEndpoints(namespace1).Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			w, err = c.WorkloadEndpoints().Watch(ctx, options.ListOptions{Namespace: namespace1, ResourceVersion: rev0})
 			Expect(err).NotTo(HaveOccurred())
 			testWatcher4 := testutils.TestResourceWatch(w)
 			defer testWatcher4.Stop()

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -364,7 +364,7 @@ func (c ipams) releaseIPsFromBlock(ips []net.IP, blockCIDR net.IPNet) ([]net.IP,
 		var updateErr error
 		if b.empty() && b.Affinity == nil {
 			log.Debugf("Deleting non-affine block '%s'", b.CIDR.String())
-			updateErr = c.client.Delete(context.Background(), obj.Key, obj.Revision)
+			_, updateErr = c.client.Delete(context.Background(), obj.Key, obj.Revision)
 		} else {
 			log.Debugf("Updating assignments in block '%s'", b.CIDR.String())
 			_, updateErr = c.client.Update(context.Background(), obj)
@@ -600,7 +600,7 @@ func (c ipams) RemoveIPAMHost(host string) error {
 	c.ReleaseHostAffinities(hostname)
 
 	// Remove the host tree from the datastore.
-	err := c.client.Delete(context.Background(), model.IPAMHostKey{Host: hostname}, "")
+	_, err := c.client.Delete(context.Background(), model.IPAMHostKey{Host: hostname}, "")
 	if err != nil {
 		// Return the error unless the resource does not exist.
 		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
@@ -702,7 +702,7 @@ func (c ipams) releaseByHandle(handleID string, blockCIDR net.IPNet) error {
 		}
 
 		if block.empty() && block.Affinity == nil {
-			err = c.client.Delete(context.Background(), model.BlockKey{blockCIDR}, "")
+			_, err = c.client.Delete(context.Background(), model.BlockKey{blockCIDR}, "")
 			if err != nil {
 				// Return the error unless the resource does not exist.
 				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
@@ -793,7 +793,7 @@ func (c ipams) decrementHandle(handleID string, blockCIDR net.IPNet, num int) er
 		// data in the KVPair, just pass this straight back to the client.
 		if handle.empty() {
 			log.Debugf("Deleting handle: %s", handleID)
-			err = c.client.Delete(context.Background(), obj.Key, obj.Revision)
+			_, err = c.client.Delete(context.Background(), obj.Key, obj.Revision)
 		} else {
 			log.Debugf("Updating handle: %s", handleID)
 			_, err = c.client.Update(context.Background(), obj)

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -203,7 +203,7 @@ func (rw blockReaderWriter) claimBlockAffinity(subnet cnet.IPNet, host string, c
 			}
 
 			// Some other host beat us to this block.  Cleanup and return error.
-			err = rw.client.Delete(context.Background(), model.BlockAffinityKey{Host: host, CIDR: b.CIDR}, "")
+			_, err = rw.client.Delete(context.Background(), model.BlockAffinityKey{Host: host, CIDR: b.CIDR}, "")
 			if err != nil {
 				log.Errorf("Error cleaning up block affinity: %s", err)
 				return err
@@ -242,7 +242,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR cnet.IPN
 
 		if b.empty() {
 			// If the block is empty, we can delete it.
-			err := rw.client.Delete(context.Background(), model.BlockKey{CIDR: b.CIDR}, "")
+			_, err := rw.client.Delete(context.Background(), model.BlockKey{CIDR: b.CIDR}, "")
 			if err != nil {
 				// Return the error unless the block didn't exist.
 				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
@@ -273,7 +273,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR cnet.IPN
 
 		// We've removed / updated the block, so update the host config
 		// to remove the CIDR.
-		err = rw.client.Delete(context.Background(), model.BlockAffinityKey{Host: host, CIDR: b.CIDR}, "")
+		_, err = rw.client.Delete(context.Background(), model.BlockAffinityKey{Host: host, CIDR: b.CIDR}, "")
 		if err != nil {
 			// Return the error unless the affinity didn't exist.
 			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {

--- a/lib/options/listwatch.go
+++ b/lib/options/listwatch.go
@@ -16,6 +16,14 @@ package options
 
 // ListOptions is the query options a List or Watch operation in the Calico API.
 type ListOptions struct {
+	// The namespace of the resource to List or Watch.  If blank, the list or watch wildcards
+	// the namespace.  Only used for namespaced resource types.
+	Namespace string
+
+	// The name of the resource to List or Watch.  If blank, the list or watch wildcards
+	// the name.
+	Name string
+
 	// The resource version to List or Watch from.
 	// When specified for list:
 	// - if unset, then the result is returned from remote storage based on quorum-read flag;

--- a/lib/testutils/resources.go
+++ b/lib/testutils/resources.go
@@ -32,6 +32,7 @@ import (
 // matches the key attributes: kind, namespace, name and the supplied Spec.  This
 // should be called within a Ginkgo test.
 const ExpectNoNamespace = ""
+
 func ExpectResource(res runtime.Object, kind, namespace, name string, spec interface{}) {
 	ma := res.(v1.ObjectMetaAccessor)
 	Expect(ma.GetObjectMeta().GetNamespace()).To(Equal(namespace))


### PR DESCRIPTION
This consists of:
-  Removing the handling of the default namespace - this should be handled by the client
-  Removing the namespace from the client constructor and instead adding to:  the Get/Delete methods on namespaced resources, and the ListWatchOptions struct.
-  Returning the deleted resource as part of the Delete request
-  Allowing List and Watch to list/watch a specific resource.
