### PR TITLE
bugfix: only get IPPools specified for the IP version

### DIFF
--- a/lib/clientv2/client.go
+++ b/lib/clientv2/client.go
@@ -136,11 +136,13 @@ func (p poolAccessor) GetEnabledPools(ipVersion int) ([]net.IPNet, error) {
 	for _, pool := range pools.Items {
 		if pool.Spec.Disabled {
 			continue
-		} else if _, cidr, err := net.ParseCIDR(pool.Spec.CIDR); err == nil {
+		} else if _, cidr, err := net.ParseCIDR(pool.Spec.CIDR); err == nil && cidr.Version() == ipVersion {
 			log.Debugf("Adding pool (%s) to the enabled IPPool list", cidr.String())
 			enabled = append(enabled, *cidr)
-		} else {
+		} else if err != nil {
 			log.Warnf("Failed to parse the IPPool: %s. Ignoring that IPPool", pool.Spec.CIDR)
+		} else {
+			log.Debugf("Ignoring IPPool: %s. IP version is different.", pool.Spec.CIDR)
 		}
 	}
 	return enabled, nil


### PR DESCRIPTION
## Description
we're passing the IPVersion but not using it to get enabled IPPools of **only** that IP version

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
