### PR TITLE
[WIP] Add ability to sync using multiple watchers

### DIFF
--- a/lib/apiv2/bgpconfig.go
+++ b/lib/apiv2/bgpconfig.go
@@ -16,7 +16,6 @@ package apiv2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )

--- a/lib/apiv2/bgppeer.go
+++ b/lib/apiv2/bgppeer.go
@@ -16,7 +16,6 @@ package apiv2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )

--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -166,9 +166,11 @@ type WatchInterface interface {
 	// any resources used by the watch.
 	Stop()
 
-	// Returns a chan which will receive all the events. If an error occurs
-	// or Stop() is called, this channel will be closed, in which case the
-	// watch should be completely cleaned up.
+	// Returns a chan which will receive all the events.  This channel is closed when:
+	// -  Stop() is called, or
+	// -  A error of type errors.ErrorWatchTerminated is received.
+	// In both cases the watcher will be cleaned up, and the client should stop receiving
+	// from this channel.
 	ResultChan() <-chan WatchEvent
 
 	// HasTerminated returns true if the watcher has terminated and released all

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -452,23 +451,6 @@ func getKeyValueStrings(d *model.KVPair) (string, string, error) {
 	}
 
 	return key, string(bytes), nil
-}
-
-// etcdToKVPair converts an etcd KeyValue in to model.KVPair.
-func etcdToKVPair(key model.Key, ekv *mvccpb.KeyValue) (*model.KVPair, error) {
-	v, err := model.ParseValue(key, ekv.Value)
-	if err != nil {
-		return nil, cerrors.ErrorDatastoreError{
-			Identifier: key,
-			Err:        err,
-		}
-	}
-
-	return &model.KVPair{
-		Key:      key,
-		Value:    v,
-		Revision: strconv.FormatInt(ekv.ModRevision, 10),
-	}, nil
 }
 
 // parseRevision parses the model.KVPair revision string and converts to the

--- a/lib/backend/etcdv3/watcher.go
+++ b/lib/backend/etcdv3/watcher.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
 )
 
 const (
@@ -91,7 +92,7 @@ func (wc *watcher) watchLoop() {
 		// which will also get the current revision we will start our watch from.
 		if err := wc.listCurrent(); err != nil {
 			log.Errorf("failed to list current with latest state: %v", err)
-			wc.sendError(err)
+			wc.sendError(err, true)
 			return
 		}
 	}
@@ -115,16 +116,17 @@ func (wc *watcher) watchLoop() {
 			// A watch channel error is a terminating event, so exit the loop.
 			err := wres.Err()
 			log.WithError(err).Error("Watch channel error")
-			wc.sendError(err)
+			wc.sendError(err, true)
 			return
 		}
 		for _, e := range wres.Events {
 			// Convert the etcdv3 event to the equivalent Watcher event.  An error
-			// parsing the event is returned as an error.
+			// parsing the event is returned as an error, but don't exit the watcher as
+			// restarting the watcher is unlikely to fix the conversion error.
 			if ae, err := convertWatchEvent(e, wc.list); ae != nil {
 				wc.sendEvent(ae)
 			} else if err != nil {
-				wc.sendError(err)
+				wc.sendError(err, false)
 			}
 		}
 	}
@@ -159,7 +161,7 @@ func (wc *watcher) listCurrent() error {
 	// We've finished listing the current data.  Send a sync'd event to let the listeners
 	// know they are now watching change events.
 	wc.sendEvent(&api.WatchEvent{
-		Type: api.WatchSynced,
+		Type:     api.WatchSynced,
 		Revision: list.Revision,
 	})
 
@@ -181,13 +183,19 @@ func (wc *watcher) terminateWatcher() {
 }
 
 // sendError packages up the error as an event and sends it in the results channel.
-func (wc *watcher) sendError(err error) {
+func (wc *watcher) sendError(err error, terminating bool) {
 	// The response from etcd commands may include a context.Canceled error if the context
 	// was cancelled before completion.  Since with our Watcher we don't include that as
 	// an error type skip over the Canceled error, the error processing in the main
 	// watch thread will terminate the watcher.
 	if err == context.Canceled {
 		return
+	}
+
+	// If this is a terminating error, wrap the error up in an errors.ErrorWatchTerminated
+	// error type.
+	if terminating {
+		err = errors.ErrorWatchTerminated{Err: err}
 	}
 
 	// Wrap the error up in a WatchEvent and use sendEvent to send it.

--- a/lib/backend/watchersyncer/doc.go
+++ b/lib/backend/watchersyncer/doc.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Rawsyncer implements a generic syncer interface that can be used to sync from an
+arbitrary set of Watchers.
+
+The syncer returns data in the version as stored in the backend.
+
+The implementation could easily be ported to work on the main client Watcher which
+would be the preferred approach once all of the entries that we need to watch are
+defined as resource types.
+
+We implement this as a syncer rather than a "multi-watcher", because the syncer
+does not require old state when sending a delete message, and since we have to maintain
+a cache a syncer would have significantly reduced occupancy.
+*/
+package watchersyncer

--- a/lib/backend/watchersyncer/watchercache.go
+++ b/lib/backend/watchersyncer/watchercache.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+type watcherCache struct {
+	logger       *logrus.Entry
+	client       api.Client
+	watch        api.WatchInterface
+	resources    map[string]resourceKey
+	oldResources map[string]resourceKey
+	results      chan<- interface{}
+	hasSynced    bool
+	resourceType ResourceType
+}
+
+type resourceKey struct {
+	revision string
+	key      model.Key
+}
+
+// Create a new watcherCache.
+// Note that the results channel is untyped.  The watcherSyncer expects one of the following
+// types:
+// -  An error
+// -  An api.Update
+// -  A api.SyncStatus (only for the very first InSync notification)
+func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- interface{}) *watcherCache {
+	wc := &watcherCache{
+		logger:       logrus.WithField("ListRoot", model.ListOptionsToDefaultPathRoot(resourceType.ListInterface)),
+		client:       client,
+		resourceType: resourceType,
+		results:      results,
+		resources:    make(map[string]resourceKey, 0),
+	}
+	return wc
+}
+
+// run creates the watcher and loops indefinitely reading from the watcher.
+func (wc *watcherCache) run() {
+	wc.createWatcher()
+	for {
+		select {
+		case event := <-wc.watch.ResultChan():
+			switch event.Type {
+			case api.WatchSynced:
+				wc.handleSyncedWatchEvent()
+			case api.WatchAdded, api.WatchModified:
+				wc.handleAddedOrModifiedWatchEvent(event)
+			case api.WatchDeleted:
+				wc.handleDeletedWatchEvent(event)
+			case api.WatchError:
+				wc.handleErrorWatchEvent(event)
+			}
+		}
+	}
+}
+
+// handleSyncedWatchEvent handles a new sync event.  If this watcher has never been synced then
+// notify the main watcherSyncer that we've synced.  We also send deleted messages for
+// cached resources that were not validated in the sync (i.e. they must have since been
+// deleted).
+func (wc *watcherCache) handleSyncedWatchEvent() {
+	// If this is our first synced event then send a synced notification.  The main
+	// watcherSyncer code will send a Synced event when it has received synced events from
+	// each cache.
+	if !wc.hasSynced {
+		wc.logger.Info("Sending synced update")
+		wc.results <- api.InSync
+		wc.hasSynced = true
+	}
+
+	// If the watcher failed at any time, we end up recreating a watcher and storing off
+	// the current known resources for revalidation.  Now that we have finished the sync,
+	// any of the remaining resources that were not accounted for must have been deleted
+	// and we need to send deleted events for them.
+	numOldResources := len(wc.oldResources)
+	if numOldResources > 0 {
+		wc.logger.WithField("Num", numOldResources).Debug("Sending resync deletes")
+		updates := make([]api.Update, 0, len(wc.oldResources))
+		for _, r := range wc.oldResources {
+			updates = append(updates, api.Update{
+				UpdateType: api.UpdateTypeKVDeleted,
+				KVPair: model.KVPair{
+					Key: r.key,
+				},
+			})
+		}
+		wc.results <- updates
+	}
+	wc.oldResources = nil
+}
+
+// handleAddedOrModifiedWatchEvent sends a New or Updated sync event depending on whether the resource
+// is currently in our cache or not, and whether the revision has changed.
+func (wc *watcherCache) handleAddedOrModifiedWatchEvent(event api.WatchEvent) {
+	// If we don't have a converter function, just process the KVPair without
+	// converting.
+	if wc.resourceType.Converter == nil {
+		wc.handleAddedOrModifiedUpdate(event.New)
+		return
+	}
+
+	// Convert the KVPair.  This returns a slice of KVPairs, and any with a nil value
+	// should trigger deletion events instead.
+	rs, err := wc.resourceType.Converter.ConvertKVPair(event.New)
+	for _, r := range rs {
+		if r.Value == nil {
+			wc.handleDeletedUpdate(r.Key)
+		} else {
+			wc.handleAddedOrModifiedUpdate(r)
+		}
+	}
+
+	if err != nil {
+		wc.results <- err
+	}
+}
+
+// handleAddedOrModifiedUpdate handles a single Added or Modified update request.
+// Whether we send an Added or Modified depends on whether we have already sent
+// an added notification for this resource.
+func (wc *watcherCache) handleAddedOrModifiedUpdate(kvp *model.KVPair) {
+	thisKey := kvp.Key
+	thisKeyString := thisKey.String()
+	thisRevision := kvp.Revision
+	wc.handleResync(thisKeyString)
+
+	// If the resource is already in our map, then this is a modified event.  Check the
+	// revision to see if we actually need to send an update.
+	if resource, ok := wc.resources[thisKeyString]; ok {
+		if resource.revision == thisRevision {
+			// No update to revision, so no event to send.
+			wc.logger.WithField("Key", thisKeyString).Debug("Entry not modified")
+			return
+		}
+		// Resource is modified, send an update event and store the latest revision.
+		wc.logger.WithField("Key", thisKeyString).Debug("Entry modified")
+		wc.results <- []api.Update{{
+			UpdateType: api.UpdateTypeKVUpdated,
+			KVPair:     *kvp,
+		}}
+		resource.revision = thisRevision
+		wc.resources[thisKeyString] = resource
+		return
+	}
+
+	// The resource has not been seen before, so send a new event, and store the
+	// current revision.
+	wc.logger.WithField("Key", thisKeyString).Debug("Entry added")
+	wc.results <- []api.Update{{
+		UpdateType: api.UpdateTypeKVNew,
+		KVPair:     *kvp,
+	}}
+	wc.resources[thisKeyString] = resourceKey{
+		revision: thisRevision,
+		key:      thisKey,
+	}
+}
+
+// handleDeletedWatchEvent sends a deleted event and removes the resource key from our cache.
+func (wc *watcherCache) handleDeletedWatchEvent(event api.WatchEvent) {
+	// If we don't have a converter function, just process the event without
+	// converting.
+	if wc.resourceType.Converter == nil {
+		wc.handleDeletedUpdate(event.Old.Key)
+		return
+	}
+
+	// Convert the Key.  This returns a slice of Keys which should all be deleted.  We only actually
+	// send delete updates if we have previously send an Added event.
+	ks, err := wc.resourceType.Converter.ConvertKey(event.Old.Key)
+	for _, k := range ks {
+		wc.handleDeletedUpdate(k)
+	}
+
+	if err != nil {
+		wc.results <- err
+	}
+}
+
+// handleDeletedWatchEvent sends a deleted event and removes the resource key from our cache.
+func (wc *watcherCache) handleDeletedUpdate(key model.Key) {
+	thisKeyString := key.String()
+	wc.handleResync(thisKeyString)
+
+	// If we have seen an added event for this key then send a deleted event and remove
+	// from the cache.
+	if _, ok := wc.resources[thisKeyString]; ok {
+		wc.logger.WithField("Key", thisKeyString).Debug("Entry deleted")
+		wc.results <- []api.Update{{
+			UpdateType: api.UpdateTypeKVDeleted,
+			KVPair: model.KVPair{
+				Key: key,
+			},
+		}}
+		delete(wc.resources, thisKeyString)
+	}
+}
+
+// handleErrorWatchEvent sends the error in the errors channel, and if necessary will
+// trigger a watcher restart.
+func (wc *watcherCache) handleErrorWatchEvent(event api.WatchEvent) {
+	wc.results <- event.Error
+	if _, ok := event.Error.(cerrors.ErrorWatchTerminated); ok {
+		wc.logger.Info("Received watch terminated error - recreate watcher")
+		wc.createWatcher()
+	}
+}
+
+// handleResync performs common processing for events required if a resync is
+// in progress.  This is a no-op if a resync is not in progress, otherwise, it moves
+// the cached resource data from the stored set of resources into the current cache.
+// This allows us to do a mark-and-sweep to send deleted events once the resync is complete
+// for resources that were deleted while we weren't watching.
+func (wc *watcherCache) handleResync(resourceKey string) {
+	if wc.oldResources != nil {
+		if oldResource, ok := wc.oldResources[resourceKey]; ok {
+			wc.logger.WithField("Key", resourceKey).Debug("Marking key as re-processed")
+			wc.resources[resourceKey] = oldResource
+			delete(wc.oldResources, resourceKey)
+		}
+	}
+}
+
+// createWatcher creates a new watcher using the supplied ListOptions
+func (wc *watcherCache) createWatcher() {
+	// Make sure any previous watcher is stopped.
+	if wc.watch != nil {
+		wc.logger.Info("Stopping previous watcher")
+		wc.watch.Stop()
+		wc.watch = nil
+	}
+
+	// Move the current resources over to the oldResources - when we reconnect we'll
+	// move entries back again when we rediscover them.  Whatever is left in the oldResources
+	// after the sync is complete indicates entries that were deleted during our reconnection.
+	if len(wc.oldResources) == 0 {
+		wc.logger.Debug("Storing current resource revisions to validate during resync")
+		wc.oldResources = wc.resources
+	} else {
+		wc.logger.Info("Appending current resource revisions unvalidated revision to validate during resync")
+		for k, v := range wc.resources {
+			wc.oldResources[k] = v
+		}
+	}
+	wc.resources = make(map[string]resourceKey, 0)
+
+	for {
+		w, err := wc.client.Watch(context.Background(), wc.resourceType.ListInterface, "")
+
+		// We created the watcher, so return.
+		if err == nil {
+			wc.logger.Info("Created watcher")
+			wc.watch = w
+			return
+		}
+
+		// Sleep so that we don't tight loop.
+		wc.logger.WithError(err).Debug("Failed to create watcher")
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/lib/backend/watchersyncer/watchersyncer.go
+++ b/lib/backend/watchersyncer/watchersyncer.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+// ResourceType groups together the watch and conversion information for a
+// specific resource type.
+type ResourceType struct {
+	// The ListInterface used to perform a watch on this resource type.
+	ListInterface model.ListInterface
+
+	// An optional converter function used to convert the update event prior to
+	// it being sent in the Syncer.
+	Converter SyncerUpdateConverter
+}
+
+// SyncerUpdateConverter is used to convert a Watch update into one or more additional
+// Syncer updates.
+type SyncerUpdateConverter interface {
+	// ConvertKey converts the original Key from a Watcher update to the equivalent full set
+	// of Keys for the mapped-resources returned on the Syncer.  Used for delete processing
+	// to delete all of the possible mapped keys.  The converter may return any combination
+	// of the return values (including nil for both).
+	ConvertKey(model.Key) ([]model.Key, error)
+
+	// ConvertKVPair converts the original KVPair from a Watcher update to the equivalent set
+	// of KVParis for the mapped-resources returned on the Syncer.  In the case where the configuration
+	// in the original KVPair would indicate deletion of some of the mapped resources, those resources
+	// should still be included in the mapped-KVPairs, but with a nil Value indicating (not present).
+	// The full set of Keys returned in the mapped KVPairs should match those that would be returned
+	// by ConvertKey (for the same resource as input).  The converter may return any combination
+	// of the return values (including nil for both).
+	ConvertKVPair(*model.KVPair) ([]*model.KVPair, error)
+}
+
+// New creates a new multiple Watcher-backed api.Syncer.
+func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks) api.Syncer {
+	rs := &watcherSyncer{
+		watcherCaches: make([]*watcherCache, len(resourceTypes)),
+		results:       make(chan interface{}, 2000),
+		callbacks:     callbacks,
+	}
+	for i, r := range resourceTypes {
+		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results)
+	}
+	return rs
+}
+
+// watcherSyncer implements the api.Syncer interface.
+type watcherSyncer struct {
+	status        api.SyncStatus
+	watcherCaches []*watcherCache
+	results       chan interface{}
+	numSynced     int
+	callbacks     api.SyncerCallbacks
+}
+
+func (rs *watcherSyncer) Start() {
+	go rs.run()
+}
+
+// Send a status update and store the status.
+func (rs *watcherSyncer) sendStatusUpdate(status api.SyncStatus) {
+	log.WithField("Status", status).Info("Sending status update")
+	rs.callbacks.OnStatusUpdated(status)
+	rs.status = status
+}
+
+// run implements the main syncer loop that loops forever receiving watch events and translating
+// to syncer updates.
+func (rs *watcherSyncer) run() {
+	rs.sendStatusUpdate(api.WaitForDatastore)
+	for _, wc := range rs.watcherCaches {
+		go wc.run()
+	}
+
+	var updates []api.Update
+	for {
+		// Block until there is data.
+		result := <-rs.results
+
+		// Process the data - this will append the data in subsequent calls, and action
+		// it if we hit a non-update event.
+		updates := rs.processResult(updates, result)
+
+		// Process remaining entries in the channel in one go.
+		remaining := len(rs.results)
+		for i := 0; i < remaining; i++ {
+			next := <-rs.results
+			updates = rs.processResult(updates, next)
+		}
+
+		// Perform final processing (pass in a nil result) before we hit the blocking
+		// call.
+		updates = rs.processResult(updates, nil)
+	}
+
+}
+
+// Process a result from the result channel.  We don't immediately action updates, but
+// instead start grouping them together so that we can send a larger single update to
+// Felix.
+func (rs *watcherSyncer) processResult(updates []api.Update, result interface{}) []api.Update {
+
+	// Final call of the interation, send any updates if we've collated some.
+	if result == nil {
+		if len(updates) > 0 {
+			rs.callbacks.OnUpdates(updates)
+		}
+		return nil
+	}
+
+	// Switch on the result type.
+	switch r := result.(type) {
+	case []api.Update:
+		// This is an update.  If we don't have previous updates then also check to see
+		// if we need to shift the status into Resync.
+		// We append these updates to the previous if there were any.
+		if len(updates) == 0 {
+			if rs.status == api.WaitForDatastore {
+				rs.sendStatusUpdate(api.ResyncInProgress)
+			}
+			updates = r
+		} else {
+			updates = append(updates, r...)
+		}
+
+	case error:
+		// Received an error.  Firstly, send any updates that we have grouped.
+		if len(updates) > 0 {
+			rs.callbacks.OnUpdates(updates)
+			updates = nil
+		}
+
+		// If this is a parsing error, and if the callbacks support
+		// it, then send the error update.
+		log.WithError(r).Info("Error received in syncer")
+		if ec, ok := rs.callbacks.(api.SyncerParseFailCallbacks); ok {
+			if pe, ok := r.(cerrors.ErrorParsingDatastoreEntry); ok {
+				ec.ParseFailed(pe.RawKey, pe.RawValue)
+			}
+		}
+
+	case api.SyncStatus:
+		// Received a synced event.  If we are still waiting for datastore, send a
+		// ResyncInProgress since at least one watcher has connected.
+		log.Info("Received sync event from watcher")
+		if rs.status == api.WaitForDatastore {
+			rs.sendStatusUpdate(api.ResyncInProgress)
+		}
+
+		// Increment the count of synced events.
+		rs.numSynced++
+
+		// If we have now received synced events from all of our watchers then we are in
+		// sync.  If we have any updates, send them first and then send the status update.
+		if rs.numSynced == len(rs.watcherCaches) {
+			if len(updates) > 0 {
+				rs.callbacks.OnUpdates(updates)
+				updates = nil
+			}
+			rs.sendStatusUpdate(api.InSync)
+		}
+	}
+
+	// Return the accumulated or processed updated.
+	return updates
+}

--- a/lib/backend/watchersyncer/watchersyncer_suite_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Backend multi-watcher/syncer test suite")
+}

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1,0 +1,1086 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+var (
+	dsError = cerrors.ErrorDatastoreError{Err: errors.New("Generic datastore error")}
+	l1Key1  = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace1",
+		Name:      "policy-1",
+	}
+	l1Key2 = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace1",
+		Name:      "policy-2",
+	}
+	l1Key3 = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace2",
+		Name:      "policy-1",
+	}
+	l1Key4 = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace2999",
+		Name:      "policy-1000",
+	}
+	l2Key1 = model.ResourceKey{
+		Kind: apiv2.KindIPPool,
+		Name: "ippool-1",
+	}
+	l2Key2 = model.ResourceKey{
+		Kind: apiv2.KindIPPool,
+		Name: "ippool-2",
+	}
+	l3Key1 = model.BlockAffinityKey{
+		CIDR: cnet.MustParseCIDR("1.2.3.0/24"),
+		Host: "mynode",
+	}
+)
+
+var _ = Describe("Test the backend datstore multi-watch syncer", func() {
+
+	r1 := watchersyncer.ResourceType{
+		ListInterface: model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+	}
+	r2 := watchersyncer.ResourceType{
+		ListInterface: model.ResourceListOptions{Kind: apiv2.KindIPPool},
+	}
+	r3 := watchersyncer.ResourceType{
+		ListInterface: model.BlockAffinityListOptions{},
+	}
+
+	It("Should receive a sync event when the watchers only provide sync events", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.startSyncer()
+		rs.expectStatus(api.WaitForDatastore)
+		rs.expectWatcherCreated(r1)
+		rs.expectWatcherCreated(r2)
+		rs.expectWatcherCreated(r3)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.InSync)
+	})
+
+	It("Should discard multiple synced events", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.startSyncer()
+		rs.expectStatus(api.WaitForDatastore)
+		rs.expectWatcherCreated(r1)
+		rs.expectWatcherCreated(r2)
+		rs.expectWatcherCreated(r3)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.InSync)
+	})
+
+	It("Should handle reconnection when all watchers initially failed to be created", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.setClientErrorWatchCreation(true)
+		rs.startSyncer()
+		rs.expectStatus(api.WaitForDatastore)
+		rs.expectNumWatchCreationErrors(r1, 2)
+		rs.expectNumWatchCreationErrors(r2, 2)
+		rs.expectNumWatchCreationErrors(r3, 2)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.setClientErrorWatchCreation(false)
+		rs.expectWatcherCreated(r1)
+		rs.expectWatcherCreated(r2)
+		rs.expectWatcherCreated(r3)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.InSync)
+	})
+
+	It("Should handle reconnection and syncing when the watcher sends a watch terminated error", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.startSyncer()
+		rs.expectWatcherCreated(r1)
+		rs.expectWatcherCreated(r2)
+		rs.expectWatcherCreated(r3)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r3, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.expectPreviousWatcherClosedThenReset(r3)
+		rs.expectWatcherCreated(r3)
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.InSync)
+	})
+
+	It("Should handle receiving events while one watcher fails and fails to reconnect", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		eventL1Added1 := addEvent(l1Key1)
+		eventL2Added1 := addEvent(l2Key1)
+		eventL2Added2 := addEvent(l2Key2)
+		eventL3Added1 := addEvent(l3Key1)
+		rs.startSyncer()
+		rs.expectWatcherCreated(r1)
+		rs.expectWatcherCreated(r2)
+		rs.expectWatcherCreated(r3)
+
+		rs.expectStatus(api.WaitForDatastore)
+		rs.sendEvent(r1, eventL1Added1)
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.setClientErrorWatchCreation(true)
+		rs.sendEvent(r3, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		rs.expectStatus(api.ResyncInProgress)
+		rs.expectPreviousWatcherClosedThenReset(r3)
+		rs.sendEvent(r2, eventL2Added1)
+		rs.sendEvent(r2, eventL2Added2)
+		rs.expectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Added2.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		})
+		rs.setClientErrorWatchCreation(false)
+		rs.expectWatcherCreated(r3)
+		rs.expectStatus(api.ResyncInProgress)
+		rs.sendEvent(r3, eventL3Added1)
+		rs.expectUpdates([]api.Update{
+			{
+				KVPair:     *eventL3Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		})
+		rs.sendEvent(r3, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.InSync)
+	})
+
+	It("Should not resend add events during a resync and should delete stale entries", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1})
+		eventL1Added1 := addEvent(l1Key1)
+		eventL1Added2 := addEvent(l1Key2)
+		eventL1Added3 := addEvent(l1Key3)
+		eventL1Added4 := addEvent(l1Key4)
+		eventL1Modified4 := modifiedEvent(l1Key4)
+		eventL1Deleted3 := deleteEvent(l1Key3)
+		rs.startSyncer()
+		rs.expectWatcherCreated(r1)
+
+		// Perform a mix of add/modified/delete events to populate our cache
+		// and trigger some interesting events.
+		rs.expectStatus(api.WaitForDatastore)
+		rs.sendEvent(r1, eventL1Added1)
+		rs.sendEvent(r1, eventL1Added2)
+		rs.sendEvent(r1, eventL1Added3)
+		rs.sendEvent(r1, eventL1Deleted3)
+		rs.sendEvent(r1, eventL1Added4)
+		rs.sendEvent(r1, eventL1Modified4)
+		rs.expectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL1Added2.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL1Added3.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				// Remove the Value for deleted.
+				KVPair: model.KVPair{
+					Key: eventL1Deleted3.Old.Key,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			},
+			{
+				KVPair:     *eventL1Added4.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL1Modified4.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+		})
+
+		// Watcher fails, new watcher is instantiated and starts to resync.
+		// Get as far as entry (1) which is modified.
+		rs.sendEvent(r1, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		rs.expectPreviousWatcherClosedThenReset(r1)
+		rs.expectWatcherCreated(r1)
+		eventL1Added1_2 := addEvent(l1Key1)
+		rs.sendEvent(r1, eventL1Added1_2)
+		rs.expectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Added1_2.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+		})
+
+		// Watcher fails again, mid-resync.  Recovers.
+		// -  Existing entry (1) is modified again (synced from datastore as an add!):  should get modified event
+		// -  Existing entry (2) is unchanged:  no update
+		// -  Previously deleted entry (3) added back in:  get an add update
+		rs.sendEvent(r1, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		rs.expectPreviousWatcherClosedThenReset(r1)
+		rs.expectWatcherCreated(r1)
+		eventL1Added1_3 := addEvent(l1Key1)
+		rs.sendEvent(r1, eventL1Added1_3)
+		rs.sendEvent(r1, eventL1Added2)
+		rs.sendEvent(r1, eventL1Added3)
+		rs.expectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Added1_3.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+			{
+				KVPair:     *eventL1Added3.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		})
+		rs.expectStatus(api.ResyncInProgress)
+
+		// Datastore finishes it's sync.  We should receive a delete notification for entry
+		// 4 that was not in the resync when we recreated the watcher.
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		rs.expectStatus(api.InSync)
+		rs.expectUpdates([]api.Update{
+			{
+				KVPair: model.KVPair{
+					Key: eventL1Modified4.New.Key,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			},
+		})
+	})
+
+	It("Should accumulate updates into a single update when the handler thread is blocked", func() {
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{r1, r2})
+		eventL1Added1 := addEvent(l1Key1)
+		eventL2Added1 := addEvent(l2Key1)
+		eventL2Added2 := addEvent(l2Key2)
+		eventL2Modified1 := modifiedEvent(l2Key1)
+		eventL2Modified2 := modifiedEvent(l2Key2)
+		eventL2Modified1_2 := modifiedEvent(l2Key1)
+		eventL1Delete1 := deleteEvent(l1Key1)
+
+		rs.startSyncer()
+		rs.expectWatcherCreated(r1)
+		rs.expectWatcherCreated(r2)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.setBlockUpdateHandling(true)
+		rs.sendEvent(r1, eventL1Added1)
+
+		// We should get the first update in a single update message, and then the update handler will block.
+		rs.expectOnUpdates([][]api.Update{{
+			{
+				KVPair:     *eventL1Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		}})
+
+		// Send a few more events.
+		rs.sendEvent(r2, eventL2Added1)
+		rs.sendEvent(r2, eventL2Added2)
+		rs.sendEvent(r2, eventL2Modified1)
+
+		// Pause briefly before unblocking the update thread.
+		// We should receive three events in 1 OnUpdate message.
+		time.Sleep(100 * time.Millisecond)
+		rs.setBlockUpdateHandling(false)
+		rs.expectOnUpdates([][]api.Update{{
+			{
+				KVPair:     *eventL2Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Added2.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Modified1.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+		}})
+
+		// Block the update process again and send in a Delete and wait for the update.
+		rs.setBlockUpdateHandling(true)
+		rs.sendEvent(r1, eventL1Delete1)
+		rs.expectOnUpdates([][]api.Update{{
+			{
+				KVPair: model.KVPair{
+					Key: eventL1Delete1.Old.Key,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			},
+		}})
+		rs.expectStatus(api.ResyncInProgress)
+
+		// Send in: update, InSync, update, InSync, update, error, update.
+		// The first InSync should be ignored since the system is only InSync when
+		// all watchers have reported.  Therefore we should get:
+		// -  An OnUpdate with 2 updates
+		// -  An Insync update
+		// -  An OnUpdate with 1 update
+		// -  An error
+		// -  An OnUpdate with 1 update
+		rs.sendEvent(r2, eventL2Modified1_2)
+		rs.sendEvent(r1, api.WatchEvent{Type: api.WatchSynced})
+		// Pause a little here because the previous watch event is on a different goroutine so
+		// we need to ensure it's been processed.
+		time.Sleep(100 * time.Millisecond)
+		rs.sendEvent(r2, eventL2Modified1)
+		rs.sendEvent(r2, api.WatchEvent{Type: api.WatchSynced})
+		rs.sendEvent(r2, eventL2Modified2)
+		rs.sendEvent(r2, api.WatchEvent{
+			Type: api.WatchError,
+			Error: cerrors.ErrorParsingDatastoreEntry{
+				RawKey:   "abcdef",
+				RawValue: "aabbccdd",
+			},
+		})
+		rs.sendEvent(r2, eventL2Modified1_2)
+
+		time.Sleep(100 * time.Millisecond)
+		rs.setBlockUpdateHandling(false)
+		rs.expectStatus(api.InSync)
+		rs.expectParseError("abcdef", "aabbccdd")
+		rs.expectOnUpdates([][]api.Update{
+			{
+				{
+					KVPair:     *eventL2Modified1_2.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+				{
+					KVPair:     *eventL2Modified1.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+			},
+			{
+				{
+					KVPair:     *eventL2Modified2.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+			},
+			{
+				{
+					KVPair:     *eventL2Modified1_2.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+			},
+		})
+	})
+
+	It("Should invoke the supplied converter to alter the update", func() {
+		rc1 := watchersyncer.ResourceType{
+			Converter:     &fakeConverter{},
+			ListInterface: model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+		}
+
+		// Since the fake converter doesn't actually look at the incoming event we can
+		// send in arbitrary data.  Block the handler thread and send in 1 event and wait for it -
+		// this event will block the update handling process.
+		// Send in another 6 events to cover the different branches of the fake converter.
+		//
+		// See fakeConverter for details on what is returned each invocation.
+		rs := newRawSyncerTester([]watchersyncer.ResourceType{rc1})
+		rs.startSyncer()
+		rs.expectWatcherCreated(rc1)
+		rs.expectStatus(api.WaitForDatastore)
+		rs.setBlockUpdateHandling(true)
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.expectStatus(api.ResyncInProgress)
+		rs.expectOnUpdates([][]api.Update{{{
+			KVPair:     *fakeConverterKVP1,
+			UpdateType: api.UpdateTypeKVNew, // key: l1Key1
+		}}})
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+
+		// Pause briefly and then unblock the thread.  The events should be collated
+		// except that an error will cause the events to be sent immediately.
+		time.Sleep(100 * time.Millisecond)
+		rs.setBlockUpdateHandling(false)
+		rs.expectOnUpdates([][]api.Update{
+			{
+				{
+					KVPair:     *fakeConverterKVP2,
+					UpdateType: api.UpdateTypeKVUpdated, // key: l1Key1
+				},
+				{
+					KVPair:     *fakeConverterKVP3,
+					UpdateType: api.UpdateTypeKVNew, // key: l1Key2
+				},
+			},
+			{
+				{
+					KVPair: model.KVPair{
+						Key: fakeConverterKVP4.Key,
+					},
+					UpdateType: api.UpdateTypeKVDeleted, // key: l1Key2
+				},
+			},
+			{
+				{
+					KVPair:     *fakeConverterKVP5,
+					UpdateType: api.UpdateTypeKVUpdated, // key: l1Key1
+				},
+				{
+					KVPair:     *fakeConverterKVP6,
+					UpdateType: api.UpdateTypeKVUpdated, // key: l1Key1
+				},
+			},
+		})
+
+		// We should have received a parse error.
+		rs.expectParseError("abcdef", "aabbccdd")
+
+		// Send a deleted event.  We should get a single deletion event for l1Key1 since
+		// l1Key2 is already deleted.  We should also get an updated Parse error.
+		rs.sendEvent(r1, deleteEvent(l1Key1))
+		time.Sleep(100 * time.Millisecond)
+		rs.expectOnUpdates([][]api.Update{
+			{
+				{
+					KVPair: model.KVPair{
+						Key: l1Key1,
+					},
+					UpdateType: api.UpdateTypeKVDeleted,
+				},
+			},
+		})
+		rs.expectParseError("zzzzz", "xxxxx")
+
+	})
+})
+
+var (
+	// Test events for the conversion code.
+	fakeConverterKVP1 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdef",
+		Revision: "abcdefg",
+	}
+	fakeConverterKVP2 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdefgh",
+		Revision: "abcdfg",
+	}
+	fakeConverterKVP3 = &model.KVPair{
+		Key:      l1Key2,
+		Value:    "abcdef",
+		Revision: "abcdefg",
+	}
+	fakeConverterKVP4 = &model.KVPair{
+		Key:      l1Key2,
+		Revision: "abfdgscdfg",
+	}
+	fakeConverterKVP5 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdeddfgh",
+		Revision: "abfdgffffscdfg",
+	}
+	fakeConverterKVP6 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdeddgjdfgjdfgdfgh",
+		Revision: "abfdgscdfg",
+	}
+)
+
+// Fake converter used to cover error and update handling paths.
+type fakeConverter struct {
+	i int
+}
+
+func (fc *fakeConverter) ConvertKVPair(kvp *model.KVPair) ([]*model.KVPair, error) {
+	fc.i++
+	switch fc.i {
+	case 1: // First update used to block update thread in test.
+		return []*model.KVPair{
+			fakeConverterKVP1,
+		}, nil
+	case 2: // Second contains two updates.
+		return []*model.KVPair{
+			fakeConverterKVP2,
+			fakeConverterKVP3,
+		}, nil
+	case 3: // Third contains an error, which will result in the update event.
+		return nil, errors.New("Fake error that we should handle gracefully")
+	case 4: // Fourth contains event and error, event will be sent and parse error will be stored.
+		return []*model.KVPair{
+				fakeConverterKVP4,
+			}, cerrors.ErrorParsingDatastoreEntry{
+				RawKey:   "abcdef",
+				RawValue: "aabbccdd",
+			}
+	case 5: // Fifth contains an update.
+		return []*model.KVPair{
+			fakeConverterKVP5,
+		}, nil
+	case 6: // Sixth contains nothing.
+		return nil, nil
+	case 7: // Seventh contains another update that will be appended to the one in case 5.
+		return []*model.KVPair{
+			fakeConverterKVP6,
+		}, nil
+	}
+	return nil, nil
+}
+
+func (fc *fakeConverter) ConvertKey(model.Key) ([]model.Key, error) {
+	return []model.Key{l1Key1, l1Key2}, cerrors.ErrorParsingDatastoreEntry{
+		RawKey:   "zzzzz",
+		RawValue: "xxxxx",
+	}
+}
+
+// Create a delete event from a Key. The value types don't need to match the
+// Key types since we aren't unmarshaling/marshaling them in this package.
+func deleteEvent(key model.Key) api.WatchEvent {
+	return api.WatchEvent{
+		Type: api.WatchDeleted,
+		Old: &model.KVPair{
+			Key:      key,
+			Value:    uuid.NewV4().String(),
+			Revision: uuid.NewV4().String(),
+		},
+	}
+}
+
+// Create an add event from a Key. The value types don't need to match the
+// Key types since we aren't unmarshaling/marshaling them in this package.
+func addEvent(key model.Key) api.WatchEvent {
+	return api.WatchEvent{
+		Type: api.WatchAdded,
+		New: &model.KVPair{
+			Key:      key,
+			Value:    uuid.NewV4().String(),
+			Revision: uuid.NewV4().String(),
+		},
+	}
+}
+
+// Create a modified event from a Key. The value types don't need to match the
+// Key types since we aren't unmarshaling/marshaling them in this package.
+func modifiedEvent(key model.Key) api.WatchEvent {
+	return api.WatchEvent{
+		Type: api.WatchModified,
+		New: &model.KVPair{
+			Key:      key,
+			Value:    uuid.NewV4().String(),
+			Revision: uuid.NewV4().String(),
+		},
+	}
+}
+
+// Create a new rawSyncerTester.
+func newRawSyncerTester(l []watchersyncer.ResourceType) *rawSyncerTester {
+	fc := &fakeClient{
+		currentWatchers:  make(map[string]*fakeWatcher, 0),
+		previousWatchers: make(map[string]*fakeWatcher, 0),
+	}
+	sr := &syncerReceiver{
+		status:    api.SyncStatus(9),
+		updates:   make([]api.Update, 0),
+		onUpdates: make([][]api.Update, 0),
+	}
+	rst := &rawSyncerTester{
+		fc:        fc,
+		sr:        sr,
+		rawSyncer: watchersyncer.New(fc, l, sr),
+	}
+	return rst
+}
+
+// rawSyncerTester is used to create, start and validate a rawSyncer.  It
+// contains a number of useful methods used for asserting current state.
+type rawSyncerTester struct {
+	fc        *fakeClient
+	sr        *syncerReceiver
+	rawSyncer api.Syncer
+}
+
+// Start the syncer.
+func (rst *rawSyncerTester) startSyncer() {
+	rst.rawSyncer.Start()
+}
+
+// Call to test the expected current status.
+func (rst *rawSyncerTester) expectStatus(status api.SyncStatus) {
+	// Pause a fraction before testing, to make sure we aren't in transition.
+	log.Infof("Expecting status of %d (%s)", status, status)
+	time.Sleep(10 * time.Millisecond)
+	Eventually(rst.sr.getStatus).Should(Equal(status))
+}
+
+// Call to test the received and collated current events.  This removes the collated
+// updates from the receiver, so the next invocation only needs to specify the subsequent updates.
+func (rst *rawSyncerTester) expectUpdates(updates []api.Update) {
+	log.Infof("Expecting updates of %v", updates)
+	pollInterval := 50 * time.Millisecond
+	waitInterval := 20 * pollInterval
+	Eventually(rst.sr.getUpdates, waitInterval, pollInterval).Should(Equal(updates))
+	rst.sr.removeSyncUpdates(len(updates))
+}
+
+// Call to test the actual OnUpdate requests that were expected.
+// This removes the onUpdate events from the receiver.
+func (rst *rawSyncerTester) expectOnUpdates(onUpdates [][]api.Update) {
+	log.Infof("Expecting updates of %v", onUpdates)
+	pollInterval := 50 * time.Millisecond
+	waitInterval := 20 * pollInterval
+	Eventually(rst.sr.getOnUpdates, waitInterval, pollInterval).Should(Equal(onUpdates))
+	rst.sr.removeOnUpdates()
+}
+
+// Call to test the actual OnUpdate requests that were expected.
+// This removes the onUpdate events from the receiver.
+func (rst *rawSyncerTester) expectParseError(key, value string) {
+	log.Infof("Expecting parse error: %v=%v", key, value)
+	pollInterval := 50 * time.Millisecond
+	waitInterval := 20 * pollInterval
+	Eventually(rst.sr.getErrorRawKey, waitInterval, pollInterval).Should(Equal(key))
+	Expect(rst.sr.getErrorRawValue()).To(Equal(value))
+}
+
+// Call to send an event via a particular watcher.
+func (rst *rawSyncerTester) sendEvent(r watchersyncer.ResourceType, event api.WatchEvent) {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithField("Name", path).Infof("Sending event")
+	w := rst.fc.getCurrentWatcher(r)
+	Expect(w).ToNot(BeNil())
+	w.sendEvent(event)
+}
+
+// Call to test that the previous watcher was closed.  This resets the previous watcher
+// so that we can re-use this test later on.
+func (rst *rawSyncerTester) expectPreviousWatcherClosedThenReset(r watchersyncer.ResourceType) {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithField("Name", path).Info("Expecting previous watcher closed")
+	pollInterval := 50 * time.Millisecond
+	waitInterval := 20 * pollInterval
+	Eventually(func() bool {
+		w := rst.fc.getPreviousWatcher(r)
+		if w == nil {
+			return false
+		}
+		if !w.HasTerminated() {
+			return false
+		}
+		rst.fc.removePreviousWatcher(r)
+		return true
+	}, waitInterval, pollInterval).Should(BeTrue())
+}
+
+// Get the current number of watch creation failures.  This tests the watcher
+// creation retry processing.  Don't make the num too high since the rawSyncer waits for
+// 1s between creation attempts.
+func (rst *rawSyncerTester) expectWatcherCreated(r watchersyncer.ResourceType) {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithField("Name", path).Info("Expecting watcher created")
+	pollInterval := 50 * time.Millisecond
+	waitInterval := time.Second + pollInterval
+	Eventually(func() int {
+		w := rst.fc.getCurrentWatcher(r)
+		if w == nil {
+			return -1
+		}
+		return w.getNumWatchCreationErrors()
+	}, waitInterval, pollInterval).Should(Equal(0))
+}
+
+// Get the current number of watch creation failures.  This tests the watcher
+// creation retry processing.  Don't make the num too high since the rawSyncer waits for
+// 1s between creation attempts.
+func (rst *rawSyncerTester) expectNumWatchCreationErrors(r watchersyncer.ResourceType, num int) {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithField("Name", path).Info("Expecting watch creation errors")
+	pollInterval := 50 * time.Millisecond
+	waitInterval := time.Duration(num)*time.Second + pollInterval
+	Eventually(func() int {
+		w := rst.fc.getCurrentWatcher(r)
+		if w == nil {
+			return -1
+		}
+		return w.getNumWatchCreationErrors()
+	}, waitInterval, pollInterval).Should(BeNumerically(">=", num))
+}
+
+// Tell the client to start failing to create watchers.
+func (rst *rawSyncerTester) setClientErrorWatchCreation(fail bool) {
+	log.WithField("Fail", fail).Info("Setting client watch creation fail flag")
+	rst.fc.setClientErrorWatchCreation(fail)
+}
+
+// Tell the receiver to block or unblock its status processing.
+func (rst *rawSyncerTester) setBlockUpdateHandling(block bool) {
+	rst.sr.setBlockUpdateHandling(block)
+}
+
+// syncerReceiver implements the api.SyncerCallbacks and api.SyncerParseFailCallbacks
+// interface and stores the events.  Test code should access this state through the
+// rawSyncerTester.
+type syncerReceiver struct {
+	lock          sync.Mutex
+	status        api.SyncStatus
+	onUpdates     [][]api.Update
+	updates       []api.Update
+	errorRawKey   string
+	errorRawValue string
+	wg            sync.WaitGroup
+}
+
+func (s *syncerReceiver) OnStatusUpdated(status api.SyncStatus) {
+	log.WithField("Status", status).Info("OnStatusUpdates called - may be blocked")
+	s.lock.Lock()
+	s.status = status
+	s.lock.Unlock()
+	log.Info("OnStatusUpdates processing complete")
+}
+
+func (s *syncerReceiver) OnUpdates(updates []api.Update) {
+	log.WithField("Updates", updates).Info("OnUpdates called - may be blocked")
+	s.lock.Lock()
+	s.updates = append(s.updates, updates...)
+	s.onUpdates = append(s.onUpdates, updates)
+	s.lock.Unlock()
+
+	// We've updated the data and released the lock, but we may need to block.
+	s.wg.Wait()
+	log.Info("OnUpdates processing complete")
+}
+
+func (s *syncerReceiver) ParseFailed(rawKey string, rawValue string) {
+	log.WithFields(log.Fields{
+		"Key":   rawKey,
+		"Value": rawValue,
+	}).Info("ParseFailed called")
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.errorRawKey = rawKey
+	s.errorRawValue = rawValue
+}
+
+// Block or unblock the status and update processing handler.
+func (s *syncerReceiver) setBlockUpdateHandling(block bool) {
+	if block {
+		log.Info("Blocking update handling thread")
+		s.wg.Add(1)
+	} else {
+		log.Info("Unblocking update handling thread")
+		s.wg.Done()
+	}
+}
+
+// Get the last reported status.
+func (s *syncerReceiver) getStatus() api.SyncStatus {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.WithField("Status", s.status).Info("getStatus()")
+	return s.status
+}
+
+// Get the raw error key from the last parse error.
+func (s *syncerReceiver) getErrorRawKey() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.WithField("errorRawKey", s.errorRawKey).Info("getErrorRawKey()")
+	return s.errorRawKey
+}
+
+// Get the raw error value from the last parse error.
+func (s *syncerReceiver) getErrorRawValue() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.WithField("errorRawValue", s.errorRawValue).Info("getErrorRawValue()")
+	return s.errorRawValue
+}
+
+// Get a copy of the current set of updates.
+func (s *syncerReceiver) getUpdates() []api.Update {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.WithField("Updates", s.updates).Info("getUpdates()")
+	return s.updates[:]
+}
+
+// Get the separate onUpdate sets we received.
+func (s *syncerReceiver) getOnUpdates() [][]api.Update {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.WithField("onUpdates", s.onUpdates).Info("getOnUpdates()")
+	return s.onUpdates[:]
+}
+
+// Remove the current set of onUpdate messages we received.
+func (s *syncerReceiver) removeOnUpdates() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.Info("removeOnUpdates()")
+	s.onUpdates = make([][]api.Update, 0)
+}
+
+// Remove the first <num> entries from the updates - this is used to clear out updates that have
+// already been validated.  We also reset the number of on update messages we received - this is
+// only a valid thing to do if there are no more messages being receive (so test code beware!).
+func (s *syncerReceiver) removeSyncUpdates(num int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.WithField("Num", num).Info("removeSyncUpdates()")
+	s.updates = s.updates[num:]
+}
+
+// fakeClient implements the api.Client interface.  We mock this out so that we can control
+// the events
+type fakeClient struct {
+	lock               sync.Mutex
+	errorWatchCreation bool
+	currentWatchers    map[string]*fakeWatcher
+	previousWatchers   map[string]*fakeWatcher
+}
+
+// We don't implement any of the CRUD related methods, just the Watch method to return
+// a fake watcher that the test code will drive.
+func (c *fakeClient) Create(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Apply(object *model.KVPair) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	panic("should not be called")
+	return nil
+}
+func (c *fakeClient) EnsureInitialized() error {
+	panic("should not be called")
+	return nil
+}
+func (c *fakeClient) Clean() error {
+	panic("should not be called")
+	return nil
+}
+
+func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+	// Create a fake watcher keyed off the ListOptions (root path).
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	path := model.ListOptionsToDefaultPathRoot(list)
+	log.WithField("Name", path).Info("Creating new watcher")
+
+	if cur, ok := c.currentWatchers[path]; ok {
+		// If we are testing watch instantiation errors, then first check to see if the current watch
+		// is an errored watcher and if so increment it's count and then return an error.
+		if c.errorWatchCreation {
+			numErrs := cur.getNumWatchCreationErrors()
+			if numErrs > 0 {
+				log.WithField("Name", path).Info("Failed to create watcher; incrementing count on existing failed watcher")
+				cur.incrementNumCreationErrors()
+				return nil, dsError
+			}
+		}
+
+		// We are creating a new watcher, so store the old one so that we can check its state.
+		c.previousWatchers[path] = cur
+	}
+
+	// Create a new watcher either to track instantiation errors or to actually use as
+	// a fake watcher.
+	if c.errorWatchCreation {
+		c.currentWatchers[path] = &fakeWatcher{
+			name: path,
+			numWatchCreationErrors: 1,
+		}
+		log.WithField("Name", path).Info("Failed to create watcher")
+		return nil, dsError
+	}
+
+	c.currentWatchers[path] = &fakeWatcher{
+		name:    path,
+		results: make(chan api.WatchEvent, 100),
+	}
+	return c.currentWatchers[path], nil
+}
+
+// Controls whether the mock client will error when attempting to create a Watch client.
+func (c *fakeClient) setClientErrorWatchCreation(fail bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.errorWatchCreation = fail
+}
+
+// Return the current watcher data for the specified ListInterface.
+func (c *fakeClient) getCurrentWatcher(r watchersyncer.ResourceType) *fakeWatcher {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.currentWatchers[path]
+}
+
+// Return the previous watcher data for the specified ListInterface.  This is updated
+// from the current watcher data when the watcher is closed.
+func (c *fakeClient) getPreviousWatcher(r watchersyncer.ResourceType) *fakeWatcher {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.previousWatchers[path]
+}
+
+// Remove the previous watcher data.  This is called once the previous watcher has
+// been validated.
+func (c *fakeClient) removePreviousWatcher(r watchersyncer.ResourceType) {
+	path := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.previousWatchers, path)
+}
+
+// fakeWatcher is used both to track watcher instantation errors, and to act as a
+// fake watcher that can be driven by the test code.
+type fakeWatcher struct {
+	name                   string
+	lock                   sync.Mutex
+	numWatchCreationErrors int
+	results                chan api.WatchEvent
+	stopCalled             bool
+}
+
+func (fw *fakeWatcher) Stop() {
+	log.WithField("Name", fw.name).Info("Stop called on watcher")
+	fw.lock.Lock()
+	defer fw.lock.Unlock()
+	fw.stopCalled = true
+}
+
+func (fw *fakeWatcher) ResultChan() <-chan api.WatchEvent {
+	// This should never be called for a failed watcher.
+	Expect(fw.results).ToNot(BeNil())
+	return fw.results
+}
+
+// Send an event for this watcher.
+func (fw *fakeWatcher) sendEvent(e api.WatchEvent) {
+	log.WithField("Name", fw.name).Infof("Send event %s", e.Type)
+	fw.results <- e
+}
+
+// Increment the number of creation errors for this watcher type.
+func (fw *fakeWatcher) incrementNumCreationErrors() {
+	fw.lock.Lock()
+	defer fw.lock.Unlock()
+	fw.numWatchCreationErrors++
+	log.WithField("Name", fw.name).Infof("Incrementing failed count to %d", fw.numWatchCreationErrors)
+}
+
+// Get the number of creation errors for this watcher type.
+func (fw *fakeWatcher) getNumWatchCreationErrors() int {
+	fw.lock.Lock()
+	defer fw.lock.Unlock()
+	log.WithField("Name", fw.name).Infof("getNumWatchCreationErrors called on watcher: %v", fw.numWatchCreationErrors)
+	return fw.numWatchCreationErrors
+}
+
+// HasTerminated returns true if the watcher has terminated and released all
+// resources.  This is used for test purposes.
+func (fw *fakeWatcher) HasTerminated() bool {
+	fw.lock.Lock()
+	defer fw.lock.Unlock()
+	log.WithField("Name", fw.name).Infof("HasTerminated called on watcher: %v", fw.stopCalled)
+	return fw.stopCalled
+}

--- a/lib/clientv2/bgppeer_e2e_test.go
+++ b/lib/clientv2/bgppeer_e2e_test.go
@@ -366,7 +366,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -396,7 +396,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -370,7 +370,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -400,7 +400,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/hostendpoint_e2e_test.go
+++ b/lib/clientv2/hostendpoint_e2e_test.go
@@ -363,7 +363,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -393,7 +393,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/ippool_e2e_test.go
+++ b/lib/clientv2/ippool_e2e_test.go
@@ -367,7 +367,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -397,7 +397,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/networkpolicy_e2e_test.go
+++ b/lib/clientv2/networkpolicy_e2e_test.go
@@ -382,7 +382,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -366,7 +366,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -396,7 +396,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/profile_e2e_test.go
+++ b/lib/clientv2/profile_e2e_test.go
@@ -365,7 +365,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -395,7 +395,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/resources.go
+++ b/lib/clientv2/resources.go
@@ -326,7 +326,7 @@ func (w *watcher) terminate() {
 // convertEvent converts a backend watch event into a client watch event.
 func (w *watcher) convertEvent(backendEvent bapi.WatchEvent) watch.Event {
 	apiEvent := watch.Event{
-		Error: backendEvent.Error,
+		Error:           backendEvent.Error,
 		ResourceVersion: backendEvent.Revision,
 	}
 	switch backendEvent.Type {

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -391,7 +391,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 					Object: outRes3,
 				},
 				{
-					Type:	watch.Synced,
+					Type: watch.Synced,
 				},
 			})
 			testWatcher3.Stop()
@@ -414,7 +414,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			testWatcher4.Stop()
 		})
 	})
-	
+
 	Describe("WorkloadEndpoint prefix list", func() {
 		It("should handle prefix lists of workload endpoints", func() {
 			c, err := clientv2.New(config)
@@ -429,11 +429,11 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace1", Name: "node--1-k8s-pod-eth0"},
-					Spec:       apiv2.WorkloadEndpointSpec{
-						Node: "node-1",
-						Orchestrator: "k8s",
-						Pod: "pod",
-						Endpoint: "eth0",
+					Spec: apiv2.WorkloadEndpointSpec{
+						Node:          "node-1",
+						Orchestrator:  "k8s",
+						Pod:           "pod",
+						Endpoint:      "eth0",
 						InterfaceName: "cali1234",
 					},
 				},
@@ -445,11 +445,11 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace1", Name: "node--1-k8s-pod--1-eth0"},
-					Spec:       apiv2.WorkloadEndpointSpec{
-						Node: "node-1",
-						Orchestrator: "k8s",
-						Pod: "pod-1",
-						Endpoint: "eth0",
+					Spec: apiv2.WorkloadEndpointSpec{
+						Node:          "node-1",
+						Orchestrator:  "k8s",
+						Pod:           "pod-1",
+						Endpoint:      "eth0",
 						InterfaceName: "cali1234",
 					},
 				},
@@ -462,11 +462,11 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace2", Name: "node--1-k8s-pod--2-eth0"},
-					Spec:       apiv2.WorkloadEndpointSpec{
-						Node: "node-1",
-						Orchestrator: "k8s",
-						Pod: "pod-2",
-						Endpoint: "eth0",
+					Spec: apiv2.WorkloadEndpointSpec{
+						Node:          "node-1",
+						Orchestrator:  "k8s",
+						Pod:           "pod-2",
+						Endpoint:      "eth0",
 						InterfaceName: "cali1235",
 					},
 				},

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -153,3 +153,23 @@ func UpdateErrorIdentifier(err error, id interface{}) error {
 	}
 	return err
 }
+
+// Error indicating the watcher has been terminated.
+type ErrorWatchTerminated struct {
+	Err error
+}
+
+func (e ErrorWatchTerminated) Error() string {
+	return fmt.Sprintf("watch terminated: %s", e.Err)
+}
+
+// Error indicating the datastore has failed to parse an entry.
+type ErrorParsingDatastoreEntry struct {
+	RawKey   string
+	RawValue string
+	Err      error
+}
+
+func (e ErrorParsingDatastoreEntry) Error() string {
+	return fmt.Sprintf("failed to parse datastore entry key=%s; value=%s: %s", e.RawKey, e.RawValue, e.Err)
+}

--- a/lib/names/workloadendpoint_test.go
+++ b/lib/names/workloadendpoint_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/names"
 )
 
-var _ =	DescribeTable("WorkloadEndpoint name construction, fully qualified names",
+var _ = DescribeTable("WorkloadEndpoint name construction, fully qualified names",
 	func(ids names.WorkloadEndpointIdentifiers, expectedName string, expectedErroredField string) {
 		name, err := ids.CalculateWorkloadEndpointName(false)
 		if len(expectedErroredField) != 0 {
@@ -80,7 +80,7 @@ var _ =	DescribeTable("WorkloadEndpoint name construction, fully qualified names
 	}, "", "workload"),
 )
 
-var _ =DescribeTable("WorkloadEndpoint name construction, name prefix",
+var _ = DescribeTable("WorkloadEndpoint name construction, name prefix",
 	func(ids names.WorkloadEndpointIdentifiers, expectedName string, expectedErroredField string) {
 		name, err := ids.CalculateWorkloadEndpointName(true)
 		if len(expectedErroredField) != 0 {
@@ -196,4 +196,3 @@ var _ = DescribeTable("WorkloadEndpoint name matching",
 		Endpoint:     "eth0",
 	}, "node--1-k8s-pod-eth0-extra", false, ""),
 )
-

--- a/run-uts
+++ b/run-uts
@@ -12,13 +12,19 @@ fi
 echo "Removing old coverprofiles..."
 find . -name "*.coverprofile" -type f -delete
 
-echo "Calculating packages to cover..."
-go_dirs=$(find -type f -name '*.go' | \
-	      grep -vE '/vendor/|.glide|.git' | \
-	      xargs -n 1 dirname | \
-	      sort | uniq | \
-	      tr '\n' ',' | \
-	      sed 's/,$//' )
+if [ -z $WHAT ]
+then
+    echo "Calculating packages to cover..."
+    go_dirs=$(find -type f -name '*.go' | \
+	          grep -vE '/vendor/|.glide|.git' | \
+	          xargs -n 1 dirname | \
+	          sort | uniq | \
+	          tr '\n' ',' | \
+	          sed 's/,$//' )
+else
+    go_dirs=$WHAT
+fi
+
 echo "Covering: $go_dirs"
 test ! -z "$go_dirs"
 


### PR DESCRIPTION
PLEASE DON'T REVIEW JUST YET.

This adds a generic "watcherSyncer" (not sure I like that name... open to suggestions) that implements the Syncer interface required by Felix, syncing the data from multiple arbitrary Watchers.

I'm going to use this for the etcdv3 syncer, and once we have Watch support covering all of the necessary K8s resources, we could use this to replace the K8s syncer code too.

For Felix, the current plan is to sync v1 data.  This generic helper class allows the user to specify an arbitrary converter interface to convert between the raw set of updates and the ones that we actually send to the consumer.