### PR TITLE
bugfix: no pools found when rewuestedIPPools is not specified

### DIFF
--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -85,11 +85,17 @@ func (rw blockReaderWriter) claimNewAffineBlock(ctx context.Context, host string
 		log.Errorf("Error reading configured pools: %s", err)
 		return nil, err
 	}
+	log.Debugf("enabled IPPools: %v", enabledPools)
 
-	for _, p := range enabledPools {
-		if isPoolInRequestedPools(p, requestedPools) {
-			pools = append(pools, p)
+	if len(requestedPools) > 0 {
+		log.Debugf("requested IPPools: %v", requestedPools)
+		for _, p := range enabledPools {
+			if isPoolInRequestedPools(p, requestedPools) {
+				pools = append(pools, p)
+			}
 		}
+	} else {
+		pools = enabledPools
 	}
 
 	// Build a map so we can lookup existing pools.
@@ -102,13 +108,13 @@ func (rw blockReaderWriter) claimNewAffineBlock(ctx context.Context, host string
 	for _, rp := range requestedPools {
 		if _, ok := pm[rp.String()]; !ok {
 			// The requested pool doesn't exist.
-			return nil, fmt.Errorf("The given pool (%s) does not exist, or is not enabled", rp.IPNet.String())
+			return nil, fmt.Errorf("the given pool (%s) does not exist, or is not enabled", rp.IPNet.String())
 		}
 	}
 
 	// If there are no pools, we cannot assign addresses.
 	if len(pools) == 0 {
-		return nil, errors.New("No configured Calico pools")
+		return nil, errors.New("no configured Calico pools")
 	}
 
 	// Iterate through pools to find a new block.

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -367,7 +367,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreEtcdV3, 
 			v4, _, err := ic.AutoAssign(context.Background(), args)
 			log.Println("v4: %d IPs", len(v4))
 
-			Expect(err.Error()).Should(Equal("The given pool (40.0.0.0/24) does not exist, or is not enabled"))
+			Expect(err.Error()).Should(Equal("the given pool (40.0.0.0/24) does not exist, or is not enabled"))
 			Expect(len(v4)).To(Equal(0))
 		})
 	})


### PR DESCRIPTION
## Description
IPAM doesn't find IPPools when specific ones are not requested explicitly
```

2017-10-05 21:58:56.634 [DEBUG][4833] conversion.go 32: Processing etcdv3 entry etcdv3-etcdKey="/calico/resources/v2/ippool/192-168-0-0-16"
2017-10-05 21:58:56.634 [DEBUG][4833] resource.go 142: Get Global Resource key from /calico/resources/v2/ippool/192-168-0-0-16
2017-10-05 21:58:56.634 [DEBUG][4833] conversion.go 34: Key is valid and converted to model-etcdKey model-etcdKey=IPPool(192-168-0-0-16)
2017-10-05 21:58:56.634 [DEBUG][4833] conversion.go 36: Value is valid - return KVPair with parsed value
2017-10-05 21:58:56.634 [DEBUG][4833] conversion.go 32: Processing etcdv3 entry etcdv3-etcdKey="/calico/resources/v2/ippool/fd80-24e2-f998-72d6---64"
2017-10-05 21:58:56.634 [DEBUG][4833] resource.go 142: Get Global Resource key from /calico/resources/v2/ippool/fd80-24e2-f998-72d6---64
2017-10-05 21:58:56.634 [DEBUG][4833] conversion.go 34: Key is valid and converted to model-etcdKey model-etcdKey=IPPool(fd80-24e2-f998-72d6---64)
2017-10-05 21:58:56.634 [DEBUG][4833] conversion.go 36: Value is valid - return KVPair with parsed value
2017-10-05 21:58:56.634 [ERROR][4833] ipam.go 150: Error claiming new block: No configured Calico pools
2017-10-05 21:58:56.634 [ERROR][4833] ipam.go 81: Error assigning IPV4 addresses: No configured Calico pools
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
