### PR TITLE
Implemented interface definitions for BGP Config resource

### DIFF
--- a/lib/apiv2/bgpconfig.go
+++ b/lib/apiv2/bgpconfig.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiv2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+const (
+	KindBGPConfiguration     = "BGPConfiguration"
+	KindBGPConfigurationList = "BGPConfigurationList"
+)
+
+// BGPConfiguration contains the configuration for any BGP routing.
+type BGPConfiguration struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// Specification of the BGPConfiguration.
+	Spec BGPConfigurationSpec `json:"spec,omitempty"`
+}
+
+// TODO: Add validation on LogSeverityScreen for valid values
+// BGPConfigurationSpec contains the values of the BGP configuration.
+type BGPConfigurationSpec struct {
+	LogSeverityScreen     string                `json:"logSeverityScreen,omitempty" validate:"omitempty"`
+	NodeToNodeMeshEnabled *bool                 `json:"nodeToNodeMeshEnabled,omitempty" validate:"omitempty"`
+	DefaultNodeASNumber   *numorstring.ASNumber `json:"defaultNodeASNumber,omitempty" validate:"omitempty"`
+}
+
+// BGPConfigurationList contains a list of BGPConfiguration resources.
+type BGPConfigurationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []BGPConfiguration `json:"items"`
+}
+
+// New BGPConfiguration creates a new (zeroed) BGPConfiguration struct with the TypeMetadata
+// initialized to the current version.
+func NewBGPConfiguration() *BGPConfiguration {
+	return &BGPConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KindBGPConfiguration,
+			APIVersion: GroupVersionCurrent,
+		},
+	}
+}
+
+// NewBGPConfigurationList creates a new 9zeroed) BGPConfigurationList struct with the TypeMetadata
+// initialized to the current version.
+func NewBGPConfigurationLits() *BGPConfigurationList {
+	return &BGPConfigurationList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KindBGPConfigurationList,
+			APIVersion: GroupVersionCurrent,
+		},
+	}
+}

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -31,6 +31,7 @@ var (
 	matchNamespacedResource = regexp.MustCompile("^/calico/resources/v2/([^/]+)/([^/]+)/([^/]+)$")
 	kindToType              = map[string]reflect.Type{
 		strings.ToLower(apiv2.KindBGPPeer):             reflect.TypeOf(apiv2.BGPPeer{}),
+		strings.ToLower(apiv2.KindBGPConfiguration):    reflect.TypeOf(apiv2.BGPConfiguration{}),
 		strings.ToLower(apiv2.KindGlobalNetworkPolicy): reflect.TypeOf(apiv2.GlobalNetworkPolicy{}),
 		strings.ToLower(apiv2.KindHostEndpoint):        reflect.TypeOf(apiv2.HostEndpoint{}),
 		strings.ToLower(apiv2.KindIPPool):              reflect.TypeOf(apiv2.IPPool{}),

--- a/lib/clientv2/bgpconfig.go
+++ b/lib/clientv2/bgpconfig.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2
+
+import (
+	"context"
+	"errors"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+// BGPConfigurationInterface has methods to work with BGPConfiguration resources.
+type BGPConfigurationInterface interface {
+	Create(ctx context.Context, res *apiv2.BGPConfiguration, opts options.SetOptions) (*apiv2.BGPConfiguration, error)
+	Update(ctx context.Context, res *apiv2.BGPConfiguration, opts options.SetOptions) (*apiv2.BGPConfiguration, error)
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.BGPConfiguration, error)
+	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.BGPConfiguration, error)
+	List(ctx context.Context, opts options.ListOptions) (*apiv2.BGPConfigurationList, error)
+	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// bgpConfigurations implements BGPConfigurationInterface
+type bgpConfigurations struct {
+	client client
+}
+
+// Create takes the representation of a BGpConfiguration and creates it.
+// Returns the stored representation of the BGPConfiguration, and an error
+// if there is any.
+func (r bgpConfigurations) Create(ctx context.Context, res *apiv2.BGPConfiguration, opts options.SetOptions) (*apiv2.BGPConfiguration, error) {
+	if err := r.ValidateDefaultOnlyFields(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindBGPConfiguration, res)
+	if out != nil {
+		return out.(*apiv2.BGPConfiguration), err
+	}
+	return nil, err
+}
+
+// Update takes the representation of a BGPConfiguration and updates it.
+// Returns the stored representation of the BGPConfiguration, and an error
+// if there is any.
+func (r bgpConfigurations) Update(ctx context.Context, res *apiv2.BGPConfiguration, opts options.SetOptions) (*apiv2.BGPConfiguration, error) {
+	// Check that NodeToNodeMeshEnabled and DefaultNodeASNumber are set. Can only be set on "default".
+	if err := r.ValidateDefaultOnlyFields(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindBGPConfiguration, res)
+	if out != nil {
+		return out.(*apiv2.BGPConfiguration), err
+	}
+	return nil, err
+}
+
+// Delete takes name of the BGPConfiguration and deletes it. Returns an
+// error if one occurs.
+func (r bgpConfigurations) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.BGPConfiguration, error) {
+	// Check if we are trying to delete "default". Prevent deletion for now.
+	if name == "default" {
+		return nil, errors.New("Cannot delete default BGP Configuration.")
+	}
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindBGPConfiguration, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.BGPConfiguration), err
+	}
+	return nil, err
+}
+
+// Get takes name of the BGPConfiguration, and returns the corresponding
+// BGPConfiguration object, and an error if there is any.
+func (r bgpConfigurations) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.BGPConfiguration, error) {
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindBGPConfiguration, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.BGPConfiguration), err
+	}
+	return nil, err
+}
+
+// List returns the list of BGPConfiguration objects that match the supplied options.
+func (r bgpConfigurations) List(ctx context.Context, opts options.ListOptions) (*apiv2.BGPConfigurationList, error) {
+	res := &apiv2.BGPConfigurationList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindBGPConfiguration, apiv2.KindBGPConfigurationList, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Watch returns a watch.Interface that watches the BGPConfiguration that
+// match the supplied options.
+func (r bgpConfigurations) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	return r.client.resources.Watch(ctx, opts, apiv2.KindBGPConfiguration)
+}
+
+func (r bgpConfigurations) ValidateDefaultOnlyFields(res *apiv2.BGPConfiguration) error {
+	errFields := []cerrors.ErroredField{}
+	if res.ObjectMeta.GetName() != "default" {
+		if res.Spec.NodeToNodeMeshEnabled != nil {
+			errFields = append(errFields, cerrors.ErroredField{
+				Name:   "BGPConfiguration.Spec.NodeToNodeMeshEnabled",
+				Reason: "Cannot set nodeToNodeMeshEnabled on a non default BGP Configuration.",
+			})
+		}
+
+		if res.Spec.DefaultNodeASNumber != nil {
+			errFields = append(errFields, cerrors.ErroredField{
+				Name:   "BGPConfiguration.Spec.DefaultNodeASNumber",
+				Reason: "Cannot set defaultNodeASNumber on a non default BGP Configuration.",
+			})
+		}
+	}
+
+	if len(errFields) > 0 {
+		return cerrors.ErrorValidation{
+			ErroredFields: errFields,
+		}
+	}
+
+	return nil
+}

--- a/lib/clientv2/bgpconfig_e2e_test.go
+++ b/lib/clientv2/bgpconfig_e2e_test.go
@@ -1,0 +1,457 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	nameDefault := "default"
+	name1 := "bgpconfig-1"
+	name2 := "bgpconfig-2"
+	ptrTrue := true
+	ptrFalse := false
+	nodeASNumber1 := numorstring.ASNumber(6512)
+	nodeASNumber2 := numorstring.ASNumber(6511)
+	specDefault1 := apiv2.BGPConfigurationSpec{
+		LogSeverityScreen:     "Info",
+		NodeToNodeMeshEnabled: &ptrTrue,
+		DefaultNodeASNumber:   &nodeASNumber1,
+	}
+	specDefault2 := apiv2.BGPConfigurationSpec{
+		LogSeverityScreen:     "Warning",
+		NodeToNodeMeshEnabled: &ptrFalse,
+		DefaultNodeASNumber:   &nodeASNumber2,
+	}
+	specInfo := apiv2.BGPConfigurationSpec{
+		LogSeverityScreen: "Info",
+	}
+	specDebug := apiv2.BGPConfigurationSpec{
+		LogSeverityScreen: "Debug",
+	}
+
+	DescribeTable("BGPConfiguration e2e CRUD tests",
+		func(name1, name2 string, specInfo, specDebug apiv2.BGPConfigurationSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the BGPConfiguration before it is created")
+			res, outError := c.BGPConfigurations().Update(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: nameDefault, ResourceVersion: "1234"},
+				Spec:       specDefault1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + nameDefault + ")"))
+
+			By("Attempting to creating a new BGPConfiguration with name1/specInfo and a non-empty ResourceVersion")
+			res, outError = c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       specInfo,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new BGPConfiguration with name1/specInfo")
+			res1, outError := c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       specInfo,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same BGPConfiguration with name1 but with specDebug")
+			res1, outError = c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       specDebug,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: BGPConfiguration(" + name1 + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting BGPConfiguration (name1) and comparing the output against specInfo")
+			res, outError = c.BGPConfigurations().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Getting BGPConfiguration (name2) before it is created")
+			res, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+
+			By("Listing all the BGPConfigurations, expecting a single result with name1/specInfo")
+			outList, outError := c.BGPConfigurations().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+
+			By("Creating a new BGPConfiguration with name2/specDebug")
+			res2, outError := c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       specDebug,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name2, specDebug)
+
+			By("Getting BGPConfiguration (name2) and comparing the output against specDebug")
+			res, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res2, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name2, specDebug)
+			Expect(res.ResourceVersion).To(Equal(res2.ResourceVersion))
+
+			By("Listing all the BGPConfigurations, expecting a two results with name1/specInfo and name2/specDebug")
+			outList, outError = c.BGPConfigurations().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name2, specDebug)
+
+			By("Updating BGPConfiguration name1 with specDebug")
+			res1.Spec = specDebug
+			res1, outError = c.BGPConfigurations().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specDebug)
+
+			// Track the version of the updated name1 data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating BGPConfiguration name1 without specifying a resource version")
+			res1.Spec = specInfo
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.BGPConfigurations().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating BGPConfiguration name1 using the previous resource version")
+			res1.Spec = specInfo
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.BGPConfigurations().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: BGPConfiguration(" + name1 + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting BGPConfiguration (name1) with the original resource version and comparing the output against specInfo")
+			res, outError = c.BGPConfigurations().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting BGPConfiguration (name1) with the updated resource version and comparing the output against specDebug")
+			res, outError = c.BGPConfigurations().Get(ctx, name1, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specDebug)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing BGPConfigurations with the original resource version and checking for a single result with name1/specInfo")
+			outList, outError = c.BGPConfigurations().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specInfo)
+
+			By("Listing BGPConfigurations with the latest resource version and checking for two results with name1/specDebug and name2/specDebug")
+			outList, outError = c.BGPConfigurations().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(2))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specDebug)
+			testutils.ExpectResource(&outList.Items[1], apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name2, specDebug)
+
+			By("Deleting BGPConfiguration (name1) with the old resource version")
+			_, outError = c.BGPConfigurations().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: BGPConfiguration(" + name1 + ")"))
+
+			By("Deleting BGPConfiguration (name1) with the new resource version")
+			dres, outError := c.BGPConfigurations().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, name1, specDebug)
+
+			By("Updating BGPConfiguration name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.BGPConfigurations().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+
+			By("Creating BGPConfiguration name2 with a 2s TTL and waiting for the entry to be deleted")
+			_, outError = c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       specDebug,
+			}, options.SetOptions{TTL: 2 * time.Second})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(1 * time.Second)
+			_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			time.Sleep(2 * time.Second)
+			_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+
+			By("Attempting to deleting BGPConfiguration (name2) again")
+			_, outError = c.BGPConfigurations().Delete(ctx, name2, options.DeleteOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+
+			By("Listing all BGPConfigurations and expecting no items")
+			outList, outError = c.BGPConfigurations().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+			By("Getting BGPConfiguration (name2) and expecting an error")
+			res, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+
+			By("Creating a default BGPConfiguration with node to node mesh enabled and a default AS number")
+			resDefault, outError := c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: nameDefault},
+				Spec:       specDefault1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(resDefault, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, nameDefault, specDefault1)
+
+			By("Updating the default BGPConfiguration with node to node mesh disabled and a different default AS number")
+			resDefault.Spec = specDefault2
+			resDefault, outError = c.BGPConfigurations().Update(ctx, resDefault, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(resDefault, apiv2.KindBGPConfiguration, testutils.ExpectNoNamespace, nameDefault, specDefault2)
+
+			By("Attempting to create a non-default BGPConfiguration with node to node mesh enabled and a default AS number")
+			_, outError = c.BGPConfigurations().Create(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "not-default"},
+				Spec:       specDefault1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+
+			By("Attempting to update BGPConfiguration name1 with node to node mesh enabled and a default AS number")
+			_, outError = c.BGPConfigurations().Update(ctx, &apiv2.BGPConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       specDefault1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+		},
+
+		// Test 1: Pass two fully populated BGPConfigurationSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated BGPConfigurationSpecs", name1, name2, specInfo, specDebug),
+	)
+
+	Describe("BGPConfiguration watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing BGPConfigurations with the latest resource version and checking for two results with name1/specDebug and name2/specDebug")
+			outList, outError := c.BGPConfigurations().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a BGPConfiguration name1/specInfo and storing the response")
+			outRes1, err := c.BGPConfigurations().Create(
+				ctx,
+				&apiv2.BGPConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       specInfo,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Configuring a BGPConfiguration name2/specDebug and storing the response")
+			outRes2, err := c.BGPConfigurations().Create(
+				ctx,
+				&apiv2.BGPConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: name2},
+					Spec:       specDebug,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.BGPConfigurations().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			_, err = c.BGPConfigurations().Delete(ctx, name1, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindBGPConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.BGPConfigurations().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.BGPConfigurations().Update(
+				ctx,
+				&apiv2.BGPConfiguration{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       specInfo,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindBGPConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+			w, err = c.BGPConfigurations().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindBGPConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher2_1.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.BGPConfigurations().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindBGPConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+				{
+					Type: watch.Synced,
+				},
+			})
+			testWatcher3.Stop()
+
+			By("Configuring BGPConfiguration name1/specInfo again and storing the response")
+			outRes1, err = c.BGPConfigurations().Create(
+				ctx,
+				&apiv2.BGPConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: name1},
+					Spec:       specInfo,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.BGPConfigurations().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher4 := testutils.TestResourceWatch(w)
+			defer testWatcher4.Stop()
+			testWatcher4.ExpectEvents(apiv2.KindBGPConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+				{
+					Type: watch.Synced,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher4.ExpectEvents(apiv2.KindBGPConfiguration, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher4.Stop()
+		})
+	})
+})

--- a/lib/clientv2/client.go
+++ b/lib/clientv2/client.go
@@ -112,6 +112,11 @@ func (c client) IPAM() ipam.Interface {
 	return ipam.NewIPAMClient(c.Backend, poolAccessor{})
 }
 
+// BGPConfiguration returns an interface for managing the BGP configuration resources.
+func (c client) BGPConfigurations() BGPConfigurationInterface {
+	return bgpConfigurations{client: c}
+}
+
 type poolAccessor struct {
 	client *client
 }

--- a/lib/clientv2/interface.go
+++ b/lib/clientv2/interface.go
@@ -35,6 +35,8 @@ type Interface interface {
 	BGPPeers() BGPPeerInterface
 	// IPAM returns an interface for managing IP address assignment and releasing.
 	IPAM() ipam.Interface
+	// BGPConfigurations returns an interface for managing the BGP configuration resources.
+	BGPConfigurations() BGPConfigurationInterface
 	// EnsureInitialized is used to ensure the backend datastore is correctly
 	// initialized for use by Calico.  This method may be called multiple times, and
 	// will have no effect if the datastore is already correctly initialized.


### PR DESCRIPTION
## Description
Adding the BGPConfiguration resource as well as the functionality and tests for CRUD operations.

## Todos
- [x] Tests
- [x] Documentation (none required here)
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
