### PR TITLE
Add watcher sync event

### DIFF
--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -184,6 +184,7 @@ const (
 	WatchModified WatchEventType = "MODIFIED"
 	WatchDeleted  WatchEventType = "DELETED"
 	WatchError    WatchEventType = "ERROR"
+	WatchSynced   WatchEventType = "SYNCED"
 )
 
 // Event represents a single event to a watched resource.
@@ -198,6 +199,13 @@ type WatchEvent struct {
 	//  * If Type is Deleted or Error: nil
 	Old *model.KVPair
 	New *model.KVPair
+
+	// Revision is set on a Sync event.  A Synced event is only sent for watchers
+	// that do not specify a Revision to watch from.  In this case, the watcher
+	// first lists the data at the current revision and sends WatchAdded events for
+	// each resource, followed by a Synced event specifying the current revision, and
+	// then watch events following on from the Synced event Revision.
+	Revision string
 
 	// The error, if EventType is Error.
 	Error error

--- a/lib/backend/etcdv3/watcher.go
+++ b/lib/backend/etcdv3/watcher.go
@@ -155,6 +155,14 @@ func (wc *watcher) listCurrent() error {
 			New:  kv,
 		})
 	}
+
+	// We've finished listing the current data.  Send a sync'd event to let the listeners
+	// know they are now watching change events.
+	wc.sendEvent(&api.WatchEvent{
+		Type: api.WatchSynced,
+		Revision: list.Revision,
+	})
+
 	return nil
 }
 

--- a/lib/clientv2/bgppeer_e2e_test.go
+++ b/lib/clientv2/bgppeer_e2e_test.go
@@ -365,6 +365,9 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 
@@ -391,6 +394,9 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 				{
 					Type:   watch.Added,
 					Object: outRes3,
+				},
+				{
+					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -369,6 +369,9 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 
@@ -395,6 +398,9 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				{
 					Type:   watch.Added,
 					Object: outRes3,
+				},
+				{
+					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/hostendpoint_e2e_test.go
+++ b/lib/clientv2/hostendpoint_e2e_test.go
@@ -362,6 +362,9 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 
@@ -388,6 +391,9 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 				{
 					Type:   watch.Added,
 					Object: outRes3,
+				},
+				{
+					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/ippool_e2e_test.go
+++ b/lib/clientv2/ippool_e2e_test.go
@@ -366,6 +366,9 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 
@@ -392,6 +395,9 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 				{
 					Type:   watch.Added,
 					Object: outRes3,
+				},
+				{
+					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/networkpolicy_e2e_test.go
+++ b/lib/clientv2/networkpolicy_e2e_test.go
@@ -381,6 +381,9 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -365,6 +365,9 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 
@@ -391,6 +394,9 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 				{
 					Type:   watch.Added,
 					Object: outRes3,
+				},
+				{
+					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/profile_e2e_test.go
+++ b/lib/clientv2/profile_e2e_test.go
@@ -364,6 +364,9 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 
@@ -390,6 +393,9 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 				{
 					Type:   watch.Added,
 					Object: outRes3,
+				},
+				{
+					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/resources.go
+++ b/lib/clientv2/resources.go
@@ -327,6 +327,7 @@ func (w *watcher) terminate() {
 func (w *watcher) convertEvent(backendEvent bapi.WatchEvent) watch.Event {
 	apiEvent := watch.Event{
 		Error: backendEvent.Error,
+		ResourceVersion: backendEvent.Revision,
 	}
 	switch backendEvent.Type {
 	case bapi.WatchError:
@@ -337,6 +338,8 @@ func (w *watcher) convertEvent(backendEvent bapi.WatchEvent) watch.Event {
 		apiEvent.Type = watch.Deleted
 	case bapi.WatchModified:
 		apiEvent.Type = watch.Modified
+	case bapi.WatchSynced:
+		apiEvent.Type = watch.Synced
 	}
 
 	if backendEvent.Old != nil {

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -390,6 +390,9 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 					Type:   watch.Added,
 					Object: outRes3,
 				},
+				{
+					Type:	watch.Synced,
+				},
 			})
 			testWatcher3.Stop()
 

--- a/lib/testutils/resources.go
+++ b/lib/testutils/resources.go
@@ -157,6 +157,13 @@ func (t *testResourceWatcher) ExpectEvents(kind string, events []watch.Event) {
 		} else {
 			Expect(t.events[i].Previous).To(BeNil())
 		}
+
+		// For synced events we can only check that the event contained a resource version
+		// but not what the resource version was (at least it's difficult to assert that in
+		// case other events in the datastore are changing the revision).
+		if t.events[i].Type == watch.Synced {
+			Expect(t.events[i].ResourceVersion).ToNot(Equal(""))
+		}
 	}
 
 	// Remove the events we've already validated.

--- a/lib/watch/interface.go
+++ b/lib/watch/interface.go
@@ -34,10 +34,29 @@ type Interface interface {
 type EventType string
 
 const (
+	// Event type:
+	// Added
+	// * a new Object has been added.  If the Watcher does not have a specific
+	//   ResourceVersion to watch from, existing entries will first be listed
+	//   and propagated as "Added" events.
+	// Modified
+	// * an Object has been modified.
+	// Deleted
+	// * an Object has been deleted
+	// Error
+	// * an error has occurred.  If the error is terminating, the results channel
+	//   will be closed.
+	// Synced
+	// * If the Watcher does not have a specific ResourceVersion to watch from,
+	//   existing entries will first be listed.  The current entries are sent as
+	//   "Added" events followed by a Synced Event, and then followed by events from
+	//   watching the data.  A Synced event will specify the ResourceVersion from which
+	//   the watch begins.
 	Added    EventType = "ADDED"
 	Modified EventType = "MODIFIED"
 	Deleted  EventType = "DELETED"
 	Error    EventType = "ERROR"
+	Synced   EventType = "SYNCED"
 
 	DefaultChanSize int32 = 100
 )
@@ -47,13 +66,17 @@ type Event struct {
 	Type EventType
 
 	// Previous is:
-	// * If Type is Added or Error: nil
+	// * If Type is Added, Error or Synced: nil
 	// * If Type is Modified or Deleted: the previous state of the object
 	// Object is:
 	//  * If Type is Added or Modified: the new state of the object.
-	//  * If Type is Deleted or Error: nil
+	//  * If Type is Deleted, Error or Synced: nil
 	Previous runtime.Object
 	Object   runtime.Object
+
+	// ResourceVersion is only set when Type is Synced.  See EventType definitions
+	// for details.
+	ResourceVersion string
 
 	// The error, if EventType is Error.
 	Error error


### PR DESCRIPTION
This PR adds a watcher synced event.  This allows the consumer to know when the current set of data has finished being listed and the watch has begun.

This only effects watchers that watch from an unspecified ResourceVersion - for this scenario the watcher first returns all of the configuration at the current resource version.

Reason I'm adding this is a little forward thinking to the confd watcher and the etcdv3 syncer code.  I think this will make the syncer implementation much easier *and* I think i'll be useful for maintaining state in confd.