### PR TITLE
Remove synced event type from the Watchers and add a watch terminating event type

### DIFF
--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -452,23 +451,6 @@ func getKeyValueStrings(d *model.KVPair) (string, string, error) {
 	}
 
 	return key, string(bytes), nil
-}
-
-// etcdToKVPair converts an etcd KeyValue in to model.KVPair.
-func etcdToKVPair(key model.Key, ekv *mvccpb.KeyValue) (*model.KVPair, error) {
-	v, err := model.ParseValue(key, ekv.Value)
-	if err != nil {
-		return nil, cerrors.ErrorDatastoreError{
-			Identifier: key,
-			Err:        err,
-		}
-	}
-
-	return &model.KVPair{
-		Key:      key,
-		Value:    v,
-		Revision: strconv.FormatInt(ekv.ModRevision, 10),
-	}, nil
 }
 
 // parseRevision parses the model.KVPair revision string and converts to the

--- a/lib/clientv2/bgpconfig_e2e_test.go
+++ b/lib/clientv2/bgpconfig_e2e_test.go
@@ -404,9 +404,6 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type: watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -433,9 +430,6 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/bgppeer_e2e_test.go
+++ b/lib/clientv2/bgppeer_e2e_test.go
@@ -365,9 +365,6 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -394,9 +391,6 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/clusterinfo_e2e_test.go
+++ b/lib/clientv2/clusterinfo_e2e_test.go
@@ -15,12 +15,12 @@
 package clientv2_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/apiv2"
@@ -317,9 +317,6 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/felixconfig_e2e_test.go
+++ b/lib/clientv2/felixconfig_e2e_test.go
@@ -368,9 +368,6 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type: watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -397,9 +394,6 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type: watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -369,9 +369,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -398,9 +395,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/hostendpoint_e2e_test.go
+++ b/lib/clientv2/hostendpoint_e2e_test.go
@@ -362,9 +362,6 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -391,9 +388,6 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/ippool_e2e_test.go
+++ b/lib/clientv2/ippool_e2e_test.go
@@ -366,9 +366,6 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -395,9 +392,6 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/networkpolicy_e2e_test.go
+++ b/lib/clientv2/networkpolicy_e2e_test.go
@@ -381,9 +381,6 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -365,9 +365,6 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -394,9 +391,6 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreAll, fun
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/profile_e2e_test.go
+++ b/lib/clientv2/profile_e2e_test.go
@@ -364,9 +364,6 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -393,9 +390,6 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreAll, 
 				{
 					Type:   watch.Added,
 					Object: outRes3,
-				},
-				{
-					Type:	watch.Synced,
 				},
 			})
 

--- a/lib/clientv2/resources.go
+++ b/lib/clientv2/resources.go
@@ -327,7 +327,6 @@ func (w *watcher) terminate() {
 func (w *watcher) convertEvent(backendEvent bapi.WatchEvent) watch.Event {
 	apiEvent := watch.Event{
 		Error: backendEvent.Error,
-		ResourceVersion: backendEvent.Revision,
 	}
 	switch backendEvent.Type {
 	case bapi.WatchError:
@@ -338,8 +337,6 @@ func (w *watcher) convertEvent(backendEvent bapi.WatchEvent) watch.Event {
 		apiEvent.Type = watch.Deleted
 	case bapi.WatchModified:
 		apiEvent.Type = watch.Modified
-	case bapi.WatchSynced:
-		apiEvent.Type = watch.Synced
 	}
 
 	if backendEvent.Old != nil {

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -390,9 +390,6 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 					Type:   watch.Added,
 					Object: outRes3,
 				},
-				{
-					Type:	watch.Synced,
-				},
 			})
 			testWatcher3.Stop()
 
@@ -414,7 +411,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			testWatcher4.Stop()
 		})
 	})
-	
+
 	Describe("WorkloadEndpoint prefix list", func() {
 		It("should handle prefix lists of workload endpoints", func() {
 			c, err := clientv2.New(config)
@@ -429,11 +426,11 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace1", Name: "node--1-k8s-pod-eth0"},
-					Spec:       apiv2.WorkloadEndpointSpec{
-						Node: "node-1",
-						Orchestrator: "k8s",
-						Pod: "pod",
-						Endpoint: "eth0",
+					Spec: apiv2.WorkloadEndpointSpec{
+						Node:          "node-1",
+						Orchestrator:  "k8s",
+						Pod:           "pod",
+						Endpoint:      "eth0",
 						InterfaceName: "cali1234",
 					},
 				},
@@ -445,11 +442,11 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace1", Name: "node--1-k8s-pod--1-eth0"},
-					Spec:       apiv2.WorkloadEndpointSpec{
-						Node: "node-1",
-						Orchestrator: "k8s",
-						Pod: "pod-1",
-						Endpoint: "eth0",
+					Spec: apiv2.WorkloadEndpointSpec{
+						Node:          "node-1",
+						Orchestrator:  "k8s",
+						Pod:           "pod-1",
+						Endpoint:      "eth0",
 						InterfaceName: "cali1234",
 					},
 				},
@@ -462,11 +459,11 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				ctx,
 				&apiv2.WorkloadEndpoint{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace2", Name: "node--1-k8s-pod--2-eth0"},
-					Spec:       apiv2.WorkloadEndpointSpec{
-						Node: "node-1",
-						Orchestrator: "k8s",
-						Pod: "pod-2",
-						Endpoint: "eth0",
+					Spec: apiv2.WorkloadEndpointSpec{
+						Node:          "node-1",
+						Orchestrator:  "k8s",
+						Pod:           "pod-2",
+						Endpoint:      "eth0",
 						InterfaceName: "cali1235",
 					},
 				},

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -153,3 +153,23 @@ func UpdateErrorIdentifier(err error, id interface{}) error {
 	}
 	return err
 }
+
+// Error indicating the watcher has been terminated.
+type ErrorWatchTerminated struct {
+	Err error
+}
+
+func (e ErrorWatchTerminated) Error() string {
+	return fmt.Sprintf("watch terminated: %s", e.Err)
+}
+
+// Error indicating the datastore has failed to parse an entry.
+type ErrorParsingDatastoreEntry struct {
+	RawKey   string
+	RawValue string
+	Err      error
+}
+
+func (e ErrorParsingDatastoreEntry) Error() string {
+	return fmt.Sprintf("failed to parse datastore entry key=%s; value=%s: %s", e.RawKey, e.RawValue, e.Err)
+}

--- a/lib/names/workloadendpoint_test.go
+++ b/lib/names/workloadendpoint_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/names"
 )
 
-var _ =	DescribeTable("WorkloadEndpoint name construction, fully qualified names",
+var _ = DescribeTable("WorkloadEndpoint name construction, fully qualified names",
 	func(ids names.WorkloadEndpointIdentifiers, expectedName string, expectedErroredField string) {
 		name, err := ids.CalculateWorkloadEndpointName(false)
 		if len(expectedErroredField) != 0 {
@@ -80,7 +80,7 @@ var _ =	DescribeTable("WorkloadEndpoint name construction, fully qualified names
 	}, "", "workload"),
 )
 
-var _ =DescribeTable("WorkloadEndpoint name construction, name prefix",
+var _ = DescribeTable("WorkloadEndpoint name construction, name prefix",
 	func(ids names.WorkloadEndpointIdentifiers, expectedName string, expectedErroredField string) {
 		name, err := ids.CalculateWorkloadEndpointName(true)
 		if len(expectedErroredField) != 0 {
@@ -196,4 +196,3 @@ var _ = DescribeTable("WorkloadEndpoint name matching",
 		Endpoint:     "eth0",
 	}, "node--1-k8s-pod-eth0-extra", false, ""),
 )
-

--- a/lib/testutils/resources.go
+++ b/lib/testutils/resources.go
@@ -157,13 +157,6 @@ func (t *testResourceWatcher) ExpectEvents(kind string, events []watch.Event) {
 		} else {
 			Expect(t.events[i].Previous).To(BeNil())
 		}
-
-		// For synced events we can only check that the event contained a resource version
-		// but not what the resource version was (at least it's difficult to assert that in
-		// case other events in the datastore are changing the revision).
-		if t.events[i].Type == watch.Synced {
-			Expect(t.events[i].ResourceVersion).ToNot(Equal(""))
-		}
 	}
 
 	// Remove the events we've already validated.

--- a/lib/watch/interface.go
+++ b/lib/watch/interface.go
@@ -46,17 +46,10 @@ const (
 	// Error
 	// * an error has occurred.  If the error is terminating, the results channel
 	//   will be closed.
-	// Synced
-	// * If the Watcher does not have a specific ResourceVersion to watch from,
-	//   existing entries will first be listed.  The current entries are sent as
-	//   "Added" events followed by a Synced Event, and then followed by events from
-	//   watching the data.  A Synced event will specify the ResourceVersion from which
-	//   the watch begins.
 	Added    EventType = "ADDED"
 	Modified EventType = "MODIFIED"
 	Deleted  EventType = "DELETED"
 	Error    EventType = "ERROR"
-	Synced   EventType = "SYNCED"
 
 	DefaultChanSize int32 = 100
 )
@@ -73,10 +66,6 @@ type Event struct {
 	//  * If Type is Deleted, Error or Synced: nil
 	Previous runtime.Object
 	Object   runtime.Object
-
-	// ResourceVersion is only set when Type is Synced.  See EventType definitions
-	// for details.
-	ResourceVersion string
 
 	// The error, if EventType is Error.
 	Error error

--- a/run-uts
+++ b/run-uts
@@ -12,13 +12,19 @@ fi
 echo "Removing old coverprofiles..."
 find . -name "*.coverprofile" -type f -delete
 
-echo "Calculating packages to cover..."
-go_dirs=$(find -type f -name '*.go' | \
-	      grep -vE '/vendor/|.glide|.git' | \
-	      xargs -n 1 dirname | \
-	      sort | uniq | \
-	      tr '\n' ',' | \
-	      sed 's/,$//' )
+if [ -z $WHAT ]
+then
+    echo "Calculating packages to cover..."
+    go_dirs=$(find -type f -name '*.go' | \
+	          grep -vE '/vendor/|.glide|.git' | \
+	          xargs -n 1 dirname | \
+	          sort | uniq | \
+	          tr '\n' ',' | \
+	          sed 's/,$//' )
+else
+    go_dirs=$WHAT
+fi
+
 echo "Covering: $go_dirs"
 test ! -z "$go_dirs"
 


### PR DESCRIPTION
G5 it turns out adding the synced state to the watcher will make the KDD processing for Watchers much more complicated and doesn't ultimately buy us anything.

So I'm removing.

One thing that was missing though was the ability to determine if the error from the Watcher indicates that the watcher had been closed.  So I've added a new error type which provides that indication.