### PR TITLE
WorkloadEndpoint name construction helper

### DIFF
--- a/lib/client/ippool.go
+++ b/lib/client/ippool.go
@@ -16,7 +16,7 @@ package client
 
 import (
 	"context"
-	
+
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -16,7 +16,7 @@ package ipam
 
 import (
 	"context"
-	
+
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -73,7 +73,7 @@ type Interface interface {
 	// GetIPAMConfig returns the global IPAM configuration.  If no IPAM configuration
 	// has been set, returns a default configuration with StrictAffinity disabled
 	// and AutoAllocateBlocks enabled.
-	GetIPAMConfig(ctx context.Context, ) (*IPAMConfig, error)
+	GetIPAMConfig(ctx context.Context) (*IPAMConfig, error)
 
 	// SetIPAMConfig sets global IPAM configuration.  This can only
 	// be done when there are no allocated blocks and IP addresses.

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -41,10 +41,10 @@ const (
 func NewIPAMClient(client bapi.Client, pools PoolAccessorInterface) Interface {
 	return &ipamClient{
 		client: client,
-		pools: pools,
+		pools:  pools,
 		blockReaderWriter: blockReaderWriter{
 			client: client,
-			pools: pools,
+			pools:  pools,
 		},
 	}
 }
@@ -398,7 +398,7 @@ func (c ipamClient) releaseIPsFromBlock(ctx context.Context, ips []net.IP, block
 }
 
 func (c ipamClient) assignFromExistingBlock(
-	ctx context.Context, blockCIDR net.IPNet, num int, handleID *string, 
+	ctx context.Context, blockCIDR net.IPNet, num int, handleID *string,
 	attrs map[string]string, host string, affCheck bool,
 ) ([]net.IP, error) {
 	// Limit number of retries.

--- a/lib/ipam/randomblock_test.go
+++ b/lib/ipam/randomblock_test.go
@@ -19,8 +19,8 @@ import (
 	"net"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
@@ -28,7 +28,7 @@ import (
 var _ = Describe("Random Block Generator", func() {
 
 	DescribeTable("Test random block generator with different CIDRs",
-		func (cidr string) {
+		func(cidr string) {
 			poolTest(cidr)
 		},
 
@@ -58,13 +58,13 @@ func poolTest(cidr string) {
 			ip, sn, err := net.ParseCIDR(blk.String())
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf( "Getting block and checking IP is within block: %s\n", blk.String()))
+			By(fmt.Sprintf("Getting block and checking IP is within block: %s\n", blk.String()))
 			for ip := ip.Mask(sn.Mask); sn.Contains(ip); increment(ip) {
 				Expect(pool.Contains(ip)).To(BeTrue())
 			}
 		}
 
-		By(fmt.Sprintf( "Checkig the block count has the correct number of blocka"))
+		By(fmt.Sprintf("Checkig the block count has the correct number of blocka"))
 		numBlocks := new(big.Int)
 		numBlocks.Div(numIP, big.NewInt(blockSize))
 		Expect(blockCount).To(Equal(numBlocks))

--- a/lib/names/names_suite_test.go
+++ b/lib/names/names_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "names Suite")
+}

--- a/lib/names/workloadendpoint.go
+++ b/lib/names/workloadendpoint.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"strings"
+
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+// WorkloadEndpointIdentifiers is a collection of identifiers that are used to uniquely
+// identify a WorkloadEndpoint resource.  Since a resource is identified by a single
+// name field, Calico requires the name to be constructed in a very specific format.
+// The format is dependent on the Orchestrator type:
+// -  k8s:  <node>-k8s-<pod>-<endpoint>
+// -  cni:  <node>-cni-<containerID>-<endpoint>
+// -  libnetwork:  <node>-libnetwork-libnetwork-<endpoint>
+// -  (other):  <node>-<orchestrator>-<workload>-<endpoint>
+//
+// Each parameter cannot start or end with a dash (-), and dashes within the parameter
+// will be escaped to a double-dash (--) in the constructed name.
+//
+// List queries allow for prefix lists (for non-KDD), the client should verify that
+// then items returned in the list match the supplied identifiers using the
+// NameMatches() method.  This is necessary because a prefix match may return endpoints
+// that do not exactly match the required identifiers.  For example , suppose you are
+// querying endpoints with node=node1, orch=k8s, pod=pod and endpoints is wild carded:
+// -  The name prefix would be `node1-k8s-pod-`
+// -  A list query using that prefix would also return endpoints with, for example,
+//    a pod call "pod-1", because the name of the endpoint might be `node1-k8s-pod--1-eth0`
+//    which matches the required name prefix.
+//
+// The Node and Orchestrator are always required for both prefix and non-prefix name
+// construction.
+type WorkloadEndpointIdentifiers struct {
+	Node         string
+	Orchestrator string
+	Endpoint     string
+	Workload     string
+	Pod          string
+	ContainerID  string
+}
+
+// NameMatches returns true if the supplied WorkloadEndpoint name matches the
+// supplied identifiers.
+// This will return an error if the identifiers are not valid.
+func (ids WorkloadEndpointIdentifiers) NameMatches(name string) (bool, error) {
+	// Extract the required segments for this orchestrator type.
+	req, err := ids.getSegments()
+	if err != nil {
+		return false, err
+	}
+
+	// Extract the parameters from the name.
+	parts := extractDashSeparatedParms(name, len(req))
+	if len(parts) == 0 {
+		return false, nil
+	}
+
+	// Check each name segment for a non-match.
+	for i, r := range req {
+		if r.value != "" && r.value != parts[i] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// CalculateWorkloadEndpointName calculates the expected name for a workload
+// endpoint given the supplied Spec.  Calico requires a precise naming convention
+// for workload endpoints that is based on orchestrator and various other orchestrator
+// specific parameters.
+//
+// If allowPrefix is true, we construct the name prefix up to the last specified index
+// and terminate with a dash.
+func (ids WorkloadEndpointIdentifiers) CalculateWorkloadEndpointName(allowPrefix bool) (string, error) {
+	req, err := ids.getSegments()
+	if err != nil {
+		return "", err
+	}
+
+	parts := []string{}
+	for _, s := range req {
+		part := ""
+
+		if len(s.value) == 0 {
+			// This segment has no value associated with it.
+			if !allowPrefix {
+				// We are not allowing prefixes.  This is an error scenario
+				return "", cerrors.ErrorValidation{
+					ErroredFields: []cerrors.ErroredField{
+						{Name: s.field, Value: s.value, Reason: "field should be assigned"},
+					},
+				}
+			}
+
+			// We are allowing prefixes, so return the prefix that we have constructed thus far,
+			// terminating with a "-".
+			return strings.Join(parts, "-") + "-", nil
+		}
+
+		part, ef := escapeDashes(s)
+		if ef != nil {
+			return "", cerrors.ErrorValidation{ErroredFields: []cerrors.ErroredField{*ef}}
+		}
+		parts = append(parts, part)
+	}
+
+	// We have extracted all of the required segments, join the segments with a "-" and
+	// return that as the name.
+	return strings.Join(parts, "-"), nil
+}
+
+// getSegments returns the ID segments specific to the orchestrator.
+func (ids WorkloadEndpointIdentifiers) getSegments() ([]segment, error) {
+	node := segment{value: ids.Node, field: "node", structField: "Node"}
+	orch := segment{value: ids.Orchestrator, field: "orchestrator", structField: "Orchestrator"}
+	cont := segment{value: ids.ContainerID, field: "containerID", structField: "ContainerID"}
+	pod := segment{value: ids.Pod, field: "pod", structField: "Pod"}
+	endp := segment{value: ids.Endpoint, field: "endpoint", structField: "Endpoint"}
+	workl := segment{value: ids.Workload, field: "workload", structField: "Workload"}
+
+	// Node and Orchestrator are *always* required.
+	if len(node.value) == 0 {
+		return nil, cerrors.ErrorValidation{
+			ErroredFields: []cerrors.ErroredField{
+				{Name: node.field, Reason: "field should be assigned"},
+			},
+		}
+	}
+	if len(orch.value) == 0 {
+		return nil, cerrors.ErrorValidation{
+			ErroredFields: []cerrors.ErroredField{
+				{Name: orch.field, Reason: "field should be assigned"},
+			},
+		}
+	}
+
+	// Extract the segment values based on the orchestrator.
+	var segments []segment
+	switch orch.value {
+	case "k8s":
+		segments = []segment{node, orch, pod, endp}
+	case "cni":
+		segments = []segment{node, orch, cont, endp}
+	case "libnetwork":
+		segments = []segment{node, orch, orch, endp}
+	default:
+		segments = []segment{node, orch, workl, endp}
+	}
+
+	return segments, nil
+}
+
+// Segment contains the information of a single name segment.  The field names
+// are geared towards the struct definition of the corresponding resource.
+type segment struct {
+	// The value of the field.
+	value string
+	// The JSON/YAML name of the corresponding field in the WorkloadEndpointSpec
+	field string
+	// The structure name of the corresponding field in the WorkloadEndpointSpec
+	structField string
+}
+
+// escapeDashes replaces a single dash with a double dash.  This type of escaping is
+// used for names constructed by joining a set of names with dashes - it assumes that
+// each name segment cannot begin or end in a dash.
+func escapeDashes(seg segment) (string, *cerrors.ErroredField) {
+	if seg.value[0] == '-' {
+		return "", &cerrors.ErroredField{Name: seg.field, Value: seg.value, Reason: "field must not begin with a '-'"}
+	}
+	if seg.value[len(seg.value)-1] == '-' {
+		return "", &cerrors.ErroredField{Name: seg.field, Value: seg.value, Reason: "field must not end with a '-'"}
+	}
+	return strings.Replace(seg.value, "-", "--", -1), nil
+}
+
+// Extract the dash separated parms from the name.  Each parm will have had their dashes escaped,
+// this also removes that escaping.  Returns nil if the parameters could not be extracted.
+func extractDashSeparatedParms(name string, numParms int) []string {
+	// The name must be at least as long as the number of parameters plus the separators.
+	if len(name) < (2*numParms - 1) {
+		return nil
+	}
+
+	parts := []string{}
+	lastDash := -1
+	for i := 1; i < len(name); i++ {
+		// Skip non-dashes.
+		if name[i] != '-' {
+			continue
+		}
+		// Skip over double dashes
+		if i < len(name)-1 && name[i+1] == '-' {
+			i++
+			continue
+		}
+		// This is a dash separator.
+		parts = append(parts, strings.Replace(name[lastDash+1:i], "--", "-", -1))
+		lastDash = i
+	}
+	// Add the last segment.
+	parts = append(parts, strings.Replace(name[lastDash+1:], "--", "-", -1))
+
+	// We should have extracted the correct number of name segments.
+	if len(parts) != numParms {
+		return nil
+	}
+
+	return parts
+}

--- a/lib/names/workloadendpoint_test.go
+++ b/lib/names/workloadendpoint_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names_test
+
+import (
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/names"
+)
+
+var _ =	DescribeTable("WorkloadEndpoint name construction, fully qualified names",
+	func(ids names.WorkloadEndpointIdentifiers, expectedName string, expectedErroredField string) {
+		name, err := ids.CalculateWorkloadEndpointName(false)
+		if len(expectedErroredField) != 0 {
+			Expect(name).To(Equal(""))
+			Expect(err).To(HaveOccurred())
+			Expect(err.(cerrors.ErrorValidation).ErroredFields).To(HaveLen(1))
+			Expect(err.(cerrors.ErrorValidation).ErroredFields[0].Name).To(Equal(expectedErroredField))
+		} else {
+			Expect(name).To(Equal(expectedName))
+		}
+	},
+	Entry("Valid k8s endpoint", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-pod--name-eth0", ""),
+	Entry("Valid CNI (non-k8s) endpoint", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "cni",
+		ContainerID:  "abcdefa0123456",
+		Endpoint:     "eth0",
+	}, "node--1-cni-abcdefa0123456-eth0", ""),
+	Entry("Valid libnetwork endpoint", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "libnetwork",
+		Endpoint:     "abcdefgh",
+	}, "node--1-libnetwork-libnetwork-abcdefgh", ""),
+	Entry("Valid unknown orchestrator endpoint", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "foo",
+		Workload:     "foo-foo",
+		Endpoint:     "abcdefgh",
+	}, "node--1-foo-foo--foo-abcdefgh", ""),
+	Entry("Missing orchestrator and workload but other unknown orchestrator fields are present", names.WorkloadEndpointIdentifiers{
+		Node:     "node-1",
+		Pod:      "pod-name",
+		Endpoint: "eth0",
+	}, "", "orchestrator"),
+	Entry("Missing k8s Pod", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Endpoint:     "eth0",
+	}, "", "pod"),
+	Entry("CNI container ID starts with a -", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "cni",
+		ContainerID:  "-abcdefa0123456",
+		Endpoint:     "eth0",
+	}, "", "containerID"),
+	Entry("Unknown orchestrator workload ends with a -", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "foo",
+		Workload:     "foo-foo-",
+		Endpoint:     "abcdefgh",
+	}, "", "workload"),
+)
+
+var _ =DescribeTable("WorkloadEndpoint name construction, name prefix",
+	func(ids names.WorkloadEndpointIdentifiers, expectedName string, expectedErroredField string) {
+		name, err := ids.CalculateWorkloadEndpointName(true)
+		if len(expectedErroredField) != 0 {
+			Expect(name).To(Equal(""))
+			Expect(err).To(HaveOccurred())
+			Expect(err.(cerrors.ErrorValidation).ErroredFields).To(HaveLen(1))
+			Expect(err.(cerrors.ErrorValidation).ErroredFields[0].Name).To(Equal(expectedErroredField))
+		} else {
+			Expect(name).To(Equal(expectedName))
+		}
+	},
+	Entry("Valid k8s endpoint", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-pod--name-eth0", ""),
+	Entry("Missing  workload but other unknown orchestrator fields are present", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "foo",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "node--1-foo-", ""),
+	Entry("Missing k8s Pod", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-", ""),
+	Entry("CNI container ID starts with a -", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "cni",
+		ContainerID:  "-abcdefa0123456",
+		Endpoint:     "eth0",
+	}, "", "containerID"),
+	Entry("Unknown orchestrator, workload ends with a -", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "foo",
+		Workload:     "foo-foo-",
+		Endpoint:     "abcdefgh",
+	}, "", "workload"),
+	Entry("Node is missing", names.WorkloadEndpointIdentifiers{
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "", "node"),
+	Entry("Orchestrator is missing", names.WorkloadEndpointIdentifiers{
+		Node:     "node-1",
+		Pod:      "pod-name",
+		Endpoint: "eth0",
+	}, "", "orchestrator"),
+)
+
+var _ = DescribeTable("WorkloadEndpoint name matching",
+	func(ids names.WorkloadEndpointIdentifiers, name string, expectValid bool, expectedErroredField string) {
+		valid, err := ids.NameMatches(name)
+		if len(expectedErroredField) != 0 {
+			Expect(valid).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(err.(cerrors.ErrorValidation).ErroredFields).To(HaveLen(1))
+			Expect(err.(cerrors.ErrorValidation).ErroredFields[0].Name).To(Equal(expectedErroredField))
+		} else {
+			Expect(valid).To(Equal(expectValid))
+		}
+	},
+	Entry("Node is missing", names.WorkloadEndpointIdentifiers{
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "", false, "node"),
+	Entry("Orchestrator is missing", names.WorkloadEndpointIdentifiers{
+		Node:     "node-1",
+		Pod:      "pod-name",
+		Endpoint: "eth0",
+	}, "", false, "orchestrator"),
+	Entry("Valid k8s endpoint and matching name", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-pod--name-eth0", true, ""),
+	Entry("Fully qualified k8s endpoint, non-matching Endpoint", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-pod--name-eth", false, ""),
+	Entry("CNI endpoint ids missing container ID but name matches remaining ids", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "cni",
+		Endpoint:     "eth0",
+	}, "node--1-cni-orchestratorid-eth0", true, ""),
+	Entry("Fully qualified CNI endpoint and matching name", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "cni",
+		ContainerID:  "abcde",
+		Endpoint:     "eth0",
+	}, "node--1-cni-abcde-eth0", true, ""),
+	Entry("Fully qualified CNI endpoint and non-matching container", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "cni",
+		ContainerID:  "abcde",
+		Endpoint:     "eth0",
+	}, "node--1-cni-abcdef-eth0", false, ""),
+	Entry("Too few name segments", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-", false, ""),
+	Entry("Too many name segments", names.WorkloadEndpointIdentifiers{
+		Node:         "node-1",
+		Orchestrator: "k8s",
+		Pod:          "pod",
+		Endpoint:     "eth0",
+	}, "node--1-k8s-pod-eth0-extra", false, ""),
+)
+


### PR DESCRIPTION
This will be useful for the CNI plugin integration and other integrations in the future.

This contains methods to construct the WEP name from a set of Identifiers, and to compare a WEP name against the set of identifiers (which will be required if you are doing a prefix list).