### PR TITLE
Add a generic syncer built upon an arbitrary set of watchers

### DIFF
--- a/lib/backend/watchersyncer/doc.go
+++ b/lib/backend/watchersyncer/doc.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+watchersyncer package contains a syncer interface that can be used to sync from an
+arbitrary set of Watchers.
+
+Optional processors may be specified for each watch type that convert between the
+raw data returned by the watch and the updates returned by the syncer.
+
+The implementation could easily be ported to work on the main client Watcher which
+would be the preferred approach once all of the entries that we need to watch are
+defined as resource types.
+
+We implement this as a syncer rather than a "multi-watcher", because the syncer
+doesn't need to maintain previous values of resources to send delete events (it only
+needs to maintain keys).  This has a smaller footprint that an equivalent multi-watcher
+would have.
+*/
+package watchersyncer

--- a/lib/backend/watchersyncer/watchercache.go
+++ b/lib/backend/watchersyncer/watchercache.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+// The watcherCache provides watcher/syncer support for a single key type in the
+// backend.  These results are sent to the main WatcherSyncer on a buffered "results"
+// channel.  To ensure the order of events is received correctly by the main WatcherSyncer,
+// we send all notification types in this channel.  Note that because of this the results
+// channel is untyped - however the watcherSyncer only expects one of the following
+// types:
+// -  An error
+// -  An api.Update
+// -  A api.SyncStatus (only for the very first InSync notification)
+type watcherCache struct {
+	logger       *logrus.Entry
+	client       api.Client
+	watch        api.WatchInterface
+	resources    map[string]cacheEntry
+	oldResources map[string]cacheEntry
+	results      chan<- interface{}
+	hasSynced    bool
+	resourceType ResourceType
+}
+
+var (
+	ListRetryInterval = 1000 * time.Millisecond
+	WatchPollInterval = 5000 * time.Millisecond
+)
+
+// cacheEntry is an entry in our cache.  It groups the a key with the last known
+// revision that we processed.  We store the revision so that we can determine
+// if an entry has been updated (adn therefore whether we need to send an update
+// event in the syncer callback).
+type cacheEntry struct {
+	revision string
+	key      model.Key
+}
+
+// Create a new watcherCache.
+func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- interface{}) *watcherCache {
+	return &watcherCache{
+		logger:       logrus.WithField("ListRoot", model.ListOptionsToDefaultPathRoot(resourceType.ListInterface)),
+		client:       client,
+		resourceType: resourceType,
+		results:      results,
+		resources:    make(map[string]cacheEntry, 0),
+	}
+}
+
+// run creates the watcher and loops indefinitely reading from the watcher.
+func (wc *watcherCache) run() {
+	wc.logger.Debug("Watcher cache starting, start initial sync processing")
+	wc.resyncAndCreateWatcher()
+
+	wc.logger.Debug("Starting main event processing loop")
+	for {
+		rc := wc.watch.ResultChan()
+		wc.logger.WithField("RC", rc).Debug("Reading event from results channel")
+		event := <-rc
+		switch event.Type {
+		case api.WatchAdded, api.WatchModified:
+			kvp := event.New
+			wc.handleWatchListEvent(kvp)
+		case api.WatchDeleted:
+			// Nil out the value to indicate a delete.
+			kvp := event.Old
+			kvp.Value = nil
+			wc.handleWatchListEvent(kvp)
+		case api.WatchError:
+			// Handle a WatchError.  First determine if the error type indicates that the
+			// watch has closed, and if so we'll need to resync and create a new watcher.
+			wc.results <- event.Error
+			if _, ok := event.Error.(cerrors.ErrorWatchTerminated); ok {
+				wc.logger.Info("Received watch terminated error - recreate watcher")
+				wc.resyncAndCreateWatcher()
+			}
+		default:
+			// Unknown event type - not much we can do other than log.
+			wc.logger.WithField("EventType", event.Type).Info("Unknown event type received from the datastore")
+		}
+	}
+}
+
+// resyncAndCreateWatcher loops performing resync processing until it successfully
+// completes a resync and starts a watcher.
+func (wc *watcherCache) resyncAndCreateWatcher() {
+	// Make sure any previous watcher is stopped.
+	wc.logger.Info("Starting watch sync/resync processing")
+	if wc.watch != nil {
+		wc.logger.Info("Stopping previous watcher")
+		wc.watch.Stop()
+		wc.watch = nil
+	}
+
+	for {
+		// Start the resync.  This processing loops until we create the watcher.  If the
+		// watcher continuously fails then this loop effectively becomes a polling based
+		// syncer.
+		wc.logger.Debug("Starting main resync loop")
+
+		// Notify the converter that we are resyncing.
+		if wc.resourceType.UpdateProcessor != nil {
+			wc.logger.Debug("Trigger converter resync notification")
+			wc.resourceType.UpdateProcessor.OnSyncerStarting()
+		}
+
+		// Start the sync by Listing the current resources.
+		l, err := wc.client.List(context.Background(), wc.resourceType.ListInterface, "")
+		if err != nil {
+			// Failed to perform the list.  Pause briefly (so we don't tight loop) and retry.
+			wc.logger.WithError(err).Debug("Failed to perform list of current data during resync")
+			time.Sleep(ListRetryInterval)
+			continue
+		}
+
+		// Move the current resources over to the oldResources
+		wc.oldResources = wc.resources
+		wc.resources = make(map[string]cacheEntry, 0)
+
+		// Send updates for each of the resources we listed - this will revalidate entries in
+		// the oldResources map.
+		for _, kvp := range l.KVPairs {
+			wc.handleWatchListEvent(kvp)
+		}
+
+		// We've listed the current settings.  Complete the sync by notifying the main WatcherSyncer
+		// go routine (if we haven't already) and by sending deletes for the old resources that were
+		// not acknowledged by the List.  The oldResources will be empty after this call.
+		wc.finishResync()
+
+		// And now start watching from the revision returned by the List.
+		w, err := wc.client.Watch(context.Background(), wc.resourceType.ListInterface, l.Revision)
+		if err != nil {
+			// Failed to create the watcher - we'll need to retry.  Sleep so that we don't
+			// tight loop.  Since we have just performed a list, we need a slightly longer
+			// delay to avoid overloading the datastore.  If the watcher keeps failing then
+			// we are effectively operating in a polling mode, so the interval should be a
+			// sensible polling interval.
+			wc.logger.WithError(err).Debug("Failed to create watcher")
+			time.Sleep(WatchPollInterval)
+			continue
+		}
+
+		// Store the watcher and exit back to the main event loop.
+		wc.logger.Debug("Resync completed, now watching for change events")
+		wc.watch = w
+		return
+	}
+}
+
+// finishResync handles processing to finish synchronization.
+// If this watcher has never been synced then notify the main watcherSyncer that we've synced.
+// We may also need to send deleted messages for old resources that were not validated in the
+// resync (i.e. they must have since been deleted).
+func (wc *watcherCache) finishResync() {
+	// If this is our first synced event then send a synced notification.  The main
+	// watcherSyncer code will send a Synced event when it has received synced events from
+	// each cache.
+	if !wc.hasSynced {
+		wc.logger.Info("Sending synced update")
+		wc.results <- api.InSync
+		wc.hasSynced = true
+	}
+
+	// If the watcher failed at any time, we end up recreating a watcher and storing off
+	// the current known resources for revalidation.  Now that we have finished the sync,
+	// any of the remaining resources that were not accounted for must have been deleted
+	// and we need to send deleted events for them.
+	numOldResources := len(wc.oldResources)
+	if numOldResources > 0 {
+		wc.logger.WithField("Num", numOldResources).Debug("Sending resync deletes")
+		updates := make([]api.Update, 0, len(wc.oldResources))
+		for _, r := range wc.oldResources {
+			updates = append(updates, api.Update{
+				UpdateType: api.UpdateTypeKVDeleted,
+				KVPair: model.KVPair{
+					Key: r.key,
+				},
+			})
+		}
+		wc.results <- updates
+	}
+	wc.oldResources = nil
+}
+
+// handleWatchListEvent handles a watch event converting it if required and passing to
+// handleConvertedWatchEvent to send the appropriate update types.
+func (wc *watcherCache) handleWatchListEvent(kvp *model.KVPair) {
+	if wc.resourceType.UpdateProcessor == nil {
+		// No update processor - handle immediately.
+		wc.handleConvertedWatchEvent(kvp)
+		return
+	}
+
+	// We have an update processor so use that to convert the event data.
+	kvps, err := wc.resourceType.UpdateProcessor.Process(kvp)
+	for _, kvp := range kvps {
+		wc.handleConvertedWatchEvent(kvp)
+	}
+
+	// If we hit a conversion error, notify the main syncer.
+	if err != nil {
+		wc.results <- err
+	}
+}
+
+// handleConvertedWatchEvent handles a converted watch event fanning out
+// to the add/mod or delete processing as necessary.
+func (wc *watcherCache) handleConvertedWatchEvent(kvp *model.KVPair) {
+	if kvp.Value == nil {
+		wc.handleDeletedUpdate(kvp.Key)
+	} else {
+		wc.handleAddedOrModifiedUpdate(kvp)
+	}
+}
+
+// handleAddedOrModifiedUpdate handles a single Added or Modified update request.
+// Whether we send an Added or Modified depends on whether we have already sent
+// an added notification for this resource.
+func (wc *watcherCache) handleAddedOrModifiedUpdate(kvp *model.KVPair) {
+	thisKey := kvp.Key
+	thisKeyString := thisKey.String()
+	thisRevision := kvp.Revision
+	wc.markAsValid(thisKeyString)
+
+	// If the resource is already in our map, then this is a modified event.  Check the
+	// revision to see if we actually need to send an update.
+	if resource, ok := wc.resources[thisKeyString]; ok {
+		if resource.revision == thisRevision {
+			// No update to revision, so no event to send.
+			wc.logger.WithField("Key", thisKeyString).Debug("Swallowing event update from datastore because entry is same as cached entry")
+			return
+		}
+		// Resource is modified, send an update event and store the latest revision.
+		wc.logger.WithField("Key", thisKeyString).Debug("Datastore entry modified, sending syncer update")
+		wc.results <- []api.Update{{
+			UpdateType: api.UpdateTypeKVUpdated,
+			KVPair:     *kvp,
+		}}
+		resource.revision = thisRevision
+		wc.resources[thisKeyString] = resource
+		return
+	}
+
+	// The resource has not been seen before, so send a new event, and store the
+	// current revision.
+	wc.logger.WithField("Key", thisKeyString).Debug("Cache entry added, sending syncer update")
+	wc.results <- []api.Update{{
+		UpdateType: api.UpdateTypeKVNew,
+		KVPair:     *kvp,
+	}}
+	wc.resources[thisKeyString] = cacheEntry{
+		revision: thisRevision,
+		key:      thisKey,
+	}
+}
+
+// handleDeletedWatchEvent sends a deleted event and removes the resource key from our cache.
+func (wc *watcherCache) handleDeletedUpdate(key model.Key) {
+	thisKeyString := key.String()
+	wc.markAsValid(thisKeyString)
+
+	// If we have seen an added event for this key then send a deleted event and remove
+	// from the cache.
+	if _, ok := wc.resources[thisKeyString]; ok {
+		wc.logger.WithField("Key", thisKeyString).Debug("Datastore entry deleted, sending syncer update")
+		wc.results <- []api.Update{{
+			UpdateType: api.UpdateTypeKVDeleted,
+			KVPair: model.KVPair{
+				Key: key,
+			},
+		}}
+		delete(wc.resources, thisKeyString)
+	}
+}
+
+// markAsValid marks a resource that we have just seen as valid, by moving it from the set of
+// "oldResources" that were stored during the resync back into the main "resources" set.  Any entries
+// remaining in the oldResources map once the current snapshot events have been processed, indicates
+// entries that were deleted during the resync - see corresponding code in finishResync().
+func (wc *watcherCache) markAsValid(resourceKey string) {
+	if wc.oldResources != nil {
+		if oldResource, ok := wc.oldResources[resourceKey]; ok {
+			wc.logger.WithField("Key", resourceKey).Debug("Marking key as re-processed")
+			wc.resources[resourceKey] = oldResource
+			delete(wc.oldResources, resourceKey)
+		}
+	}
+}

--- a/lib/backend/watchersyncer/watchersyncer.go
+++ b/lib/backend/watchersyncer/watchersyncer.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+const (
+	maxUpdatesToConsolidate = 1000
+)
+
+// ResourceType groups together the watch and conversion information for a
+// specific resource type.
+type ResourceType struct {
+	// The ListInterface used to perform a watch on this resource type.
+	ListInterface model.ListInterface
+
+	// An update processor used to convert the update event prior to it being sent in
+	// the Syncer.
+	UpdateProcessor SyncerUpdateProcessor
+}
+
+// SyncerUpdateProcessor is used to convert a Watch update into one or more additional
+// Syncer updates.
+type SyncerUpdateProcessor interface {
+	// Process is called to process a watch update.  The processor may convert this
+	// to zero or more updates.  The processor may use these calls to maintain a local cache
+	// if required.  It is safe for the processor to send multiple duplicate adds or deletes
+	// since the WatcherSyncer maintains it's own cache and will swallow duplicates.
+	// A KVPair with a nil value indicates a delete.  A non nil value indicates an add/modified.
+	// The processor may respond with any number of adds or deletes.
+	Process(*model.KVPair) ([]*model.KVPair, error)
+
+	// OnSyncerStarting is called when syncer is starting a full sync for the associated resource
+	// type.  That means it is first going to list current resources and then watch for any updates.
+	// If the processor maintains a private internal cache, then the cache should be cleared at
+	// this point since the cache will be re-populated from the sync.
+	OnSyncerStarting()
+}
+
+// New creates a new multiple Watcher-backed api.Syncer.
+func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks) api.Syncer {
+	rs := &watcherSyncer{
+		watcherCaches: make([]*watcherCache, len(resourceTypes)),
+		results:       make(chan interface{}, 2000),
+		callbacks:     callbacks,
+	}
+	for i, r := range resourceTypes {
+		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results)
+	}
+	return rs
+}
+
+// watcherSyncer implements the api.Syncer interface.
+type watcherSyncer struct {
+	status        api.SyncStatus
+	watcherCaches []*watcherCache
+	results       chan interface{}
+	numSynced     int
+	callbacks     api.SyncerCallbacks
+}
+
+func (rs *watcherSyncer) Start() {
+	log.Info("Start called")
+	go rs.run()
+}
+
+// Send a status update and store the status.
+func (rs *watcherSyncer) sendStatusUpdate(status api.SyncStatus) {
+	log.WithField("Status", status).Info("Sending status update")
+	rs.callbacks.OnStatusUpdated(status)
+	rs.status = status
+}
+
+// run implements the main syncer loop that loops forever receiving watch events and translating
+// to syncer updates.
+func (rs *watcherSyncer) run() {
+	log.Debug("Sending initial status event and starting watchers")
+	rs.sendStatusUpdate(api.WaitForDatastore)
+	for _, wc := range rs.watcherCaches {
+		go wc.run()
+	}
+
+	log.Info("Starting main event processing loop")
+	var updates []api.Update
+	for {
+		// Block until there is data.
+		result := <-rs.results
+
+		// Process the data - this will append the data in subsequent calls, and action
+		// it if we hit a non-update event.
+		updates := rs.processResult(updates, result)
+
+		// Append results into the one update until we either flush the channel or we
+		// hit our fixed limit per update.
+	consolidatationloop:
+		for ii := 0; ii < maxUpdatesToConsolidate; ii++ {
+			select {
+			case next := <-rs.results:
+				updates = rs.processResult(updates, next)
+			default:
+				break consolidatationloop
+			}
+		}
+
+		// Perform final processing (pass in a nil result) before we loop and hit the blocking
+		// call again.
+		updates = rs.sendUpdates(updates)
+	}
+}
+
+// Process a result from the result channel.  We don't immediately action updates, but
+// instead start grouping them together so that we can send a larger single update to
+// Felix.
+func (rs *watcherSyncer) processResult(updates []api.Update, result interface{}) []api.Update {
+
+	// Switch on the result type.
+	switch r := result.(type) {
+	case []api.Update:
+		// This is an update.  If we don't have previous updates then also check to see
+		// if we need to shift the status into Resync.
+		// We append these updates to the previous if there were any.
+		if len(updates) == 0 && rs.status == api.WaitForDatastore {
+			rs.sendStatusUpdate(api.ResyncInProgress)
+		}
+		updates = append(updates, r...)
+
+	case error:
+		// Received an error.  Firstly, send any updates that we have grouped.
+		updates = rs.sendUpdates(updates)
+
+		// If this is a parsing error, and if the callbacks support
+		// it, then send the error update.
+		log.WithError(r).Info("Error received in main syncer event processing loop")
+		if ec, ok := rs.callbacks.(api.SyncerParseFailCallbacks); ok {
+			log.Debug("SyncerParseFailCallbacks interface is supported")
+			if pe, ok := r.(cerrors.ErrorParsingDatastoreEntry); ok {
+				ec.ParseFailed(pe.RawKey, pe.RawValue)
+			}
+		}
+
+	case api.SyncStatus:
+		// Received a synced event.  If we are still waiting for datastore, send a
+		// ResyncInProgress since at least one watcher has connected.
+		log.WithField("SyncUpdate", r).Debug("Received sync status event from watcher")
+		if r == api.InSync {
+			log.Info("Received InSync event from one of the watcher caches")
+
+			if rs.status == api.WaitForDatastore {
+				rs.sendStatusUpdate(api.ResyncInProgress)
+			}
+
+			// Increment the count of synced events.
+			rs.numSynced++
+
+			// If we have now received synced events from all of our watchers then we are in
+			// sync.  If we have any updates, send them first and then send the status update.
+			if rs.numSynced == len(rs.watcherCaches) {
+				log.Info("All watchers have sync'd data - sending data and final sync")
+				updates = rs.sendUpdates(updates)
+				rs.sendStatusUpdate(api.InSync)
+			}
+		}
+	}
+
+	// Return the accumulated or processed updated.
+	return updates
+}
+
+// sendUpdates is used to send the consoidated set of updates.  Returns nil.
+func (rs *watcherSyncer) sendUpdates(updates []api.Update) []api.Update {
+	log.WithField("NumUpdates", len(updates)).Debug("Sending syncer updates (if any to send)")
+	if len(updates) > 0 {
+		rs.callbacks.OnUpdates(updates)
+	}
+	return nil
+}

--- a/lib/backend/watchersyncer/watchersyncer_suite_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Backend multi-watcher/syncer test suite")
+}

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1,0 +1,1115 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var (
+	dsError = cerrors.ErrorDatastoreError{Err: errors.New("Generic datastore error")}
+	l1Key1  = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace1",
+		Name:      "policy-1",
+	}
+	l1Key2 = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace1",
+		Name:      "policy-2",
+	}
+	l1Key3 = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace2",
+		Name:      "policy-1",
+	}
+	l1Key4 = model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Namespace: "namespace2999",
+		Name:      "policy-1000",
+	}
+	l2Key1 = model.ResourceKey{
+		Kind: apiv2.KindIPPool,
+		Name: "ippool-1",
+	}
+	l2Key2 = model.ResourceKey{
+		Kind: apiv2.KindIPPool,
+		Name: "ippool-2",
+	}
+	l3Key1 = model.BlockAffinityKey{
+		CIDR: cnet.MustParseCIDR("1.2.3.0/24"),
+		Host: "mynode",
+	}
+	emptyList = &model.KVPairList{
+		Revision: "abcdef12345",
+	}
+	genError = errors.New("Generic error")
+)
+
+var _ = Describe("Test the backend datstore multi-watch syncer", func() {
+
+	r1 := watchersyncer.ResourceType{
+		ListInterface: model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+	}
+	r2 := watchersyncer.ResourceType{
+		ListInterface: model.ResourceListOptions{Kind: apiv2.KindIPPool},
+	}
+	r3 := watchersyncer.ResourceType{
+		ListInterface: model.BlockAffinityListOptions{},
+	}
+
+	It("should receive a sync event when the watchers have listed current settings", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.clientListResponse(r2, emptyList)
+		rs.ExpectStatusUnchanged()
+		rs.clientListResponse(r3, emptyList)
+		rs.ExpectStatusUpdate(api.InSync)
+	})
+
+	It("should handle reconnection if watchers fail to be created", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+
+		// Temporarily reduce the watch and list poll interval to make the tests faster.
+		// Since we are timing the processing, we still need the interval to be sufficiently
+		// large to make the measurements more accurate.
+		defer setWatchIntervals(watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
+		setWatchIntervals(500*time.Millisecond, 2000*time.Millisecond)
+
+		// All of the events should have been consumed within a time frame dictated by the
+		// list retry and poll timers.
+		//
+		// For resource 1, the client responses should be:
+		// - list succeeds
+		// - watch fails (watch interval)
+		// - list fails (list interval)
+		// - list succeeds
+		// - watch succeeds ...
+		//
+		// For resource 2, the client responses should be:
+		// - list succeeds
+		// - watch fails (watch interval)
+		// - list succeeds
+		// - watch fails (watch interval)
+		// - list succeeds
+		// - watch succeeds ...
+		//
+		// The longest of these is resource 2 (since the watcher poll timer is longer).  We'll
+		// check that connection succeeds within +- 30% of the expected interval.
+		By("Driving a bunch of List complete, Watch fail events for 2/3 resource types")
+		expectedDuration := watchersyncer.WatchPollInterval * 2
+		minDuration := 70 * expectedDuration / 100
+		maxDuration := 130 * expectedDuration / 100
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.clientWatchResponse(r1, genError)
+		rs.clientListResponse(r1, genError)
+		rs.clientListResponse(r1, emptyList)
+		rs.clientWatchResponse(r1, nil)
+		rs.clientListResponse(r2, emptyList)
+		rs.clientWatchResponse(r2, genError)
+		rs.clientListResponse(r2, emptyList)
+		rs.clientWatchResponse(r2, genError)
+		rs.clientListResponse(r2, emptyList)
+		rs.clientWatchResponse(r2, nil)
+		By("Expecting the time for all events to be handled is within a sensible window")
+		before := time.Now()
+		for i := time.Duration(0); i < maxDuration/(10*time.Millisecond); i++ {
+			if rs.allEventsHandled() {
+				break
+			}
+			time.Sleep(minDuration / 50)
+		}
+		duration := time.Now().Sub(before)
+		rs.expectAllEventsHandled()
+		Expect(duration).To(BeNumerically(">", minDuration))
+		Expect(duration).To(BeNumerically("<", maxDuration))
+		rs.ExpectStatusUnchanged()
+
+		// Sim. for resource 3.  We send in these client responses:
+		// - list succeeds
+		// - watch fails (watch interval)
+		// - list fails (list interval)
+		// - list succeeds
+		// - watch succeeds ... total 6s
+		By("Driving a bunch of List complete, Watch fail events for the 3rd resource type")
+		expectedDuration = watchersyncer.WatchPollInterval * watchersyncer.ListRetryInterval
+		minDuration = 70 * expectedDuration / 100
+		maxDuration = 130 * expectedDuration / 100
+		rs.clientListResponse(r3, emptyList)
+		rs.ExpectStatusUpdate(api.InSync)
+		rs.clientWatchResponse(r3, genError)
+		rs.clientListResponse(r3, genError)
+		rs.clientListResponse(r3, emptyList)
+		rs.clientWatchResponse(r3, nil)
+		By("Expecting the time for the events of the final resource sync to be handled is within sensible window")
+		before = time.Now()
+		Expect(rs.allEventsHandled()).To(BeFalse())
+		for i := time.Duration(0); i < maxDuration/(10*time.Millisecond); i++ {
+			if rs.allEventsHandled() {
+				break
+			}
+			time.Sleep(minDuration / 50)
+		}
+		duration = time.Now().Sub(before)
+		rs.expectAllEventsHandled()
+		Expect(duration).To(BeNumerically(">", minDuration))
+		Expect(duration).To(BeNumerically("<", maxDuration))
+	})
+
+	It("Should handle reconnection and syncing when the watcher sends a watch terminated error", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.clientWatchResponse(r1, nil)
+		rs.clientListResponse(r2, emptyList)
+		rs.clientWatchResponse(r2, nil)
+		rs.ExpectStatusUnchanged()
+		rs.clientListResponse(r3, emptyList)
+		rs.ExpectStatusUpdate(api.InSync)
+		rs.clientWatchResponse(r3, nil)
+		rs.sendEvent(r3, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		rs.clientListResponse(r3, emptyList)
+		rs.clientWatchResponse(r3, nil)
+
+		// Watch fails, but gets created again immediately.  This should happen without
+		// additional pauses.
+		rs.expectAllEventsHandled()
+	})
+
+	It("Should handle receiving events while one watcher fails and fails to recreate", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		eventL1Added1 := addEvent(l1Key1)
+		eventL2Added1 := addEvent(l2Key1)
+		eventL2Added2 := addEvent(l2Key2)
+		eventL3Added1 := addEvent(l3Key1)
+
+		// Temporarily reduce the watch and list poll interval to make the tests faster.
+		defer setWatchIntervals(watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond)
+
+		By("Syncing a single result for resource 1 and creating the watch")
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, &model.KVPairList{
+			Revision: "aabababababa",
+			KVPairs: []*model.KVPair{
+				{
+					Revision: eventL1Added1.New.Revision,
+					Key:      eventL1Added1.New.Key,
+					Value:    eventL1Added1.New.Value,
+				},
+			},
+		})
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.clientWatchResponse(r1, nil)
+
+		// For resource 2 we fail to create a watch.  This will invoke the watch poll interval.
+		By("Syncing no results for resource 2, failing to create a watch, retrying successfully.")
+		rs.clientListResponse(r2, emptyList)
+		rs.clientWatchResponse(r2, genError)
+		rs.clientListResponse(r2, emptyList)
+		rs.clientWatchResponse(r2, nil)
+		time.Sleep(130 * watchersyncer.WatchPollInterval / 100)
+		rs.expectAllEventsHandled()
+
+		By("Sending two watch events for resource 2.")
+		rs.sendEvent(r2, eventL2Added1)
+		rs.sendEvent(r2, eventL2Added2)
+
+		By("Syncing no reults for resource 3, creating a watcher and then terminating the watcher.")
+		rs.clientListResponse(r3, emptyList)
+		rs.ExpectStatusUpdate(api.InSync)
+		rs.clientWatchResponse(r3, nil)
+		rs.sendEvent(r3, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		// All events should be handled.
+		rs.expectAllEventsHandled()
+
+		By("Validating we are still resyncing and we have received all the current events thus far")
+		rs.ExpectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Added2.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		})
+
+		By("Checking that resource 3 can reconnect and then receive events")
+		rs.clientListResponse(r3, emptyList)
+		rs.clientWatchResponse(r3, nil)
+		rs.sendEvent(r3, eventL3Added1)
+		rs.ExpectUpdates([]api.Update{
+			{
+				KVPair:     *eventL3Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		})
+	})
+
+	It("Should not resend add events during a resync and should delete stale entries", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		eventL1Added1 := addEvent(l1Key1)
+		eventL1Deleted1 := deleteEvent(l1Key1)
+		eventL1Added2 := addEvent(l1Key2)
+		eventL1Added3 := addEvent(l1Key3)
+		eventL1Added4 := addEvent(l1Key4)
+		eventL1Modified4 := modifiedEvent(l1Key4)
+		eventL1Modified4_2 := modifiedEvent(l1Key4)
+
+		// Temporarily reduce the watch and list poll interval to make the tests faster.
+		defer setWatchIntervals(watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond)
+
+		By("returning a sync list with three entries and then failing the watch")
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, &model.KVPairList{
+			Revision: "12345",
+			KVPairs: []*model.KVPair{
+				eventL1Added1.New,
+				eventL1Added2.New,
+				eventL1Added3.New,
+			},
+		})
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.ExpectStatusUpdate(api.InSync)
+
+		// The retry thread will be blocked for the watch poll interval.
+		rs.clientWatchResponse(r1, genError)
+		time.Sleep(watchersyncer.WatchPollInterval)
+
+		By("returning a sync list with one entry removed and a new one added")
+		rs.clientListResponse(r1, &model.KVPairList{
+			Revision: "12346",
+			KVPairs: []*model.KVPair{
+				eventL1Added1.New,
+				eventL1Added3.New,
+				eventL1Added4.New,
+			},
+		})
+		rs.clientWatchResponse(r1, nil)
+
+		By("Expecting new events for the first three entries followed by an add and then the delete")
+		rs.ExpectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL1Added2.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL1Added3.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL1Added4.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				// Remove the Value for deleted.
+				KVPair: model.KVPair{
+					Key: eventL1Added2.New.Key,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			},
+		})
+
+		By("Sending a watch event updating one of the entries and deleting another")
+		rs.sendEvent(r1, eventL1Modified4)
+		rs.sendEvent(r1, eventL1Deleted1)
+
+		By("Sending the same events (bug) but same revision, so no updates expected")
+		rs.sendEvent(r1, eventL1Modified4)
+		rs.sendEvent(r1, eventL1Deleted1)
+
+		By("Failing the watch, and resyncing with another modified entry")
+		rs.sendEvent(r1, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: cerrors.ErrorWatchTerminated{Err: dsError},
+		})
+		rs.clientListResponse(r1, &model.KVPairList{
+			Revision: "12347",
+			KVPairs: []*model.KVPair{
+				eventL1Added3.New,
+				eventL1Modified4_2.New,
+			},
+		})
+		rs.clientWatchResponse(r1, nil)
+
+		By("Expecting mod, delete, mod updates")
+		rs.ExpectUpdates([]api.Update{
+			{
+				KVPair:     *eventL1Modified4.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+			{
+				// Remove the Value for deleted.
+				KVPair: model.KVPair{
+					Key: eventL1Deleted1.Old.Key,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			},
+			{
+				KVPair:     *eventL1Modified4_2.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+		})
+	})
+
+	It("Should accumulate updates into a single update when the handler thread is blocked", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2})
+		eventL1Added1 := addEvent(l1Key1)
+		eventL2Added1 := addEvent(l2Key1)
+		eventL2Added2 := addEvent(l2Key2)
+		eventL2Modified1 := modifiedEvent(l2Key1)
+		eventL2Modified1_2 := modifiedEvent(l2Key1)
+		eventL2Modified2 := modifiedEvent(l2Key2)
+		eventL1Delete1 := deleteEvent(l1Key1)
+
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.clientWatchResponse(r1, nil)
+		rs.clientListResponse(r2, emptyList)
+		rs.ExpectStatusUpdate(api.InSync)
+		rs.clientWatchResponse(r2, nil)
+
+		// Block the handling thread.  We need a single event to actual cause the main
+		// handling loop to block though, so send one.
+		rs.BlockUpdateHandling()
+		rs.sendEvent(r1, eventL1Added1)
+
+		// We should get the first update in a single update message, and then the update handler will block.
+		rs.ExpectOnUpdates([][]api.Update{{
+			{
+				KVPair:     *eventL1Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+		}})
+
+		// Send a few more events.
+		rs.sendEvent(r2, eventL2Added1)
+		rs.sendEvent(r2, eventL2Added2)
+		rs.sendEvent(r2, eventL2Modified1)
+
+		// Pause briefly before unblocking the update thread.
+		// We should receive three events in 1 OnUpdate message.
+		time.Sleep(100 * time.Millisecond)
+		rs.UnblockUpdateHandling()
+		rs.ExpectOnUpdates([][]api.Update{{
+			{
+				KVPair:     *eventL2Added1.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Added2.New,
+				UpdateType: api.UpdateTypeKVNew,
+			},
+			{
+				KVPair:     *eventL2Modified1.New,
+				UpdateType: api.UpdateTypeKVUpdated,
+			},
+		}})
+
+		// Block the update process again and send in a Delete and wait for the update.
+		rs.BlockUpdateHandling()
+		rs.sendEvent(r1, eventL1Delete1)
+		rs.ExpectOnUpdates([][]api.Update{{
+			{
+				KVPair: model.KVPair{
+					Key: eventL1Delete1.Old.Key,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			},
+		}})
+
+		// Send in: an add, an update, a parse error and another update.
+		// -  An OnUpdate with 2 updates (the error will spit up the update)
+		// -  An OnUpdate with 1 update
+		// -  A parse error
+		rs.sendEvent(r1, eventL1Added1)
+		// Pause a little here because the previous watch event is on a different goroutine so
+		// we need to ensure it's been processed in a reliable order.
+		time.Sleep(100 * time.Millisecond)
+		rs.sendEvent(r2, eventL2Modified1_2)
+		rs.sendEvent(r2, eventL2Modified2)
+		rs.sendEvent(r2, api.WatchEvent{
+			Type: api.WatchError,
+			Error: cerrors.ErrorParsingDatastoreEntry{
+				RawKey:   "abcdef",
+				RawValue: "aabbccdd",
+			},
+		})
+		rs.sendEvent(r2, eventL2Modified1)
+
+		// Pause a little before unblocking the handler to allow the updates to be
+		// consolidated.
+		time.Sleep(100 * time.Millisecond)
+		rs.UnblockUpdateHandling()
+		rs.ExpectOnUpdates([][]api.Update{
+			{
+				{
+					KVPair:     *eventL1Added1.New,
+					UpdateType: api.UpdateTypeKVNew,
+				},
+				{
+					KVPair:     *eventL2Modified1_2.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+				{
+					KVPair:     *eventL2Modified2.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+			},
+			{
+				{
+					KVPair:     *eventL2Modified1.New,
+					UpdateType: api.UpdateTypeKVUpdated,
+				},
+			},
+		})
+		rs.ExpectParseError("abcdef", "aabbccdd")
+	})
+
+	It("Should invoke the supplied converter to alter the update", func() {
+		rc1 := watchersyncer.ResourceType{
+			UpdateProcessor: &fakeConverter{},
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+		}
+
+		// Since the fake converter doesn't actually look at the incoming event we can
+		// send in arbitrary data.  Block the handler thread and send in 1 event and wait for it -
+		// this event will block the update handling process.
+		// Send in another 6 events to cover the different branches of the fake converter.
+		//
+		// See fakeConverter for details on what is returned each invocation.
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{rc1})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.ExpectStatusUpdate(api.InSync)
+		rs.clientWatchResponse(r1, nil)
+		rs.BlockUpdateHandling()
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.ExpectOnUpdates([][]api.Update{{{
+			KVPair:     *fakeConverterKVP1,
+			UpdateType: api.UpdateTypeKVNew, // key: l1Key1
+		}}})
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+		rs.sendEvent(r1, addEvent(l1Key1))
+
+		// Pause briefly and then unblock the thread.  The events should be collated
+		// except that an error will cause the events to be sent immediately.
+		time.Sleep(100 * time.Millisecond)
+		rs.UnblockUpdateHandling()
+		rs.ExpectOnUpdates([][]api.Update{
+			{
+				{
+					KVPair:     *fakeConverterKVP2,
+					UpdateType: api.UpdateTypeKVUpdated, // key: l1Key1
+				},
+				{
+					KVPair:     *fakeConverterKVP3,
+					UpdateType: api.UpdateTypeKVNew, // key: l1Key2
+				},
+			},
+			{
+				{
+					KVPair: model.KVPair{
+						Key: fakeConverterKVP4.Key,
+					},
+					UpdateType: api.UpdateTypeKVDeleted, // key: l1Key2
+				},
+			},
+			{
+				{
+					KVPair:     *fakeConverterKVP5,
+					UpdateType: api.UpdateTypeKVUpdated, // key: l1Key1
+				},
+				{
+					KVPair:     *fakeConverterKVP6,
+					UpdateType: api.UpdateTypeKVUpdated, // key: l1Key1
+				},
+			},
+		})
+
+		// We should have received a parse error.
+		rs.ExpectParseError("abcdef", "aabbccdd")
+
+		// Send a deleted event.  We should get a single deletion event for l1Key1 since
+		// l1Key2 is already deleted.  We should also get an updated Parse error.
+		rs.sendEvent(r1, deleteEvent(l1Key1))
+		time.Sleep(100 * time.Millisecond)
+		rs.ExpectOnUpdates([][]api.Update{
+			{
+				{
+					KVPair: model.KVPair{
+						Key: l1Key1,
+					},
+					UpdateType: api.UpdateTypeKVDeleted,
+				},
+			},
+		})
+		rs.ExpectParseError("zzzzz", "xxxxx")
+
+	})
+})
+
+var (
+	// Test events for the conversion code.
+	fakeConverterKVP1 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdef",
+		Revision: "abcdefg",
+	}
+	fakeConverterKVP2 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdefgh",
+		Revision: "abcdfg",
+	}
+	fakeConverterKVP3 = &model.KVPair{
+		Key:      l1Key2,
+		Value:    "abcdef",
+		Revision: "abcdefg",
+	}
+	fakeConverterKVP4 = &model.KVPair{
+		Key:      l1Key2,
+		Revision: "abfdgscdfg",
+	}
+	fakeConverterKVP5 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdeddfgh",
+		Revision: "abfdgffffscdfg",
+	}
+	fakeConverterKVP6 = &model.KVPair{
+		Key:      l1Key1,
+		Value:    "abcdeddgjdfgjdfgdfgh",
+		Revision: "abfdgscdfg",
+	}
+)
+
+// Set the list interval and watch interval in the WatcherSyncer.  We do this to reduce
+// the test time.
+func setWatchIntervals(listRetryInterval, watchPollInterval time.Duration) {
+	watchersyncer.ListRetryInterval = listRetryInterval
+	watchersyncer.WatchPollInterval = watchPollInterval
+}
+
+// Fake converter used to cover error and update handling paths.
+type fakeConverter struct {
+	i int
+}
+
+func (fc *fakeConverter) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	if kvp.Value == nil {
+		// This is a delete.
+		return []*model.KVPair{
+				{
+					Key: l1Key1,
+				},
+				{
+					Key: l1Key2,
+				},
+			}, cerrors.ErrorParsingDatastoreEntry{
+				RawKey:   "zzzzz",
+				RawValue: "xxxxx",
+			}
+	}
+
+	// This is an add.
+	fc.i++
+	switch fc.i {
+	case 1: // First update used to block update thread in test.
+		return []*model.KVPair{
+			fakeConverterKVP1,
+		}, nil
+	case 2: // Second contains two updates.
+		return []*model.KVPair{
+			fakeConverterKVP2,
+			fakeConverterKVP3,
+		}, nil
+	case 3: // Third contains an error, which will result in the update event.
+		return nil, errors.New("Fake error that we should handle gracefully")
+	case 4: // Fourth contains event and error, event will be sent and parse error will be stored.
+		return []*model.KVPair{
+				fakeConverterKVP4,
+			}, cerrors.ErrorParsingDatastoreEntry{
+				RawKey:   "abcdef",
+				RawValue: "aabbccdd",
+			}
+	case 5: // Fifth contains an update.
+		return []*model.KVPair{
+			fakeConverterKVP5,
+		}, nil
+	case 6: // Sixth contains nothing.
+		return nil, nil
+	case 7: // Seventh contains another update that will be appended to the one in case 5.
+		return []*model.KVPair{
+			fakeConverterKVP6,
+		}, nil
+	}
+	return nil, nil
+}
+
+func (fc *fakeConverter) OnSyncerStarting() {
+}
+
+// Create a delete event from a Key. The value types don't need to match the
+// Key types since we aren't unmarshaling/marshaling them in this package.
+func deleteEvent(key model.Key) api.WatchEvent {
+	return api.WatchEvent{
+		Type: api.WatchDeleted,
+		Old: &model.KVPair{
+			Key:      key,
+			Value:    uuid.NewV4().String(),
+			Revision: uuid.NewV4().String(),
+		},
+	}
+}
+
+// Create an add event from a Key. The value types don't need to match the
+// Key types since we aren't unmarshaling/marshaling them in this package.
+func addEvent(key model.Key) api.WatchEvent {
+	return api.WatchEvent{
+		Type: api.WatchAdded,
+		New: &model.KVPair{
+			Key:      key,
+			Value:    uuid.NewV4().String(),
+			Revision: uuid.NewV4().String(),
+		},
+	}
+}
+
+// Create a modified event from a Key. The value types don't need to match the
+// Key types since we aren't unmarshaling/marshaling them in this package.
+func modifiedEvent(key model.Key) api.WatchEvent {
+	return api.WatchEvent{
+		Type: api.WatchModified,
+		New: &model.KVPair{
+			Key:      key,
+			Value:    uuid.NewV4().String(),
+			Revision: uuid.NewV4().String(),
+		},
+	}
+}
+
+// Create a new watcherSyncerTester - this creates and starts a WatcherSyncer with
+// client and sync consumer interfaces implemented and controlled by the test.
+func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
+	// Create the required watchers.  This hs methods that we use to drive
+	// responses.
+	lws := map[string]*listWatchSource{}
+	for _, r := range l {
+		// We create a watcher for each resource type.  We'll store these off the
+		// default enumeration path for that resource.
+		name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+		lws[name] = &listWatchSource{
+			name:            name,
+			watchCallError:  make(chan error, 10),
+			listCallResults: make(chan interface{}, 100),
+			stopEvents:      make(chan struct{}, 100),
+			results:         make(chan api.WatchEvent, 100),
+		}
+	}
+
+	fc := &fakeClient{
+		lws: lws,
+	}
+
+	// Create the syncer tester.
+	st := testutils.NewSyncerTester()
+	rst := &watcherSyncerTester{
+		SyncerTester:  st,
+		fc:            fc,
+		watcherSyncer: watchersyncer.New(fc, l, st),
+		lws:           lws,
+	}
+	rst.watcherSyncer.Start()
+	return rst
+}
+
+// watcherSyncerTester is used to create, start and validate a watcherSyncer.  It
+// contains a number of useful methods used for asserting current state.
+//
+// This helper extends the function of the testutils SyncerTester.
+type watcherSyncerTester struct {
+	*testutils.SyncerTester
+	fc            *fakeClient
+	lws           map[string]*listWatchSource
+	watcherSyncer api.Syncer
+}
+
+// Call to test that all of the client and watcher events have been processed.
+// Note that an unhandled event could easily be a problem with the test rather
+// than the WatcherSyncer.
+func (rst *watcherSyncerTester) expectAllEventsHandled() {
+	log.Infof("Expecting all events to have been handled")
+	for _, l := range rst.lws {
+		Expect(l.listCallResults).To(HaveLen(0), "pending list results to be processed")
+		Expect(l.stopEvents).To(HaveLen(0), "pending stop events to be processed")
+		Expect(l.results).To(HaveLen(0), "pending watch results to be processed")
+	}
+}
+
+// Call to test whether the client and watcher events have been processed.
+// If you expect all events to be handled, use expectAllEventsHandled as the diagnostics
+// are better.
+func (rst *watcherSyncerTester) allEventsHandled() bool {
+	eventsHandled := true
+	for _, l := range rst.lws {
+		eventsHandled = eventsHandled && (len(l.listCallResults) == 0)
+		eventsHandled = eventsHandled && (len(l.stopEvents) == 0)
+		eventsHandled = eventsHandled && (len(l.results) == 0)
+	}
+	return eventsHandled
+}
+
+// Call to send an event via a particular watcher.
+func (rst *watcherSyncerTester) sendEvent(r watchersyncer.ResourceType, event api.WatchEvent) {
+	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithField("Name", name).Infof("Sending event")
+
+	// The test framework uses a single results channel for each resource, so to send the
+	// results deterministically we need to wait for a terminating watcher to finish
+	// terminating (so we know exactly which mock watcher invocation the result will be sent
+	// from).
+	log.Info("Waiting for previous watcher to terminate (if any)")
+	rst.lws[name].termWg.Wait()
+	log.Info("Previous watcher terminated (if any)")
+
+	if event.Type == api.WatchError {
+		if _, ok := event.Error.(cerrors.ErrorWatchTerminated); ok {
+			// This is a terminating event.  Our test framework will shut down the previous
+			// watcher as part of the creation of the new one.  Increment the init wait group
+			// in the watcher which will be decremented once the old one has fully terminated.
+			log.WithField("Name", name).Info("Watcher error will trigger restart - increment termination count")
+			rst.lws[name].termWg.Add(1)
+		}
+	}
+
+	log.WithField("Name", name).Info("Sending event")
+	rst.lws[name].results <- event
+
+	if event.Type == api.WatchError {
+		// Finally, since this is a terminating event then we expect a corresponding Stop()
+		// invocation (now that the event has been sent).
+		if _, ok := event.Error.(cerrors.ErrorWatchTerminated); ok {
+			log.WithField("Name", name).Info("Expecting a stop invocation")
+			rst.expectStop(r)
+			log.WithField("Name", name).Info("Stop invoked")
+		}
+	}
+}
+
+// Call to verify that stop has been invoked on the watcher.
+func (rst *watcherSyncerTester) expectStop(r watchersyncer.ResourceType) {
+	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithField("Name", name).Infof("Expecting Stop")
+	Eventually(func() bool {
+		return len(rst.lws[name].stopEvents) > 0
+	}).Should(BeTrue())
+
+	// Pull the stop event to acknowledge it.
+	<-rst.lws[name].stopEvents
+}
+
+// Call to specify the response of the client List invocation.  The List call will block
+// until the response has been specified.
+// The response should either be of type error, or type *KVPairList.
+func (rst *watcherSyncerTester) clientListResponse(r watchersyncer.ResourceType, response interface{}) {
+	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithFields(log.Fields{
+		"Name":     name,
+		"Response": response,
+	}).Info("Setting client List response")
+	switch response.(type) {
+	case error, *model.KVPairList:
+		rst.lws[name].listCallResults <- response
+	default:
+		panic("Error in test, wrong type specified")
+	}
+}
+
+// Call to specify the response of the client Watch invocation.  The Watch call will block
+// until the response has been specified.
+// The response should either be error type or nil (indicating no error).
+func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType, err error) {
+	name := model.ListOptionsToDefaultPathRoot(r.ListInterface)
+	log.WithFields(log.Fields{
+		"Name":  name,
+		"Error": err,
+	}).Info("Setting client Watch response")
+
+	// Send the required response.
+	rst.lws[name].watchCallError <- err
+}
+
+// fakeClient implements the api.Client interface.  We mock this out so that we can control
+// the events
+type fakeClient struct {
+	lws map[string]*listWatchSource
+}
+
+// We don't implement any of the CRUD related methods, just the Watch method to return
+// a fake watcher that the test code will drive.
+func (c *fakeClient) Create(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Apply(object *model.KVPair) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	panic("should not be called")
+	return nil, nil
+}
+func (c *fakeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	panic("should not be called")
+	return nil
+}
+func (c *fakeClient) EnsureInitialized() error {
+	panic("should not be called")
+	return nil
+}
+func (c *fakeClient) Clean() error {
+	panic("should not be called")
+	return nil
+}
+
+func (c *fakeClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	// Create a fake watcher keyed off the ListOptions (root path).
+	name := model.ListOptionsToDefaultPathRoot(list)
+	log.WithField("Name", name).Info("List request")
+	if l, ok := c.lws[name]; !ok || l == nil {
+		panic("List for unhandled resource type")
+	} else {
+		return l.list()
+	}
+}
+
+func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+	// Create a fake watcher keyed off the ListOptions (root path).
+	name := model.ListOptionsToDefaultPathRoot(list)
+	log.WithField("Name", name).Info("Watch request")
+	if l, ok := c.lws[name]; !ok || l == nil {
+		panic("Watch for unhandled resource type")
+	} else {
+		return l.watch()
+	}
+}
+
+// listWatchSource provides the resource type specific control of the client List and Watch response,
+// and the data returned by the watcher.
+type listWatchSource struct {
+	name string
+
+	// The client Watch call will block until it receives on this channel.  A nil
+	// error indicates the a watcher should be returned, a non-nil error will be
+	// returned by the watch command.
+	watchCallError chan error
+
+	// The list results.  This channel with contain either:
+	// - an error
+	// - a *model.KVPairList
+	listCallResults chan interface{}
+
+	// Stop events channel.  We add an event each time stop is called for a watcher.
+	stopEvents chan struct{}
+
+	// The watcher blocks until it receives some events on the results chan.
+	results chan api.WatchEvent
+
+	// Current watcher.
+	watcher *watcher
+
+	// Termination wait group.  This is used to block sending events until the current watcher
+	// has terminated.  This is required for this test harness due to the sharing of the results
+	// channel.
+	termWg sync.WaitGroup
+}
+
+// List returns the list results specified on the listCallError or listCallResults channel.
+func (fw *listWatchSource) list() (*model.KVPairList, error) {
+	result := <-fw.listCallResults
+	switch r := result.(type) {
+	case error:
+		log.WithField("Name", fw.name).WithError(r).Info("Returning error from List invocation")
+		return nil, r
+	case *model.KVPairList:
+		log.WithField("Name", fw.name).Info("Returning results from List invocation")
+		return r, nil
+	default:
+		log.WithField("Result", r).Fatal("Unexpected result on list result channel")
+		return nil, nil
+	}
+}
+
+// List returns the list results specified on the listCallError or listCallResults channel.
+func (fw *listWatchSource) watch() (api.WatchInterface, error) {
+	// another, wait for the previous watcher thread to terminate.  If Stop is not called then
+	// this will block (but won't block the test) so the test will time out.
+	if fw.watcher != nil {
+		fw.watcher.terminate()
+		fw.watcher = nil
+
+		// Perform a non-blocking check to see if there is any unexpected data on the
+		// results channel.
+		select {
+		case r := <-fw.results:
+			log.Fatalf("Test harness for %s expects results chan to be empty during watch creation: %v", fw.name, r)
+		default:
+		}
+
+		// Previous watcher, if there was one has now terminated.
+		log.WithField("Name", fw.name).Info("Marking termWg as done")
+		fw.termWg.Done()
+	}
+
+	// Receive from the watchCallError channel to determine the result of this Watch invocation.
+	e := <-fw.watchCallError
+	if e != nil {
+		log.WithField("Name", fw.name).WithError(e).Info("Returning error from watch invocation")
+		return nil, e
+	}
+
+	// Create a new watcher and start the receive thread.  Note that the channels we use here are
+	// blocking - so that we only drain from the test source channel when we actually process the
+	// various events - this allows us to assert that when the main test channels are empty then
+	// the watcher has sent/received all notification.
+	log.WithField("Name", fw.name).Info("Returning new watcher")
+	fw.watcher = &watcher{
+		name:       fw.name,
+		stopEvents: fw.stopEvents,
+		results:    make(chan api.WatchEvent),
+		done:       make(chan struct{}),
+	}
+
+	fw.watcher.start(fw.results)
+	return fw.watcher, nil
+}
+
+// Each fake watcher has it's own results channel to ensure the WatcherSyncer is pulling from
+// the correct watcher.
+type watcher struct {
+	name             string
+	watcherRunningWg sync.WaitGroup
+	stopEvents       chan<- struct{}
+	results          chan api.WatchEvent
+	done             chan struct{}
+}
+
+func (w *watcher) Stop() {
+	log.WithField("Name", w.name).Info("Stop called on watcher")
+	if w.stopEvents != nil {
+		// It is ok for Stop() to be called multiple times, but we are only interested in
+		// one call per watcher, so nil out the channel after sending so we don't send again.
+		w.stopEvents <- struct{}{}
+		w.stopEvents = nil
+	}
+}
+
+func (w *watcher) ResultChan() <-chan api.WatchEvent {
+	return w.results
+}
+
+func (w *watcher) HasTerminated() bool {
+	// Never invoked by the syncer code, so no need to return anything sensible.
+	log.WithField("Name", w.name).Fatalf("HasTerminated called on watcher - not expected")
+	return false
+}
+
+// start the watcher goroutine.
+func (w *watcher) start(results <-chan api.WatchEvent) {
+	log.WithField("Name", w.name).Info("start watcher")
+	w.watcherRunningWg.Add(1)
+	go w.run(results)
+}
+
+// terminate this watcher - this blocks until the watcher loop has exited.
+func (w *watcher) terminate() {
+	log.WithField("Name", w.name).Info("terminate watcher")
+	w.done <- struct{}{}
+	close(w.results)
+	w.watcherRunningWg.Wait()
+}
+
+func (w *watcher) run(results <-chan api.WatchEvent) {
+	defer w.watcherRunningWg.Done()
+	for {
+		select {
+		// Funnel the result directly down this watchers result channel.
+		case result := <-results:
+			log.WithField("Name", w.name).Info("Sending watch event")
+			select {
+			case w.results <- result:
+				log.WithField("Name", w.name).Info("Sent watch event")
+			case <-w.done:
+				log.WithField("Name", w.name).Info("Watcher loop is terminating")
+				return
+			}
+
+		// Exit if we receive a done notification.
+		case <-w.done:
+			log.WithField("Name", w.name).Info("Watcher loop is terminating")
+			return
+		}
+	}
+}

--- a/lib/testutils/syncertester.go
+++ b/lib/testutils/syncertester.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package testutils
+
+import (
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+// Create a new SyncerTester.  This helper class implements the api.SyncerCallbacks
+// and provides a number of useful methods for asserting the data that has been
+// supplied on the callbacks.
+func NewSyncerTester() *SyncerTester {
+	return &SyncerTester{
+		cache:  make(map[string]model.KVPair),
+		status: UnsetSyncStatus,
+	}
+}
+
+var (
+	UnsetSyncStatus = api.SyncStatus(255)
+)
+
+// Encapsulates parse error details for easy handling with a single channel.
+type parseError struct {
+	rawKey   string
+	rawValue string
+}
+
+type SyncerTester struct {
+	status        api.SyncStatus
+	statusChanged bool
+	statusBlocker sync.WaitGroup
+	updateBlocker sync.WaitGroup
+	lock          sync.Mutex
+
+	// Stored update information.
+	cache       map[string]model.KVPair
+	onUpdates   [][]api.Update
+	updates     []api.Update
+	parseErrors []parseError
+}
+
+// OnStatusUpdated updates the current status and then blocks until a call to
+// ExpectStatusUpdate() has been called.
+func (st *SyncerTester) OnStatusUpdated(status api.SyncStatus) {
+	st.lock.Lock()
+	current := st.status
+	st.status = status
+	st.statusChanged = true
+	st.statusBlocker.Add(1)
+	st.lock.Unlock()
+
+	// If this is not the first status event then perform additional validation on the status.
+	if current != UnsetSyncStatus {
+		// None of the concrete syncers that we are testing expect should have the same
+		// status update repeated, nor should the status decrease.  Log and panic.
+		if status == current {
+			log.WithField("Status", status).Fatal("Duplicate identical status updates from syncer")
+		}
+		if status < current {
+			log.WithFields(log.Fields{
+				"NewStatus": status,
+				"OldStatus": st.status,
+			}).Fatal("Decrementing status updates from syncer")
+		}
+	}
+
+	log.Infof("Status set and blocking for ack: %s", status)
+
+	// For statuses, this requires the consumer to explicitly expect the status updates
+	// to unblock the processing.
+	st.statusBlocker.Wait()
+	log.Info("OnStatusUpdated now unblocked")
+
+}
+
+// OnUpdates just stores the update and asserts the state of the cache and the update.
+func (st *SyncerTester) OnUpdates(updates []api.Update) {
+	// Store the updates and onUpdates.
+	st.lock.Lock()
+	st.onUpdates = append(st.onUpdates, updates)
+	for _, u := range updates {
+		// Append the updates to the total set of updates.
+		st.updates = append(st.updates, u)
+
+		// Update our cache of current entries.
+		k, err := model.KeyToDefaultPath(u.Key)
+		Expect(err).NotTo(HaveOccurred())
+		switch u.UpdateType {
+		case api.UpdateTypeKVDeleted:
+			Expect(st.cache).To(HaveKey(k))
+			delete(st.cache, k)
+		case api.UpdateTypeKVNew:
+			log.WithFields(log.Fields{
+				"Key":   k,
+				"Value": u.KVPair.Value,
+			}).Info("Handling new cache entry")
+			Expect(st.cache).NotTo(HaveKey(k))
+			Expect(u.Value).NotTo(BeNil())
+			st.cache[k] = u.KVPair
+		case api.UpdateTypeKVUpdated:
+			log.WithFields(log.Fields{
+				"Key":   k,
+				"Value": u.KVPair.Value,
+			}).Info("Handling modified cache entry")
+			Expect(st.cache).To(HaveKey(k))
+			Expect(u.Value).NotTo(BeNil())
+			st.cache[k] = u.KVPair
+		}
+	}
+	st.lock.Unlock()
+
+	// We may need to block if the test has blocked the main event processing.
+	st.updateBlocker.Wait()
+}
+
+// ParseFailed just stores the parse failure.
+func (st *SyncerTester) ParseFailed(rawKey string, rawValue string) {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	st.parseErrors = append(st.parseErrors, parseError{rawKey: rawKey, rawValue: rawValue})
+}
+
+// ExpectStatusUpdate verifies a status update message has been received.  This should only
+// be called *after* a new status change has occurred.  Since the concrete implementations
+// of the syncer API only migrate status in increasing readiness, this means it should be
+// called once each for the following statuses in order:  WaitingForDatastore, ResyncInProgress, InSync.
+// The OnStatusUpdate callback will panic if the above is not true.
+func (st *SyncerTester) ExpectStatusUpdate(status api.SyncStatus) {
+	log.Infof("Expecting status of: %s", status)
+	cs := func() api.SyncStatus {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return st.status
+	}
+	Eventually(cs).Should(Equal(status))
+	Consistently(cs).Should(Equal(status))
+
+	log.Infof("Status is at expected status: %s", status)
+
+	// Get the current statusChanged status, and reset it.  Validate that the status was actually
+	// updated to this state (i.e. the test code hasn't re-called this with the same status).
+	st.lock.Lock()
+	current := st.statusChanged
+	st.statusChanged = false
+	st.lock.Unlock()
+	Expect(current).To(BeTrue())
+
+	// We've verified the status, so reset the statusChanged flag.
+	st.lock.Lock()
+	st.statusChanged = false
+	st.lock.Unlock()
+
+	// If you hit a panic here, it's because you must have called this again with the
+	// same status.
+	st.statusBlocker.Done()
+}
+
+// ExpectStatusUnchanged verifies that the status has not changed since the last ExpectStatusUpdate
+// call.
+func (st *SyncerTester) ExpectStatusUnchanged() {
+	sc := func() bool {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return st.statusChanged
+	}
+	Eventually(sc).Should(BeFalse())
+	Consistently(sc).Should(BeFalse())
+}
+
+// ExpectCacheSize verifies that the cache size is as expected.
+func (st *SyncerTester) ExpectCacheSize(size int) {
+	sfn := func() int {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return len(st.cache)
+	}
+	Eventually(sfn).Should(Equal(size))
+	Consistently(sfn).Should(Equal(size))
+}
+
+// ExpectData verifies that a KVPair is in the cache.
+func (st *SyncerTester) ExpectData(kvp model.KVPair) {
+	key, err := model.KeyToDefaultPath(kvp.Key)
+	Expect(err).NotTo(HaveOccurred())
+	efn := func() model.KVPair {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return st.cache[key]
+	}
+	Eventually(efn).Should(Equal(kvp))
+	Consistently(efn).Should(Equal(kvp))
+}
+
+// ExpectNoData verifies that a Key is not in the cache.
+func (st *SyncerTester) ExpectNoData(k model.Key) {
+	key, err := model.KeyToDefaultPath(k)
+	Expect(err).NotTo(HaveOccurred())
+	efn := func() bool {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		_, ok := st.cache[key]
+		return ok
+	}
+	Eventually(efn).Should(BeFalse(), fmt.Sprintf("Found key %s in cache - not expected", key))
+	Consistently(efn).Should(BeFalse(), fmt.Sprintf("Found key %s in cache - not expected", key))
+}
+
+// GetCacheEntries returns a slice of the current cache entries.
+func (st *SyncerTester) GetCacheEntries() []model.KVPair {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	es := []model.KVPair{}
+	for _, e := range st.cache {
+		es = append(es, e)
+	}
+	return es
+}
+
+// Call to test the onUpdate events (without worrying about which specific
+// OnUpdate events were received).
+// This removes all updates/onUpdate events from this receiver, so that the
+// next call to this just requires the next set of updates.
+//
+// Note that for this function to be useful, your test code needs to have
+// fine grained control over the order in which events occur.
+func (st *SyncerTester) ExpectUpdates(expected []api.Update) {
+	log.Infof("Expecting updates of %v", expected)
+
+	// Poll until we have the correct number of updates to check.
+	nu := func() int {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return len(st.updates)
+	}
+	Eventually(nu).Should(Equal(len(expected)))
+
+	// Extract the updates and remove the updates and onUpdates from our cache.
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	updates := st.updates
+	st.updates = nil
+	st.onUpdates = nil
+	Expect(updates).To(Equal(expected))
+}
+
+// Call to test which onUpdate events were received.
+// This removes all updates/onUpdate events from this receiver, so that the
+// next call to this just requires the next set of updates.
+//
+// Note that for this function to be useful, your test code needs to have
+// fine grained control over the order in which events occur.
+func (st *SyncerTester) ExpectOnUpdates(expected [][]api.Update) {
+	log.Infof("Expecting OnUpdates of %v", expected)
+
+	// Poll until we have the correct number of updates to check.
+	nu := func() int {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return len(st.onUpdates)
+	}
+	Eventually(nu).Should(Equal(len(expected)))
+
+	// Extract the onUpdates and remove the updates and onUpdates from our cache.
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	onUpdates := st.onUpdates
+	st.updates = nil
+	st.onUpdates = nil
+	Expect(onUpdates).To(Equal(expected))
+}
+
+// Call to test the next parse error that we expect to have received.
+// This removes the parse error from the receiver.
+func (st *SyncerTester) ExpectParseError(key, value string) {
+	log.Infof("Expecting parse error: %v=%v", key, value)
+	// Poll until we have an error to check.
+	ne := func() int {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return len(st.parseErrors)
+	}
+	Eventually(ne).Should(Not(BeZero()))
+
+	// Extract the parse error and remove from our cache.
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	pe := st.parseErrors[0]
+	st.parseErrors = st.parseErrors[1:]
+	Expect(pe.rawKey).To(Equal(key))
+	Expect(pe.rawValue).To(Equal(value))
+}
+
+// Block the update handling.
+func (st *SyncerTester) BlockUpdateHandling() {
+	st.updateBlocker.Add(1)
+}
+
+// Unblock the update handling.
+func (st *SyncerTester) UnblockUpdateHandling() {
+	st.updateBlocker.Done()
+}


### PR DESCRIPTION
This is a generic syncer implementation built against the backend API (it would be easy enough to translate to be against the main client watcher API, but for the time being while we're converting to v1 models I want to keep this in the backend).

I'm intending to to use this syncer to replace the existing confd processing.  Since KDD won't support Watchers for the initial releases this Watcher-Syncer is designed to drop in to a polling mode with a 5s poll interval - i.e. basically the same behavior for KDD as we have at the moment.  

