### PR TITLE
Implemented interface definitions for Cluster Information resource

### DIFF
--- a/lib/apiv2/bgpconfig.go
+++ b/lib/apiv2/bgpconfig.go
@@ -38,9 +38,12 @@ type BGPConfiguration struct {
 // TODO: Add validation on LogSeverityScreen for valid values
 // BGPConfigurationSpec contains the values of the BGP configuration.
 type BGPConfigurationSpec struct {
-	LogSeverityScreen     string                `json:"logSeverityScreen,omitempty" validate:"omitempty"`
-	NodeToNodeMeshEnabled *bool                 `json:"nodeToNodeMeshEnabled,omitempty" validate:"omitempty"`
-	DefaultNodeASNumber   *numorstring.ASNumber `json:"defaultNodeASNumber,omitempty" validate:"omitempty"`
+	// LogSeverityScreen is the log severity above which logs are sent to the stdout. [Default: INFO]
+	LogSeverityScreen string `json:"logSeverityScreen,omitempty" validate:"omitempty"`
+	// NodeToNodeMeshEnabled sets whether full node to node BGP mesh is enabled. [Default: true]
+	NodeToNodeMeshEnabled *bool `json:"nodeToNodeMeshEnabled,omitempty" validate:"omitempty"`
+	// DefaultNodeASNumber is the default AS number used by a node. [Default: 64512]
+	DefaultNodeASNumber *numorstring.ASNumber `json:"defaultNodeASNumber,omitempty" validate:"omitempty"`
 }
 
 // BGPConfigurationList contains a list of BGPConfiguration resources.

--- a/lib/apiv2/clusterinfo.go
+++ b/lib/apiv2/clusterinfo.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiv2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	KindClusterInformation     = "ClusterInformation"
+	KindClusterInformationList = "ClusterInformationList"
+)
+
+// ClusterInformation contains the cluster specific information.
+type ClusterInformation struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// Specification of the ClusterInformation.
+	Spec ClusterInformationSpec `json:"spec,omitempty"`
+}
+
+// ClusterInformationSpec contains the values of describing the cluster.
+type ClusterInformationSpec struct {
+	// ClusterGUID is the GUID of the cluster
+	ClusterGUID string `json:"clusterGUID,omitempty" validate:"omitempty"`
+	// ClusterType describes the type of the cluster
+	ClusterType string `json:"clusterType,omitempty" validate:"omitempty"`
+	// CalicoVersion is the version of Calico that the cluster is running
+	CalicoVersion string `json:"calicoVersion,omitempty" validate:"omitempty"`
+}
+
+// ClusterInformationList contains a list of ClusterInformation resources
+// (even though there should only be one).
+type ClusterInformationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []ClusterInformation `json:"items"`
+}
+
+// New ClusterInformation creates a new (zeroed) ClusterInformation struct with the TypeMetadata
+// initialized to the current version.
+func NewClusterInformation() *ClusterInformation {
+	return &ClusterInformation{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KindClusterInformation,
+			APIVersion: GroupVersionCurrent,
+		},
+	}
+}
+
+// NewClusterInformationList creates a new 9zeroed) ClusterInformationList struct with the TypeMetadata
+// initialized to the current version.
+func NewClusterInformationList() *ClusterInformationList {
+	return &ClusterInformationList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KindClusterInformationList,
+			APIVersion: GroupVersionCurrent,
+		},
+	}
+}

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -32,6 +32,7 @@ var (
 	kindToType              = map[string]reflect.Type{
 		strings.ToLower(apiv2.KindBGPPeer):             reflect.TypeOf(apiv2.BGPPeer{}),
 		strings.ToLower(apiv2.KindBGPConfiguration):    reflect.TypeOf(apiv2.BGPConfiguration{}),
+		strings.ToLower(apiv2.KindClusterInformation):  reflect.TypeOf(apiv2.ClusterInformation{}),
 		strings.ToLower(apiv2.KindFelixConfiguration):  reflect.TypeOf(apiv2.FelixConfiguration{}),
 		strings.ToLower(apiv2.KindGlobalNetworkPolicy): reflect.TypeOf(apiv2.GlobalNetworkPolicy{}),
 		strings.ToLower(apiv2.KindHostEndpoint):        reflect.TypeOf(apiv2.HostEndpoint{}),

--- a/lib/clientv2/client.go
+++ b/lib/clientv2/client.go
@@ -112,14 +112,19 @@ func (c client) IPAM() ipam.Interface {
 	return ipam.NewIPAMClient(c.Backend, poolAccessor{client: &c})
 }
 
-// BGPConfiguration returns an interface for managing the BGP configuration resources.
+// BGPConfigurations returns an interface for managing the BGP configuration resources.
 func (c client) BGPConfigurations() BGPConfigurationInterface {
 	return bgpConfigurations{client: c}
 }
 
-// FelixConfiguration returns an interface for managing the Felix configuration resources.
+// FelixConfigurations returns an interface for managing the Felix configuration resources.
 func (c client) FelixConfigurations() FelixConfigurationInterface {
 	return felixConfigurations{client: c}
+}
+
+// ClusterInformation returns an interface for managing the cluster information resource.
+func (c client) ClusterInformation() ClusterInformationInterface {
+	return clusterInformation{client: c}
 }
 
 type poolAccessor struct {

--- a/lib/clientv2/clusterinfo.go
+++ b/lib/clientv2/clusterinfo.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2
+
+import (
+	"context"
+	"errors"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+// ClusterInformationInterface has methods to work with ClusterInformation resources.
+type ClusterInformationInterface interface {
+	Create(ctx context.Context, res *apiv2.ClusterInformation, opts options.SetOptions) (*apiv2.ClusterInformation, error)
+	Update(ctx context.Context, res *apiv2.ClusterInformation, opts options.SetOptions) (*apiv2.ClusterInformation, error)
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.ClusterInformation, error)
+	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.ClusterInformation, error)
+	List(ctx context.Context, opts options.ListOptions) (*apiv2.ClusterInformationList, error)
+	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// clusterInformation implements ClusterInformationInterface
+type clusterInformation struct {
+	client client
+}
+
+// Create takes the representation of a ClusterInformation and creates it.
+// Returns the stored representation of the ClusterInformation, and an error
+// if there is any.
+func (r clusterInformation) Create(ctx context.Context, res *apiv2.ClusterInformation, opts options.SetOptions) (*apiv2.ClusterInformation, error) {
+	if res.ObjectMeta.GetName() != "default" {
+		return nil, errors.New("Cannot create a Cluster Information resource with a name other than \"default\"")
+	}
+	out, err := r.client.resources.Create(ctx, opts, apiv2.KindClusterInformation, res)
+	if out != nil {
+		return out.(*apiv2.ClusterInformation), err
+	}
+	return nil, err
+}
+
+// Update takes the representation of a ClusterInformation and updates it.
+// Returns the stored representation of the ClusterInformation, and an error
+// if there is any.
+func (r clusterInformation) Update(ctx context.Context, res *apiv2.ClusterInformation, opts options.SetOptions) (*apiv2.ClusterInformation, error) {
+	out, err := r.client.resources.Update(ctx, opts, apiv2.KindClusterInformation, res)
+	if out != nil {
+		return out.(*apiv2.ClusterInformation), err
+	}
+	return nil, err
+}
+
+// Delete takes name of the ClusterInformation and deletes it. Returns an
+// error if one occurs.
+func (r clusterInformation) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv2.ClusterInformation, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv2.KindClusterInformation, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.ClusterInformation), err
+	}
+	return nil, err
+}
+
+// Get takes name of the ClusterInformation, and returns the corresponding
+// ClusterInformation object, and an error if there is any.
+func (r clusterInformation) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv2.ClusterInformation, error) {
+	out, err := r.client.resources.Get(ctx, opts, apiv2.KindClusterInformation, noNamespace, name)
+	if out != nil {
+		return out.(*apiv2.ClusterInformation), err
+	}
+	return nil, err
+}
+
+// List returns the list of ClusterInformation objects that match the supplied options.
+func (r clusterInformation) List(ctx context.Context, opts options.ListOptions) (*apiv2.ClusterInformationList, error) {
+	res := &apiv2.ClusterInformationList{}
+	if err := r.client.resources.List(ctx, opts, apiv2.KindClusterInformation, apiv2.KindClusterInformationList, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Watch returns a watch.Interface that watches the ClusterInformation that
+// match the supplied options.
+func (r clusterInformation) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	return r.client.resources.Watch(ctx, opts, apiv2.KindClusterInformation)
+}

--- a/lib/clientv2/clusterinfo_e2e_test.go
+++ b/lib/clientv2/clusterinfo_e2e_test.go
@@ -1,0 +1,337 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv2_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name := "default"
+	spec1 := apiv2.ClusterInformationSpec{
+		ClusterGUID:   "test-cluster-guid1",
+		ClusterType:   "test-cluster-type1",
+		CalicoVersion: "test-version1",
+	}
+	spec2 := apiv2.ClusterInformationSpec{
+		ClusterGUID:   "test-cluster-guid2",
+		ClusterType:   "test-cluster-type2",
+		CalicoVersion: "test-version2",
+	}
+
+	DescribeTable("ClusterInformation e2e CRUD tests",
+		func(name string, spec1, spec2 apiv2.ClusterInformationSpec) {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Updating the ClusterInformation before it is created")
+			res, outError := c.ClusterInformation().Update(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("resource does not exist: ClusterInformation(" + name + ")"))
+
+			By("Attempting to creating a new ClusterInformation with name/spec1 and a non-empty ResourceVersion")
+			res, outError = c.ClusterInformation().Create(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(res).To(BeNil())
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Getting ClusterInformation (name) before it is created")
+			res, outError = c.ClusterInformation().Get(ctx, name, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource does not exist: ClusterInformation(" + name + ")"))
+
+			By("Attempting to create a new ClusterInformation with a non-default name and spec1")
+			res1, outError := c.ClusterInformation().Create(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: "not-default"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("Cannot create a Cluster Information resource with a name other than \"default\""))
+
+			By("Creating a new ClusterInformation with name/spec1")
+			res1, outError = c.ClusterInformation().Create(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec1)
+
+			// Track the version of the original data for name.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same ClusterInformation with name but with spec2")
+			res1, outError = c.ClusterInformation().Create(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: ClusterInformation(" + name + ")"))
+			// Check return value is actually the previously stored value.
+			testutils.ExpectResource(res1, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec1)
+			Expect(res1.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting ClusterInformation (name) and comparing the output against spec1")
+			res, outError = c.ClusterInformation().Get(ctx, name, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec1)
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Listing all the ClusterInformation, expecting a single result with name/spec1")
+			outList, outError := c.ClusterInformation().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec1)
+
+			By("Updating ClusterInformation name with spec2")
+			res1.Spec = spec2
+			res1, outError = c.ClusterInformation().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec2)
+
+			// Track the version of the updated name data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating ClusterInformation name without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			res, outError = c.ClusterInformation().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+			Expect(res).To(BeNil())
+
+			By("Updating ClusterInformation name using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			res1, outError = c.ClusterInformation().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: ClusterInformation(" + name + ")"))
+			Expect(res1.ResourceVersion).To(Equal(rv1_2))
+
+			By("Getting ClusterInformation (name) with the original resource version and comparing the output against spec1")
+			res, outError = c.ClusterInformation().Get(ctx, name, options.GetOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec1)
+			Expect(res.ResourceVersion).To(Equal(rv1_1))
+
+			By("Getting ClusterInformation (name) with the updated resource version and comparing the output against spec2")
+			res, outError = c.ClusterInformation().Get(ctx, name, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec2)
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			By("Listing ClusterInformation with the original resource version and checking for a single result with name/spec1")
+			outList, outError = c.ClusterInformation().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec1)
+
+			By("Listing ClusterInformation with the latest resource version and checking for one result with name/spec2")
+			outList, outError = c.ClusterInformation().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(1))
+			testutils.ExpectResource(&outList.Items[0], apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec2)
+
+			By("Deleting ClusterInformation (name) with the old resource version")
+			_, outError = c.ClusterInformation().Delete(ctx, name, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: ClusterInformation(" + name + ")"))
+
+			By("Deleting ClusterInformation (name) with the new resource version")
+			dres, outError := c.ClusterInformation().Delete(ctx, name, options.DeleteOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(dres, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec2)
+
+			By("Listing all ClusterInformation and expecting no items")
+			outList, outError = c.ClusterInformation().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+		},
+
+		// Test 1: Pass two fully populated ClusterInformationSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated ClusterInformationSpecs", name, spec1, spec2),
+	)
+
+	Describe("ClusterInformation watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Listing ClusterInformation with the latest resource version and checking for one result with name/spec2")
+			outList, outError := c.ClusterInformation().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a ClusterInformation name/spec1 and storing the response")
+			outRes1, err := c.ClusterInformation().Create(
+				ctx,
+				&apiv2.ClusterInformation{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			rev1 := outRes1.ResourceVersion
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.ClusterInformation().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.TestResourceWatch(w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			_, err = c.ClusterInformation().Delete(ctx, name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for two events, create res2 and delete re1")
+			testWatcher1.ExpectEvents(apiv2.KindClusterInformation, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Configuring a ClusterInformation name2/spec2 and storing the response")
+			outRes2, err := c.ClusterInformation().Create(
+				ctx,
+				&apiv2.ClusterInformation{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.ClusterInformation().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.TestResourceWatch(w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.ClusterInformation().Update(
+				ctx,
+				&apiv2.ClusterInformation{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv2.KindClusterInformation, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			By("Starting a watcher from rev0 watching name - this should get all events for name")
+			w, err = c.ClusterInformation().Watch(ctx, options.ListOptions{Name: name, ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2_1 := testutils.TestResourceWatch(w)
+			defer testWatcher2_1.Stop()
+			testWatcher2_1.ExpectEvents(apiv2.KindClusterInformation, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2_1.Stop()
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.ClusterInformation().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.TestResourceWatch(w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEvents(apiv2.KindClusterInformation, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+				{
+					Type: watch.Synced,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			be.Clean()
+			testWatcher3.ExpectEvents(apiv2.KindClusterInformation, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+		})
+	})
+})

--- a/lib/clientv2/interface.go
+++ b/lib/clientv2/interface.go
@@ -37,8 +37,10 @@ type Interface interface {
 	IPAM() ipam.Interface
 	// BGPConfigurations returns an interface for managing the BGP configuration resources.
 	BGPConfigurations() BGPConfigurationInterface
-	// FelixConfiguration returns an interface for managing the Felix configuration resources.
+	// FelixConfigurations returns an interface for managing the Felix configuration resources.
 	FelixConfigurations() FelixConfigurationInterface
+	// ClusterInformation returns an interface for managing the cluster information resource.
+	ClusterInformation() ClusterInformationInterface
 	// EnsureInitialized is used to ensure the backend datastore is correctly
 	// initialized for use by Calico.  This method may be called multiple times, and
 	// will have no effect if the datastore is already correctly initialized.


### PR DESCRIPTION
## Description
Adding the ClusterInformation resource as well as the functionality and tests for CRUD operations.

## Todos
- [x] Tests
- [x] Documentation (not needed here now)
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
