### PR TITLE
Build the BGP Syncer using the WatcherSyncer

### DIFF
--- a/lib/apiv2/bgpconfig.go
+++ b/lib/apiv2/bgpconfig.go
@@ -39,11 +39,11 @@ type BGPConfiguration struct {
 // BGPConfigurationSpec contains the values of the BGP configuration.
 type BGPConfigurationSpec struct {
 	// LogSeverityScreen is the log severity above which logs are sent to the stdout. [Default: INFO]
-	LogSeverityScreen string `json:"logSeverityScreen,omitempty" validate:"omitempty"`
+	LogSeverityScreen string `json:"logSeverityScreen,omitempty" validate:"omitempty" confignamev1:"loglevel"`
 	// NodeToNodeMeshEnabled sets whether full node to node BGP mesh is enabled. [Default: true]
-	NodeToNodeMeshEnabled *bool `json:"nodeToNodeMeshEnabled,omitempty" validate:"omitempty"`
-	// DefaultNodeASNumber is the default AS number used by a node. [Default: 64512]
-	DefaultNodeASNumber *numorstring.ASNumber `json:"defaultNodeASNumber,omitempty" validate:"omitempty"`
+	NodeToNodeMeshEnabled *bool `json:"nodeToNodeMeshEnabled,omitempty" validate:"omitempty" confignamev1:"node_mesh"`
+	// ASNumber is the default AS number used by a node. [Default: 64512]
+	ASNumber *numorstring.ASNumber `json:"asNumber,omitempty" validate:"omitempty" confignamev1:"as_num"`
 }
 
 // BGPConfigurationList contains a list of BGPConfiguration resources.
@@ -64,7 +64,7 @@ func NewBGPConfiguration() *BGPConfiguration {
 	}
 }
 
-// NewBGPConfigurationList creates a new 9zeroed) BGPConfigurationList struct with the TypeMetadata
+// NewBGPConfigurationList creates a new zeroed) BGPConfigurationList struct with the TypeMetadata
 // initialized to the current version.
 func NewBGPConfigurationList() *BGPConfigurationList {
 	return &BGPConfigurationList{

--- a/lib/apiv2/felixconfig.go
+++ b/lib/apiv2/felixconfig.go
@@ -47,14 +47,14 @@ type FelixConfigurationSpec struct {
 	// RouterefreshInterval is the period, in seconds, at which Felix re-checks the routes
 	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.
 	// Set to 0 to disable route refresh. [Default: 90]
-	RouteRefreshIntervalSecs *int `json:"routeRefreshIntervalSecs,omitempty" configname:"RouteRefreshInterval"`
+	RouteRefreshIntervalSecs *int `json:"routeRefreshIntervalSecs,omitempty" confignamev1:"RouteRefreshInterval"`
 	// IptablesRefreshInterval is the period, in seconds, at which Felix re-checks the IP sets
 	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.
 	// Set to 0 to disable IP sets refresh. Note: the default for this value is lower than the
 	// other refresh intervals as a workaround for a Linux kernel bug that was fixed in kernel
 	// version 4.11. If you are using v4.11 or greater you may want to set this to, a higher value
 	// to reduce Felix CPU usage. [Default: 10]
-	IptablesRefreshIntervalSecs *int `json:"iptablesRefreshIntervalSecs,omitempty" configname:"IptablesRefreshInterval"`
+	IptablesRefreshIntervalSecs *int `json:"iptablesRefreshIntervalSecs,omitempty" confignamev1:"IptablesRefreshInterval"`
 	// IptablesPostWriteCheckIntervalSecs is the period, in seconds, after Felix has done a write
 	// to the dataplane that it schedules an extra read back in order to check the write was not
 	// clobbered by another process. This should only occur if another application on the system
@@ -77,7 +77,7 @@ type FelixConfigurationSpec struct {
 	// IpsetsRefreshIntervalSecs is the period, in seconds, at which Felix re-checks all iptables
 	// state to ensure that no other process has accidentally broken Calico’s rules. Set to 0 to
 	// disable iptables refresh. [Default: 90]
-	IpsetsRefreshIntervalSecs *int `json:"ipsetsRefreshIntervalSecs,omitempty" configname:"IpsetsRefreshInterval"`
+	IpsetsRefreshIntervalSecs *int `json:"ipsetsRefreshIntervalSecs,omitempty" confignamev1:"IpsetsRefreshInterval"`
 	MaxIpsetSize              *int `json:"maxIpsetSize,omitempty"`
 
 	NetlinkTimeoutSecs *int `json:"netlinkTimeoutSecs,omitempty"`
@@ -180,8 +180,8 @@ type FelixConfigurationSpec struct {
 
 	DebugMemoryProfilePath              string `json:"debugMemoryProfilePath,omitempty"`
 	DebugDisableLogDropping             *bool  `json:"debugDisableLogDropping,omitempty"`
-	DebugSimulateCalcGraphHangAfterSecs *int   `json:"debugSimulateCalcGraphHangAfterSecs,omitempty" configname:"DebugSimulateCalcGraphHangAfter"`
-	DebugSimulateDataplaneHangAfterSecs *int   `json:"debugSimulateDataplaneHangAfterSecs,omitempty" configname:"DebugSimualteDataplaneHangAfter"`
+	DebugSimulateCalcGraphHangAfterSecs *int   `json:"debugSimulateCalcGraphHangAfterSecs,omitempty" confignamev1:"DebugSimulateCalcGraphHangAfter"`
+	DebugSimulateDataplaneHangAfterSecs *int   `json:"debugSimulateDataplaneHangAfterSecs,omitempty" confignamev1:"DebugSimualteDataplaneHangAfter"`
 }
 
 type ProtoPort struct {

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgpsyncer
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// New creates a new BGP v1 Syncer.  Since only etcdv3 supports Watchers for all of
+// the required resource types, the WatcherSyncer will go into a polling loop for
+// KDD.  An optional node name may be supplied.  If set, the syncer only watches
+// the specified node rather than all nodes.
+func New(client api.Client, callbacks api.SyncerCallbacks, node string, watchAllNodes bool) api.Syncer {
+	// Create the set of ResourceTypes required for Felix.  Since the update processors
+	// also cache state, we need to create individual ones per syncer rather than create
+	// a common global set.
+	// For BGP we always only care about affinity blocks assigned to our own particuar node.
+	// However, depending on whether we are in full-mesh mode or not changes whether we want
+	// to watch all Node resources or just our own.
+	nodeToWatch := node
+	if watchAllNodes {
+		nodeToWatch = ""
+	}
+	resourceTypes := []watchersyncer.ResourceType{
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindIPPool},
+			UpdateProcessor: updateprocessors.NewIPPoolUpdateProcessor(),
+		},
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindBGPConfiguration},
+			UpdateProcessor: updateprocessors.NewBGPConfigUpdateProcessor(),
+		},
+		{
+			ListInterface: model.ResourceListOptions{
+				Kind: apiv2.KindNode,
+				Name: nodeToWatch,
+			},
+			UpdateProcessor: updateprocessors.NewBGPNodeUpdateProcessor(),
+		},
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindBGPPeer},
+			UpdateProcessor: updateprocessors.NewBGPPeerUpdateProcessor(),
+		},
+		{
+			ListInterface: model.BlockAffinityListOptions{Host: node},
+		},
+	}
+
+	return watchersyncer.New(
+		client,
+		resourceTypes,
+		callbacks,
+	)
+}

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgpsyncer_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/bgpsyncer"
+	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/ipip"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+// These tests validate that the various resources that the BGP watches are
+// handled correctly by the syncer.  We don't validate in detail the behavior of
+// each of udpate handlers that are invoked, since these are tested more thoroughly
+// elsewhere.
+var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+
+	Describe("BGP syncer functionality", func() {
+		It("should receive the synced after return all current data", func() {
+			// Create a v2 client to drive data changes (luckily because this is the _test module,
+			// we don't get circular imports.
+			c, err := clientv2.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create the backend client to obtain a syncer interface.
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			// Create a SyncerTester to receive the BGP syncer callback events and to allow us
+			// to assert state.
+			syncTester := testutils.NewSyncerTester()
+			syncer := bgpsyncer.New(be, syncTester, "mynode", true)
+			syncer.Start()
+
+			By("Checking status is updated to sync'd when there is no data")
+			syncTester.ExpectStatusUpdate(api.WaitForDatastore)
+			syncTester.ExpectCacheSize(0)
+			syncTester.ExpectStatusUpdate(api.ResyncInProgress)
+			syncTester.ExpectCacheSize(0)
+			syncTester.ExpectStatusUpdate(api.InSync)
+			syncTester.ExpectCacheSize(0)
+
+			By("Disabling node to node mesh and adding a default ASNumber")
+			n2n := false
+			asn := numorstring.ASNumber(12345)
+			bgpCfg, err := c.BGPConfigurations().Create(
+				ctx,
+				&apiv2.BGPConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "default"},
+					Spec: apiv2.BGPConfigurationSpec{
+						NodeToNodeMeshEnabled: &n2n,
+						ASNumber:              &asn,
+					},
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// We should have entries for each config option (i.e. 2)
+			syncTester.ExpectCacheSize(2)
+			syncTester.ExpectData(model.KVPair{
+				Key:      model.GlobalBGPConfigKey{"as_num"},
+				Value:    "12345",
+				Revision: bgpCfg.ResourceVersion,
+			})
+			syncTester.ExpectData(model.KVPair{
+				Key:      model.GlobalBGPConfigKey{"node_mesh"},
+				Value:    "{\"enabled\":false}",
+				Revision: bgpCfg.ResourceVersion,
+			})
+
+			By("Creating a node with BGP configuration")
+			node, err := c.Nodes().Create(
+				ctx,
+				&apiv2.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "mynode"},
+					Spec: apiv2.NodeSpec{
+						BGP: &apiv2.NodeBGPSpec{
+							IPv4Address: "1.2.3.4/24",
+							IPv6Address: "aa:bb::cc/120",
+						},
+					},
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			// The two IP addresses will also add two networks ( +4 )
+			syncTester.ExpectCacheSize(6)
+			syncTester.ExpectData(model.KVPair{
+				Key:      model.NodeBGPConfigKey{Nodename: "mynode", Name: "ip_addr_v4"},
+				Value:    "1.2.3.4",
+				Revision: node.ResourceVersion,
+			})
+			syncTester.ExpectData(model.KVPair{
+				Key:      model.NodeBGPConfigKey{Nodename: "mynode", Name: "ip_addr_v6"},
+				Value:    "aa:bb::cc",
+				Revision: node.ResourceVersion,
+			})
+			syncTester.ExpectData(model.KVPair{
+				Key:      model.NodeBGPConfigKey{Nodename: "mynode", Name: "network_v4"},
+				Value:    "1.2.3.0/24",
+				Revision: node.ResourceVersion,
+			})
+			syncTester.ExpectData(model.KVPair{
+				Key:      model.NodeBGPConfigKey{Nodename: "mynode", Name: "network_v6"},
+				Value:    "aa:bb::/120",
+				Revision: node.ResourceVersion,
+			})
+
+			By("Updating the BGPConfiguration to remove the default ASNumber")
+			bgpCfg.Spec.ASNumber = nil
+			_, err = c.BGPConfigurations().Update(ctx, bgpCfg, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			// Removing one config option ( -1 )
+			syncTester.ExpectCacheSize(5)
+			syncTester.ExpectNoData(model.GlobalBGPConfigKey{"as_num"})
+
+			By("Creating an IPPool")
+			poolCIDR := "192.124.0.0/21"
+			poolCIDRNet := net.MustParseCIDR(poolCIDR)
+			pool, err := c.IPPools().Create(
+				ctx,
+				&apiv2.IPPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "mypool"},
+					Spec: apiv2.IPPoolSpec{
+						CIDR: poolCIDR,
+						IPIP: &apiv2.IPIPConfiguration{
+							Mode: apiv2.IPIPModeCrossSubnet,
+						},
+						NATOutgoing: true,
+					},
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			// The pool will add as single entry ( +1 )
+			syncTester.ExpectCacheSize(6)
+			syncTester.ExpectData(model.KVPair{
+				Key: model.IPPoolKey{CIDR: net.MustParseCIDR("192.124.0.0/21")},
+				Value: &model.IPPool{
+					CIDR:          poolCIDRNet,
+					IPIPInterface: "tunl0",
+					IPIPMode:      ipip.CrossSubnet,
+					Masquerade:    true,
+					IPAM:          true,
+					Disabled:      false,
+				},
+				Revision: pool.ResourceVersion,
+			})
+
+			By("Creating a BGPPeer")
+			peer1, err := c.BGPPeers().Create(
+				ctx,
+				&apiv2.BGPPeer{
+					ObjectMeta: metav1.ObjectMeta{Name: "peer1"},
+					Spec: apiv2.BGPPeerSpec{
+						PeerIP:   "192.124.10.20",
+						ASNumber: numorstring.ASNumber(75758),
+					},
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			peer1kvp := model.KVPair{
+				Key: model.GlobalBGPPeerKey{PeerIP: net.MustParseIP("192.124.10.20")},
+				Value: &model.BGPPeer{
+					PeerIP: net.MustParseIP("192.124.10.20"),
+					ASNum:  numorstring.ASNumber(75758),
+				},
+				Revision: peer1.ResourceVersion,
+			}
+			// The peer will add as single entry ( +1 )
+			syncTester.ExpectCacheSize(7)
+			syncTester.ExpectData(peer1kvp)
+
+			By("Adding a new BGPPeer with conflicting peer IP (and lower priority than the first one)")
+			peer2, err := c.BGPPeers().Create(
+				ctx,
+				&apiv2.BGPPeer{
+					ObjectMeta: metav1.ObjectMeta{Name: "peer9-lowerpriority"},
+					Spec: apiv2.BGPPeerSpec{
+						PeerIP:   "192.124.10.20",
+						ASNumber: numorstring.ASNumber(99999),
+					},
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			peer2kvp := model.KVPair{
+				Key: model.GlobalBGPPeerKey{PeerIP: net.MustParseIP("192.124.10.20")},
+				Value: &model.BGPPeer{
+					PeerIP: net.MustParseIP("192.124.10.20"),
+					ASNum:  numorstring.ASNumber(99999),
+				},
+				Revision: peer2.ResourceVersion,
+			}
+			// The peer will result in no updates and the entry key off 192.124.10.20
+			// will still be the same.
+			syncTester.ExpectCacheSize(7)
+			syncTester.ExpectData(peer1kvp)
+
+			By("Updating the first peer to be a Node specific peer (get updates for both peers)")
+			peer1.Spec.Node = "mynode"
+			peer1, err = c.BGPPeers().Update(ctx, peer1, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			peer1kvp = model.KVPair{
+				Key: model.NodeBGPPeerKey{Nodename: "mynode", PeerIP: net.MustParseIP("192.124.10.20")},
+				Value: &model.BGPPeer{
+					PeerIP: net.MustParseIP("192.124.10.20"),
+					ASNum:  numorstring.ASNumber(75758),
+				},
+				Revision: peer1.ResourceVersion,
+			}
+
+			// The first peer has moved to be a node-specific peer and no longer clashes with
+			// the second.  We should have an extra data store entry, and both peers should be present.
+			syncTester.ExpectCacheSize(8)
+			syncTester.ExpectData(peer1kvp)
+			syncTester.ExpectData(peer2kvp)
+
+			By("Allocating an IP address and checking that we get an allocation block")
+			_, _, err = c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+				Num4:     1,
+				Hostname: "mynode",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Allocating an IP will create an affinity block that we should be notified of.  Not sure
+			// what CIDR will be chosen, so search the cached entries.
+			syncTester.ExpectCacheSize(9)
+			current := syncTester.GetCacheEntries()
+			found := false
+			for _, kvp := range current {
+				if kab, ok := kvp.Key.(model.BlockAffinityKey); ok {
+					if kab.Host == "mynode" && poolCIDRNet.Contains(kab.CIDR.IP) {
+						found = true
+						break
+					}
+				}
+			}
+			Expect(found).To(BeTrue(), "Did not find affinity block in sync data")
+
+			By("Starting a new syncer and verifying that all current entries are returned before sync status")
+			// We need to create a new syncTester and syncer.
+			syncTester = testutils.NewSyncerTester()
+			syncer = bgpsyncer.New(be, syncTester, "mynode", true)
+			syncer.Start()
+
+			// Verify the data is the same as the data from the previous cache.  We got the cache in the previous
+			// step.
+			syncTester.ExpectStatusUpdate(api.WaitForDatastore)
+			syncTester.ExpectStatusUpdate(api.ResyncInProgress)
+			syncTester.ExpectCacheSize(len(current))
+			for _, e := range current {
+				syncTester.ExpectData(e)
+			}
+			syncTester.ExpectStatusUpdate(api.InSync)
+		})
+	})
+})

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_suite_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgpsyncer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BGP syncer test suite")
+}

--- a/lib/backend/syncersv1/bgpsyncer/doc.go
+++ b/lib/backend/syncersv1/bgpsyncer/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgpsyncer
+
+/*
+bgpsyncer implements an api.Syncer for consumers of BGP configuration.
+
+The primary use case here is for a generic Calico backend for confd.
+
+This implementation uses the watchersyncer.
+*/

--- a/lib/backend/syncersv1/felixsyncer/doc.go
+++ b/lib/backend/syncersv1/felixsyncer/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package felixsyncer
+
+/*
+felixsyncerv1 implements an api.Syncer for use with Felix.
+
+It consumes the v2 data from the datastore and dynamically converts it to
+v1 data for consumption by Felix.
+
+This implementation uses the watchersyncer.
+*/

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package felixsyncer
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// New creates a new Felix v1 Syncer.  Currently only the etcdv3 backend is supported
+// since KDD does not yet fully support Watchers.
+func New(client api.Client, callbacks api.SyncerCallbacks) api.Syncer {
+	// Create the set of ResourceTypes required for Felix.  Since the update processors
+	// also cache state, we need to create individual ones per syncer rather than create
+	// a common global set.
+	resourceTypes := []watchersyncer.ResourceType{
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindClusterInformation},
+			UpdateProcessor: updateprocessors.NewClusterInfoUpdateProcessor(),
+		},
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindFelixConfiguration},
+			UpdateProcessor: updateprocessors.NewFelixConfigUpdateProcessor(),
+		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv2.KindGlobalNetworkPolicy},
+		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv2.KindHostEndpoint},
+		},
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindIPPool},
+			UpdateProcessor: updateprocessors.NewIPPoolUpdateProcessor(),
+		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+		},
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindNode},
+			UpdateProcessor: updateprocessors.NewFelixNodeUpdateProcessor(),
+		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv2.KindProfile},
+		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv2.KindWorkloadEndpoint},
+		},
+	}
+
+	return watchersyncer.New(
+		client,
+		resourceTypes,
+		callbacks,
+	)
+}

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1_suite_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package felixsyncer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Felix syncer test suite")
+}

--- a/lib/backend/syncersv1/updateprocessors/bgpconfigprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/bgpconfigprocessor.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+// Create a new SyncerUpdateProcessor to sync BGPConfiguration data in v1 format for
+// consumption by the BGP daemon.
+func NewBGPConfigUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewConfigUpdateProcessor(
+		reflect.TypeOf(apiv2.BGPConfigurationSpec{}),
+		AllowAnnotations,
+		func(node, name string) model.Key { return model.NodeBGPConfigKey{Nodename: node, Name: name} },
+		func(name string) model.Key { return model.GlobalBGPConfigKey{Name: name} },
+		map[string]ValueToStringFn{
+			"loglevel":  logLevelStringifier,
+			"node_mesh": nodeMeshStringifier,
+		},
+	)
+}
+
+// Bird log level currently only supports granularity of none, debug and info.  Debug/Info are
+// left unchanged, all others treated as none.
+var logLevelStringifier = func(value interface{}) string {
+	l := strings.ToLower(value.(string))
+	switch l {
+	case "", "debug", "info":
+	default:
+		l = "none"
+	}
+	return l
+}
+
+// In v1, the node mesh enabled field was wrapped up in some JSON - wrap up the value to
+// return via the syncer.
+var nodeMeshStringifier = func(value interface{}) string {
+	enabled := value.(bool)
+	d, err := json.Marshal(nodeToNodeMesh{Enabled: enabled})
+	cerrors.FatalIfErrored(err)
+	return string(d)
+}
+
+// nodeToNodeMesh is a struct containing whether node-to-node mesh is enabled.  It can be
+// JSON marshalled into the correct structure that is understood by the Calico BGP component.
+type nodeToNodeMesh struct {
+	Enabled bool `json:"enabled"`
+}

--- a/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// Create a new SyncerUpdateProcessor to sync Node data in v1 format for
+// consumption by the BGP daemon.
+func NewBGPNodeUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return &bgpNodeUpdateProcessor{}
+}
+
+// bgpNodeUpdateProcessor implements the SyncerUpdateProcessor interface.
+// This converts the v2 node configuration into the v1 data types consumed by confd.
+type bgpNodeUpdateProcessor struct {
+}
+
+func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	// Extract the name.
+	name, err := c.extractName(kvp.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the separate bits of BGP config - these are stored as separate keys in the
+	// v1 model.  For a delete these will all be nil.
+	var asNum, ipv4, netv4, ipv6, netv6 interface{}
+	if kvp.Value != nil {
+		node, ok := kvp.Value.(*apiv2.Node)
+		if !ok {
+			return nil, errors.New("Incorrect value type - expecting resource of kind Node")
+		}
+
+		// The bird templates always expects the BGP IP keys to be present for a node even
+		// if they are not specified (the value in that case should be a blank string).  All
+		// other fields should have their corresponding configuration removed when they are
+		// not present in the Spec.  Store failures to convert, but treat as if unassigned.
+		// Return the first error that was hit.
+		ipv4 = ""
+		ipv6 = ""
+		if bgp := node.Spec.BGP; bgp != nil {
+			if len(bgp.IPv4Address) != 0 {
+				ip, cidr, perr := net.ParseCIDROrIP(bgp.IPv4Address)
+				if perr == nil {
+					ipv4 = ip.String()
+					netv4 = cidr.Network().String()
+				} else {
+					err = perr
+				}
+			}
+			if len(bgp.IPv6Address) != 0 {
+				ip, cidr, perr := net.ParseCIDROrIP(bgp.IPv6Address)
+				if perr == nil {
+					ipv6 = ip.String()
+					netv6 = cidr.Network().String()
+				} else if err == nil {
+					err = perr
+				}
+			}
+			if bgp.ASNumber != nil {
+				asNum = bgp.ASNumber.String()
+			}
+		}
+	}
+
+	return []*model.KVPair{
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "ip_addr_v4",
+			},
+			Value:    ipv4,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "ip_addr_v6",
+			},
+			Value:    ipv6,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "network_v4",
+			},
+			Value:    netv4,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "network_v6",
+			},
+			Value:    netv6,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "as_num",
+			},
+			Value:    asNum,
+			Revision: kvp.Revision,
+		},
+	}, err
+}
+
+// Sync is restarting - nothing to do for this processor.
+func (c *bgpNodeUpdateProcessor) OnSyncerStarting() {
+	log.Debug("Sync starting called on BGP node update processor")
+}
+
+func (c *bgpNodeUpdateProcessor) extractName(k model.Key) (string, error) {
+	rk, ok := k.(model.ResourceKey)
+	if !ok || rk.Kind != apiv2.KindNode {
+		return "", errors.New("Incorrect key type - expecting resource of kind Node")
+	}
+	return rk.Name, nil
+}

--- a/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var _ = Describe("Test the (BGP) Node update processor", func() {
+	v2NodeKey1 := model.ResourceKey{
+		Kind: apiv2.KindNode,
+		Name: "bgpnode1",
+	}
+	numBgpConfigs := 5
+	up := updateprocessors.NewBGPNodeUpdateProcessor()
+
+	BeforeEach(func() {
+		up.OnSyncerStarting()
+	})
+
+	// The Node contains a bunch of v1 per-node BGP configuration - so we can simply use the
+	// checkExpectedConfigs() function defined in the configurationprocessor_test to perform
+	// our validation.  Note that it expects a node name of bgpnode1.
+	It("should handle conversion of valid Nodes", func() {
+		By("converting a zero-ed Node")
+		res := apiv2.NewNode()
+		res.Name = "bgpnode1"
+		expected := map[string]interface{}{
+			"ip_addr_v4": "",
+			"ip_addr_v6": "",
+			"network_v4": nil,
+			"network_v6": nil,
+			"as_num":     nil,
+		}
+		kvps, err := up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("converting a zero-ed but non-nil BGPNodeSpec")
+		res = apiv2.NewNode()
+		res.Name = "bgpnode1"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// same expected results as the fully zeroed struct.
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("converting a Node with an IPv4 (specified without the network) only - expect /32 net")
+		res = apiv2.NewNode()
+		res.Name = "bgpnode1"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4",
+		}
+		expected = map[string]interface{}{
+			"ip_addr_v4": "1.2.3.4",
+			"ip_addr_v6": "",
+			"network_v4": "1.2.3.4/32",
+			"network_v6": nil,
+			"as_num":     nil,
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("converting a Node with an IPv6 (specified without the network) only - expect /128 net")
+		res = apiv2.NewNode()
+		res.Name = "bgpnode1"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv6Address: "aa:bb:cc::",
+		}
+		expected = map[string]interface{}{
+			"ip_addr_v4": "",
+			"ip_addr_v6": "aa:bb:cc::",
+			"network_v4": nil,
+			"network_v6": "aa:bb:cc::/128",
+			"as_num":     nil,
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("converting a Node with IPv4 and IPv6 network and AS number")
+		res = apiv2.NewNode()
+		res.Name = "bgpnode1"
+		asn := numorstring.ASNumber(12345)
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/24",
+			IPv6Address: "aa:bb:cc::ffff/120",
+			ASNumber:    &asn,
+		}
+		expected = map[string]interface{}{
+			"ip_addr_v4": "1.2.3.4",
+			"ip_addr_v6": "aa:bb:cc::ffff",
+			"network_v4": "1.2.3.0/24",
+			"network_v6": "aa:bb:cc::ff00/120",
+			"as_num":     "12345",
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewNode()
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalConfigKey{
+				Name: "foobar",
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewBGPPeer()
+		_, err = up.Process(&model.KVPair{
+			Key:      v2NodeKey1,
+			Value:    wres,
+			Revision: "abcdef",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with an invalid IPv4 address - treat as unassigned")
+		res = apiv2.NewNode()
+		res.Name = "bgpnode1"
+		asn := numorstring.ASNumber(12345)
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/240",
+			IPv6Address: "aa:bb:cc::ffff/120",
+			ASNumber: &asn,
+		}
+		kvps, err := up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		// IPv4 address should be blank, network should be nil (deleted)
+		expected := map[string]interface{}{
+			"ip_addr_v4": "",
+			"ip_addr_v6": "aa:bb:cc::ffff",
+			"network_v4": nil,
+			"network_v6": "aa:bb:cc::ff00/120",
+			"as_num":     "12345",
+		}
+		Expect(err).To(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("trying to convert with an invalid IPv6 address - treat as unassigned")
+		res = apiv2.NewNode()
+		res.Name = "bgpnode1"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/24",
+			IPv6Address: "aazz::qq/100",
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		// IPv6 address should be blank, network should be nil (deleted)
+		expected = map[string]interface{}{
+			"ip_addr_v4": "1.2.3.4",
+			"ip_addr_v6": "",
+			"network_v4": "1.2.3.0/24",
+			"network_v6": nil,
+			"as_num":     nil,
+		}
+		Expect(err).To(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/bgppeerprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/bgppeerprocessor.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	"github.com/projectcalico/libcalico-go/lib/converter/modelv2v1"
+)
+
+// Create a new SyncerUpdateProcessor to sync IPPool data in v1 format for
+// consumption by both Felix and the BGP daemon.
+func NewBGPPeerUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	ipc := modelv2v1.BGPPeerConverter{}
+	return NewConflictResolvingCacheUpdateProcessor(apiv2.KindBGPPeer, ipc.ConvertV2ToV1)
+}

--- a/lib/backend/syncersv1/updateprocessors/bgppeerprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/bgppeerprocessor_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+var _ = Describe("Test the BGPPeer update processor", func() {
+	v2PeerKey1 := model.ResourceKey{
+		Kind: apiv2.KindBGPPeer,
+		Name: "name1",
+	}
+	v2PeerKey2 := model.ResourceKey{
+		Kind: apiv2.KindBGPPeer,
+		Name: "name2",
+	}
+	ip1str := "1.2.3.0"
+	ip2str := "aa:bb:cc::"
+	node1 := "node1"
+	v1GlobalPeerKeyIP1 := model.GlobalBGPPeerKey{
+		PeerIP: net.MustParseIP(ip1str),
+	}
+	v1GlobalPeerKeyIP2 := model.GlobalBGPPeerKey{
+		PeerIP: net.MustParseIP(ip2str),
+	}
+	v1Node1PeerKeyIP2 := model.NodeBGPPeerKey{
+		Nodename: node1,
+		PeerIP:   net.MustParseIP(ip2str),
+	}
+
+	It("should handle conversion of valid BGPPeers", func() {
+		up := updateprocessors.NewBGPPeerUpdateProcessor()
+
+		By("converting a global BGPPeer with minimum configuration")
+		res := apiv2.NewBGPPeer()
+		res.Name = v2PeerKey1.Name
+		res.Spec.PeerIP = ip1str
+		res.Spec.ASNumber = 11111
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1GlobalPeerKeyIP1,
+			Value: &model.BGPPeer{
+				PeerIP: v1GlobalPeerKeyIP1.PeerIP,
+				ASNum:  11111,
+			},
+			Revision: "abcde",
+		}))
+
+		By("adding/updating/deleting/adding another global BGPPeer with the same PeerIP (but higher alphanumeric name - no update expected")
+		res = apiv2.NewBGPPeer()
+		res.Name = v2PeerKey2.Name
+		res.Spec.PeerIP = ip1str
+		res.Spec.ASNumber = 1234
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(0))
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey2,
+			Value:    res,
+			Revision: "1235",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(0))
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey2,
+			Revision: "1235",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(0))
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey2,
+			Value:    res,
+			Revision: "1239",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(0))
+
+		By("updating the first BGPPeer to be node specific and with a different IP - expect updates for both BGPPeers")
+		res = apiv2.NewBGPPeer()
+		res.Name = v2PeerKey1.Name
+		res.Spec.PeerIP = ip2str
+		res.Spec.ASNumber = 11111
+		res.Spec.Node = node1
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "abcdef",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1GlobalPeerKeyIP1,
+				Value: &model.BGPPeer{
+					PeerIP: v1GlobalPeerKeyIP1.PeerIP,
+					ASNum:  1234,
+				},
+				Revision: "1239",
+			},
+			{
+				Key: v1Node1PeerKeyIP2,
+				Value: &model.BGPPeer{
+					PeerIP: v1GlobalPeerKeyIP2.PeerIP,
+					ASNum:  11111,
+				},
+				Revision: "abcdef",
+			},
+		}))
+
+		By("deleting the first BGPPeer")
+		kvps, err = up.Process(&model.KVPair{
+			Key: v2PeerKey1,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1Node1PeerKeyIP2,
+			},
+		}))
+
+		By("deleting the second BGPPeer")
+		kvps, err = up.Process(&model.KVPair{
+			Key: v2PeerKey2,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1GlobalPeerKeyIP1,
+			},
+		}))
+
+		By("checking global and node peers are treated separately even if they have the same IP")
+		res = apiv2.NewBGPPeer()
+		res.Name = v2PeerKey1.Name
+		res.Spec.PeerIP = ip2str
+		res.Spec.ASNumber = 11111
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "00000",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1GlobalPeerKeyIP2,
+			Value: &model.BGPPeer{
+				PeerIP: v1GlobalPeerKeyIP2.PeerIP,
+				ASNum:  11111,
+			},
+			Revision: "00000",
+		}))
+
+		res = apiv2.NewBGPPeer()
+		res.Name = v2PeerKey2.Name
+		res.Spec.PeerIP = ip2str
+		res.Spec.Node = node1
+		res.Spec.ASNumber = 22222
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey2,
+			Value:    res,
+			Revision: "00001",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1Node1PeerKeyIP2,
+			Value: &model.BGPPeer{
+				PeerIP: v1GlobalPeerKeyIP2.PeerIP,
+				ASNum:  22222,
+			},
+			Revision: "00001",
+		}))
+
+		By("clearing the cache (by starting sync) and failing to delete the second BGPPeer")
+		up.OnSyncerStarting()
+		kvps, err = up.Process(&model.KVPair{
+			Key: v2PeerKey2,
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewBGPPeerUpdateProcessor()
+
+		By("trying to convert with the wrong key type")
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: net.MustParseIP("1.2.3.4"),
+			},
+			Value:    apiv2.NewIPPool(),
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		res := apiv2.NewBGPPeer()
+		res.Name = "name1"
+		res.Spec.PeerIP = "1.2.3.4"
+		_, err = up.Process(&model.KVPair{
+			Key:      model.IPPoolKey{CIDR: net.MustParseCIDR("1.2.3.0/24")},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert a peer with an invalid IP")
+		res = apiv2.NewBGPPeer()
+		res.Name = "name1"
+		res.Spec.PeerIP = "1.2.3.x"
+		_, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should handle failures to convert a BGPPeer", func() {
+		up := updateprocessors.NewBGPPeerUpdateProcessor()
+
+		By("converting a global BGPPeer with minimum configuration")
+		res := apiv2.NewBGPPeer()
+		res.Name = v2PeerKey1.Name
+		res.Spec.PeerIP = ip1str
+		res.Spec.ASNumber = 11111
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1GlobalPeerKeyIP1,
+			Value: &model.BGPPeer{
+				PeerIP: v1GlobalPeerKeyIP1.PeerIP,
+				ASNum:  11111,
+			},
+			Revision: "abcde",
+		}))
+
+		By("setting an invalid PeerIP address and checking for error with delete")
+		res = apiv2.NewBGPPeer()
+		res.Name = v2PeerKey1.Name
+		res.Spec.PeerIP = "not a valid IP"
+		res.Spec.ASNumber = 11111
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "abcdeg",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1GlobalPeerKeyIP1,
+		}))
+
+		By("setting another invalid PeerIP address and checking for error with no update")
+		res = apiv2.NewBGPPeer()
+		res.Name = v2PeerKey1.Name
+		res.Spec.PeerIP = "not a valid IP 2"
+		res.Spec.ASNumber = 11111
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PeerKey1,
+			Value:    res,
+			Revision: "abcdef",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(kvps).To(HaveLen(0))
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/clusterinfoprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/clusterinfoprocessor.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"reflect"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// Create a new NewClusterInfoUpdateProcessor.
+func NewClusterInfoUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewConfigUpdateProcessor(
+		reflect.TypeOf(apiv2.ClusterInformationSpec{}),
+		DisallowAnnotations,
+		func(node, name string) model.Key { return model.HostConfigKey{Hostname: node, Name: name} },
+		func(name string) model.Key { return model.GlobalConfigKey{Name: name} },
+		nil,
+	)
+}

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
@@ -1,0 +1,349 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+const (
+	AllowAnnotations    = true
+	DisallowAnnotations = false
+)
+
+// NewConfigUpdateProcessor creates a SyncerUpdateProcessor that can be used to map
+// Configuration-type resources to the v1 model.  This converter basically
+// expands each field as a separate key and uses a stringified of the field as the
+// configuration value.  If the field is not specified in the configuration resource
+// we expand that that a delete for the associated key.
+//
+// If the field specifies a "confignamev1" tag, then the value in that tag is used
+// as the config name, otherwise the struct field name is used.
+//
+// A set of ValueToStringFn can be specified for each of the (converted) field names
+// to handle marshaling the field value into the string value required in the v1
+// model.
+//
+// It is assumed that the name of the resource follows the format:
+// - `default` for global
+// - `node.<nodename>` for per-node
+//
+// If allowAnnotations is set to true, then this helper will also check the annotations
+// for additional config key/values.  An annotation prefixed with "config.projectcalico.org/"
+// will be used (prefix removed) as the config key, and the value of the annotation used as
+// the value.  These values are not validated, and take precedence over keys of the same
+// name in the Spec - thus it's possible to use an annotation to work around any validation
+// provided on the Spec.
+func NewConfigUpdateProcessor(
+	specType reflect.Type,
+	allowAnnotations bool,
+	nodeConfigKeyFn NodeConfigKeyFn,
+	globalConfigKeyFn GlobalConfigKeyFn,
+	stringifiers map[string]ValueToStringFn,
+) watchersyncer.SyncerUpdateProcessor {
+	names := make(map[string]struct{}, specType.NumField())
+	for i := 0; i < specType.NumField(); i++ {
+		names[getConfigName(specType.Field(i))] = struct{}{}
+	}
+	return &configUpdateProcessor{
+		specType:          specType,
+		allowAnnotations:  allowAnnotations,
+		nodeConfigKeyFn:   nodeConfigKeyFn,
+		globalConfigKeyFn: globalConfigKeyFn,
+		names:             names,
+		additionalNames:   map[string]struct{}{},
+		stringifiers:      stringifiers,
+	}
+}
+
+// Convert the node and config name to the corresponding per-node config key
+type NodeConfigKeyFn func(node, name string) model.Key
+
+// Convert the config name to the corresponding global config key
+type GlobalConfigKeyFn func(name string) model.Key
+
+// Convert an arbitrary value to the string value used in the config.
+type ValueToStringFn func(value interface{}) string
+
+var (
+	globalConfigName        = "default"
+	perNodeConfigNamePrefix = "node."
+	annotationConfigPrefix  = "config.projectcalico.org/"
+)
+
+// configUpdateProcessor implements the SyncerUpdateProcessor interface for converting
+// between v2 configuration resources (FelixConfiguration and ClusterInformation) and
+// individual global or per-node values.
+//
+// This helper class uses the name of the resource to determine whether the
+// converted resource is global or per-node, and then creates a separate update for
+// each field, using either the name of the field or the value in the confignamev1 tag
+// as the name of the config key and the value of the field converted to the config value.
+// The struct field values are converted as follows:
+// -  if the field is nil, or an empty string - the converted value is nil indicating a
+//    deletion of the config key.
+// -  if a converter has been provided for the field then the value is converted using
+//    that converter.
+// -  if it is a string field, the value is used as is.
+// -  booleans and ints are stringified in the standard way
+//
+// This converter caches a list of additional config names that it has seen defined in
+// annotations.  This is used as a simplistic mechanism for sending deletes for config
+// removed from an annotation.
+type configUpdateProcessor struct {
+	specType          reflect.Type
+	allowAnnotations  bool
+	nodeConfigKeyFn   NodeConfigKeyFn
+	globalConfigKeyFn GlobalConfigKeyFn
+	names             map[string]struct{}
+	additionalNames   map[string]struct{}
+	stringifiers      map[string]ValueToStringFn
+}
+
+func (c *configUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	if kvp.Value == nil {
+		return c.processDeleted(kvp)
+	} else {
+		return c.processAddOrModified(kvp)
+	}
+}
+
+// processDeleted is called when the syncer is processing a delete event.
+func (c *configUpdateProcessor) processDeleted(kvp *model.KVPair) ([]*model.KVPair, error) {
+	node, err := c.extractNode(kvp.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	kvps := make([]*model.KVPair, len(c.names)+len(c.additionalNames))
+	i := 0
+	for name := range c.names {
+		kvps[i] = &model.KVPair{
+			Key: c.createV1Key(node, name),
+		}
+		i++
+	}
+	for name := range c.additionalNames {
+		kvps[i] = &model.KVPair{
+			Key: c.createV1Key(node, name),
+		}
+		i++
+	}
+
+	return kvps, nil
+}
+
+// processAddOrModified is called when the syncer is processing either a New or Updated event.
+func (c *configUpdateProcessor) processAddOrModified(kvp *model.KVPair) ([]*model.KVPair, error) {
+	node, err := c.extractNode(kvp.Key)
+	if err != nil {
+		log.WithField("Key", kvp.Key).Warning("Failed to extract node/global name from key")
+		return nil, err
+	}
+
+	// Extract the config override annotations from the Metadata.  This in turn will validate that
+	// it is a resource in the value.
+	overrides, err := c.extractAnnotations(kvp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the Spec from the resource.
+	specValue := reflect.ValueOf(kvp.Value).Elem().FieldByName("Spec")
+	if !specValue.IsValid() || specValue.Type() != c.specType {
+		log.WithFields(log.Fields{
+			"SpecValue":    specValue,
+			"ExpectedType": c.specType,
+		}).Info("Spec is missing or incorrect type")
+		return nil, errors.New("Spec is missing or incorrect type")
+	}
+
+	// Create a KVP for each field in the Spec struct.
+	kvps := make([]*model.KVPair, len(c.names))
+	numFields := len(c.names)
+	for i := 0; i < numFields; i++ {
+		fieldInfo := c.specType.Field(i)
+		name := getConfigName(fieldInfo)
+
+		// If we have an override, handle explicitly and then skip to the next field.
+		if v, ok := overrides[name]; ok {
+			kvps[i] = &model.KVPair{
+				Key:      c.createV1Key(node, name),
+				Value:    v,
+				Revision: kvp.Revision,
+			}
+
+			// Delete from the overrides list to indicate it's handled.
+			delete(overrides, name)
+			continue
+		}
+
+		// Extract the field value and dereference pointers, storing a nil value if the pointer is nil
+		// or if it's a zero length string.
+		var value interface{}
+		field := specValue.Field(i)
+		if field.Kind() == reflect.Ptr {
+			if !field.IsNil() {
+				value = field.Elem().Interface()
+			}
+		} else {
+			value = field.Interface()
+			if s, ok := value.(string); ok && len(s) == 0 {
+				value = nil
+			}
+		}
+
+		// Check if the field has a conversion function and invoke it if it does.
+		if value != nil {
+			if s, ok := c.stringifiers[name]; ok {
+				value = s(value)
+			}
+		}
+
+		// Stringify the value according to its type.  An empty string is returned as
+		// nil (i.e. delete entry).
+		if value != nil {
+			switch vt := value.(type) {
+			case string:
+				value = vt
+			default:
+				value = fmt.Sprintf("%v", vt)
+			}
+		}
+
+		// Add this value to the set to return.
+		kvps[i] = &model.KVPair{
+			Key:      c.createV1Key(node, name),
+			Value:    value,
+			Revision: kvp.Revision,
+		}
+	}
+
+	// Now handle the additional fields that may have been added through annotations
+	// on previous requests.  This ensures we send deletes for them in case our previous
+	// settings had it set.  The WatcherSyncer handles gracefully multiple deletes for
+	// the same key, so it doesn't matter if it wasn't previously set.
+	var value interface{}
+	for name := range c.additionalNames {
+		// If we have an override for this additional config option then use that value,
+		// otherwise leave the value as nil to ensure we delete the option if it was
+		// previously set.  Remove from the overrides map once handled.
+		if v, ok := overrides[name]; ok {
+			value = v
+			delete(overrides, name)
+		} else {
+			value = nil
+		}
+		kvps = append(kvps, &model.KVPair{
+			Key:      c.createV1Key(node, name),
+			Value:    value,
+			Revision: kvp.Revision,
+		})
+	}
+
+	// Any remaining overrides are ones we haven't seen before.  Add them to the config and
+	// include them in the additionalNames.
+	for name, value := range overrides {
+		kvps = append(kvps, &model.KVPair{
+			Key:      c.createV1Key(node, name),
+			Value:    value,
+			Revision: kvp.Revision,
+		})
+		c.additionalNames[name] = struct{}{}
+	}
+
+	return kvps, nil
+}
+
+// Sync has restarted, so we can clear our cache of additional fields.
+func (c *configUpdateProcessor) OnSyncerStarting() {
+	c.additionalNames = map[string]struct{}{}
+}
+
+// extractAnnotations extracts the config override annotations from the
+// configuration resource.
+func (c *configUpdateProcessor) extractAnnotations(kvp *model.KVPair) (map[string]string, error) {
+	ma, ok := kvp.Value.(v1.ObjectMetaAccessor)
+	if !ok {
+		return nil, errors.New("Unexpected value type in conversion")
+	}
+	overrides := map[string]string{}
+
+	// If annotations are not allowed, don't bother extracting them - just return an empty
+	// map.
+	if !c.allowAnnotations {
+		log.Debug("Annotations are disallowed - skipping extraction")
+		return overrides, nil
+	}
+
+	annotations := ma.GetObjectMeta().GetAnnotations()
+	for k, v := range annotations {
+		if strings.HasPrefix(k, annotationConfigPrefix) {
+			overrides[k[len(annotationConfigPrefix):]] = v
+		}
+	}
+	return overrides, nil
+}
+
+// extractNode returns the name of the Node for which this configuration is for.  A empty string
+// indicates that this is global configuration.
+//
+// Currently the name of a configuration resource has a strict format.  It is either "default"
+// for the global default values, or "node.<nodename>" for the node specific vales.  Returns an
+// error if the name is in neither format.
+func (c *configUpdateProcessor) extractNode(key model.Key) (string, error) {
+	k, ok := key.(model.ResourceKey)
+	if !ok {
+		return "", errors.New("Unexpected key type in conversion")
+	}
+	switch {
+	case k.Name == globalConfigName:
+		return "", nil
+	case strings.HasPrefix(k.Name, perNodeConfigNamePrefix):
+		return k.Name[len(perNodeConfigNamePrefix):], nil
+	default:
+		return "", cerrors.ErrorParsingDatastoreEntry{RawKey: k.Name}
+	}
+}
+
+// Create the appropriate v1 config key depending on whether this global or node specific
+// configuration.
+func (c *configUpdateProcessor) createV1Key(node, name string) model.Key {
+	if node == "" {
+		return c.globalConfigKeyFn(name)
+	} else {
+		return c.nodeConfigKeyFn(node, name)
+	}
+}
+
+// Return the config name from the field.  The field name is either specified in the
+// configname tag, otherwise it just uses the struct field name.
+func getConfigName(field reflect.StructField) string {
+	name := field.Tag.Get("confignamev1")
+	if name == "" {
+		name = field.Name
+	}
+	return name
+}

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -1,0 +1,625 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// What the expected sync datatypes are.
+	isGlobalFelixConfig = iota
+	isNodeFelixConfig
+	isGlobalBgpConfig
+	isNodeBgpConfig
+
+	hostIPMarker = "*HOSTIP*"
+)
+
+var _ = Describe("Test the generic configuration update processor and the concrete implementations", func() {
+	// Define some common values
+	perNodeFelixKey := model.ResourceKey{
+		Kind: apiv2.KindFelixConfiguration,
+		Name: "node.mynode",
+	}
+	globalFelixKey := model.ResourceKey{
+		Kind: apiv2.KindFelixConfiguration,
+		Name: "default",
+	}
+	invalidFelixKey := model.ResourceKey{
+		Kind: apiv2.KindFelixConfiguration,
+		Name: "foobar",
+	}
+	globalClusterKey := model.ResourceKey{
+		Kind: apiv2.KindClusterInformation,
+		Name: "default",
+	}
+	nodeClusterKey := model.ResourceKey{
+		Kind: apiv2.KindClusterInformation,
+		Name: "node.mynode",
+	}
+	globalBgpConfigKey := model.ResourceKey{
+		Kind: apiv2.KindBGPConfiguration,
+		Name: "default",
+	}
+	nodeBgpConfigKey := model.ResourceKey{
+		Kind: apiv2.KindBGPConfiguration,
+		Name: "node.bgpnode1",
+	}
+	numFelixConfigs := 46
+	numClusterConfigs := 3
+	numBgpConfigs := 3
+	felixMappedNames := map[string]interface{}{
+		"RouteRefreshInterval":    nil,
+		"IptablesRefreshInterval": nil,
+		"IpsetsRefreshInterval":   nil,
+	}
+
+	It("should handle conversion of node-specific delete with no additional configs", func() {
+		cc := updateprocessors.NewFelixConfigUpdateProcessor()
+		By("converting a per-node felix key and checking for the correct number of fields")
+		kvps, err := cc.Process(&model.KVPair{
+			Key: perNodeFelixKey,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(kvps, isNodeFelixConfig, numFelixConfigs, felixMappedNames)
+	})
+
+	It("should handle conversion of global delete with no additional configs", func() {
+		cc := updateprocessors.NewFelixConfigUpdateProcessor()
+		By("converting a global felix key and checking for the correct number of fields")
+		kvps, err := cc.Process(&model.KVPair{
+			Key: globalFelixKey,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(kvps, isGlobalFelixConfig, numFelixConfigs, felixMappedNames)
+	})
+
+	It("should handle conversion of node-specific zero value KVPairs with no additional configs", func() {
+		cc := updateprocessors.NewFelixConfigUpdateProcessor()
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   perNodeFelixKey,
+			Value: apiv2.NewFelixConfiguration(),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// Explicitly pass in the "mapped" name values to check to ensure the names are mapped.
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			felixMappedNames,
+		)
+	})
+
+	It("should handle conversion of global zero value KVPairs with no additional configs", func() {
+		cc := updateprocessors.NewFelixConfigUpdateProcessor()
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   globalFelixKey,
+			Value: apiv2.NewFelixConfiguration(),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// Explicitly pass in the "mapped" name values to check to ensure the names are mapped.
+		checkExpectedConfigs(
+			kvps,
+			isGlobalFelixConfig,
+			numFelixConfigs,
+			felixMappedNames,
+		)
+	})
+
+	It("should gracefully handle invalid names/keys/types/values", func() {
+		cc := updateprocessors.NewFelixConfigUpdateProcessor()
+		By("Testing invalid Key on ProcessDeleted")
+		_, err := cc.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: net.MustParseIP("1.2.3.4"),
+			},
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("Testing invalid Key on Process")
+		_, err = cc.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: net.MustParseIP("1.2.3.4"),
+			},
+			Value: apiv2.NewFelixConfiguration(),
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("Testing non-resource type value on Process with add/mod")
+		_, err = cc.Process(&model.KVPair{
+			Key:   globalFelixKey,
+			Value: "this isn't a resource",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("Testing incorrect resource type value on Process with add/mod")
+		_, err = cc.Process(&model.KVPair{
+			Key:   globalFelixKey,
+			Value: apiv2.NewWorkloadEndpoint(),
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("Testing incorrect name structure on Process with add/mod")
+		_, err = cc.Process(&model.KVPair{
+			Key:   invalidFelixKey,
+			Value: apiv2.NewFelixConfiguration(),
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("Testing incorrect name structure on Process with delete")
+		_, err = cc.Process(&model.KVPair{
+			Key: invalidFelixKey,
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should handle different field types being assigned", func() {
+		cc := updateprocessors.NewFelixConfigUpdateProcessor()
+		By("converting a per-node felix KVPair with certain values and checking for the correct number of fields")
+		res := apiv2.NewFelixConfiguration()
+		int1 := int(12345)
+		bool1 := false
+		uint1 := uint32(1313)
+		res.Spec.RouteRefreshIntervalSecs = &int1
+		res.Spec.InterfacePrefix = "califoobar"
+		res.Spec.IpInIpEnabled = &bool1
+		res.Spec.IptablesMarkMask = &uint1
+		res.Spec.FailsafeInboundHostPorts = &[]apiv2.ProtoPort{}
+		res.Spec.FailsafeOutboundHostPorts = &[]apiv2.ProtoPort{
+			{
+				Protocol: "tcp",
+				Port:     1234,
+			},
+			{
+				Protocol: "udp",
+				Port:     22,
+			},
+			{
+				Protocol: "tcp",
+				Port:     65535,
+			},
+		}
+		expected := map[string]interface{}{
+			"RouteRefreshInterval":      "12345",
+			"InterfacePrefix":           "califoobar",
+			"IpInIpEnabled":             "false",
+			"IptablesMarkMask":          "1313",
+			"FailsafeInboundHostPorts":  "",
+			"FailsafeOutboundHostPorts": "tcp:1234,udp:22,tcp:65535",
+		}
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   perNodeFelixKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+	})
+
+	It("should handle cluster config string slice field", func() {
+		cc := updateprocessors.NewClusterInfoUpdateProcessor()
+		By("converting a global cluster info KVPair with values assigned")
+		res := apiv2.NewClusterInformation()
+		res.Spec.ClusterGUID = "abcedfg"
+		res.Spec.ClusterType = "Mesos,K8s"
+		expected := map[string]interface{}{
+			"ClusterGUID": "abcedfg",
+			"ClusterType": "Mesos,K8s",
+		}
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   globalClusterKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalFelixConfig,
+			numClusterConfigs,
+			expected,
+		)
+	})
+
+	It("should allow setting of a known field through an annotation to override validation", func() {
+		cc := updateprocessors.NewBGPConfigUpdateProcessor()
+		res := apiv2.NewBGPConfiguration()
+		res.Annotations = map[string]string{
+			"config.projectcalico.org/loglevel": "this is not validated!",
+		}
+		expected := map[string]interface{}{
+			"loglevel": "this is not validated!",
+		}
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+	})
+
+	It("should override struct value when equivalent annotation is set", func() {
+		cc := updateprocessors.NewBGPConfigUpdateProcessor()
+		res := apiv2.NewBGPConfiguration()
+		res.Annotations = map[string]string{
+			"config.projectcalico.org/loglevel": "this is not validated!",
+			"config.projectcalico.org/as_num":   "asnum foobar",
+		}
+		asNum := numorstring.ASNumber(12345)
+		res.Spec.ASNumber = &asNum
+		res.Spec.LogSeverityScreen = "debug"
+		expected := map[string]interface{}{
+			"loglevel": "this is not validated!",
+			"as_num":   "asnum foobar",
+		}
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+	})
+
+	It("should handle new config options specified through annotations", func() {
+		cc := updateprocessors.NewBGPConfigUpdateProcessor()
+		res := apiv2.NewBGPConfiguration()
+
+		By("validating that the new values are output in addition to the existing ones")
+		res.Annotations = map[string]string{
+			"config.projectcalico.org/NewConfigType":        "newFieldValue",
+			"config.projectcalico.org/AnotherNewConfigType": "newFieldValue2",
+			"thisisnotvalid":                                "not included",
+		}
+		asNum := numorstring.ASNumber(12345)
+		res.Spec.ASNumber = &asNum
+		expected := map[string]interface{}{
+			"as_num":               "12345",
+			"NewConfigType":        "newFieldValue",
+			"AnotherNewConfigType": "newFieldValue2",
+		}
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs+2,
+			expected,
+		)
+
+		By("validating that the options are persisted to allow delete notifications")
+		res.Annotations = nil
+		expected = map[string]interface{}{
+			"as_num":               "12345",
+			"NewConfigType":        nil,
+			"AnotherNewConfigType": nil,
+		}
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs+2,
+			expected,
+		)
+
+		By("validating the delete keys also include the cached config options")
+		kvps, err = cc.Process(&model.KVPair{
+			Key: globalBgpConfigKey,
+		})
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs+2,
+			map[string]interface{}{
+				"NewConfigType":        nil,
+				"AnotherNewConfigType": nil,
+			},
+		)
+
+		By("adding another new config option and reusing one of the previous ones")
+		res.Annotations = map[string]string{
+			"config.projectcalico.org/NewConfigType":           "foobar",
+			"config.projectcalico.org/YetAnotherNewConfigType": "foobarbaz",
+		}
+		res.Spec.ASNumber = nil
+		expected = map[string]interface{}{
+			"as_num":                  nil,
+			"NewConfigType":           "foobar",
+			"AnotherNewConfigType":    nil,
+			"YetAnotherNewConfigType": "foobarbaz",
+		}
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs+3,
+			expected,
+		)
+
+		By("validating the delete keys also include the new cached config option")
+		kvps, err = cc.Process(&model.KVPair{
+			Key: globalBgpConfigKey,
+		})
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs+3,
+			map[string]interface{}{
+				"NewConfigType":           nil,
+				"AnotherNewConfigType":    nil,
+				"YetAnotherNewConfigType": nil,
+			},
+		)
+
+		By("invoking resync and checking old fields are no longer cached")
+		cc.OnSyncerStarting()
+		res.Annotations = nil
+		res.Spec.ASNumber = nil
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			nil,
+		)
+
+		By("validating the delete keys are also back to original")
+		kvps, err = cc.Process(&model.KVPair{
+			Key: globalClusterKey,
+		})
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			nil,
+		)
+	})
+
+	It("should handle BGP configuration correctly", func() {
+		cc := updateprocessors.NewBGPConfigUpdateProcessor()
+		res := apiv2.NewBGPConfiguration()
+
+		By("validating an empty configuration")
+		expected := map[string]interface{}{
+			"loglevel":  nil,
+			"as_num":    nil,
+			"node_mesh": nil,
+		}
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("validating a full configuration")
+		asNum := numorstring.ASNumber(12345)
+		n2n := true
+		res.Spec.LogSeverityScreen = "warning"
+		res.Spec.ASNumber = &asNum
+		res.Spec.NodeToNodeMeshEnabled = &n2n
+		expected = map[string]interface{}{
+			"loglevel":  "none",
+			"as_num":    "12345",
+			"node_mesh": "{\"enabled\":true}",
+		}
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("validating a partial configuration")
+		n2n = false
+		res.Spec.LogSeverityScreen = "debug"
+		res.Spec.ASNumber = nil
+		res.Spec.NodeToNodeMeshEnabled = &n2n
+		expected = map[string]interface{}{
+			"loglevel":  "debug",
+			"as_num":    nil,
+			"node_mesh": "{\"enabled\":false}",
+		}
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   globalBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isGlobalBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("validating node specific configuration")
+		n2n = false
+		res.Spec.LogSeverityScreen = "debug"
+		res.Spec.ASNumber = nil
+		res.Spec.NodeToNodeMeshEnabled = nil
+		expected = map[string]interface{}{
+			"loglevel":  "debug",
+			"as_num":    nil,
+			"node_mesh": nil,
+		}
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   nodeBgpConfigKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+	})
+
+	It("should handle node cluster information", func() {
+		cc := updateprocessors.NewClusterInfoUpdateProcessor()
+		res := apiv2.NewClusterInformation()
+
+		By("validating an empty per node cluster is processed correctly")
+		kvps, err := cc.Process(&model.KVPair{
+			Key:   nodeClusterKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numClusterConfigs,
+			nil,
+		)
+
+		By("validating it is not possible to set/override values using the annotations")
+		res.Annotations = map[string]string{
+			"config.projectcalico.org/ClusterType": "this is not validated!",
+			"config.projectcalico.org/NewField":    "this is also not validated!",
+		}
+		kvps, err = cc.Process(&model.KVPair{
+			Key:   nodeClusterKey,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numClusterConfigs,
+			nil,
+		)
+	})
+})
+
+// Check the KVPairs returned by the UpdateProcessor are as expected.  The expectedValues contains
+// the expected set of data in the updates, any config not specified in the set is expected
+// to be nil in the KVPair.
+// You can use expectedValues to verify certain fields were included in the response even
+// if the values were nil.
+func checkExpectedConfigs(kvps []*model.KVPair, dataType int, expectedNum int, expectedValues map[string]interface{}) {
+	// Copy/convert input data.  We keep track of:
+	// - all field names, so that we can check for duplicates
+	// - extra fields that we have not yet seen
+	// - expected field values that we have not yet validated
+	ev := make(map[string]interface{}, len(expectedValues))
+	for k, v := range expectedValues {
+		ev[k] = v
+	}
+	allNames := map[string]struct{}{}
+
+	By(" - checking the expected number of results")
+	Expect(kvps).To(HaveLen(expectedNum))
+
+	By(" - checking for duplicated, nil values and assigned values as expected")
+	for _, kvp := range kvps {
+		var name string
+		switch dataType {
+		case isGlobalFelixConfig:
+			Expect(kvp.Key).To(BeAssignableToTypeOf(model.GlobalConfigKey{}))
+			name = kvp.Key.(model.GlobalConfigKey).Name
+		case isNodeFelixConfig:
+			switch kt := kvp.Key.(type) {
+			case model.HostConfigKey:
+				node := kt.Hostname
+				Expect(node).To(Equal("mynode"))
+				name = kt.Name
+			case model.HostIPKey:
+				// Although the HostIPKey is not in the same key space as the HostConfig, we
+				// special case this to make this test reusable for more tests.
+				node := kt.Hostname
+				Expect(node).To(Equal("mynode"))
+				name = hostIPMarker
+				logrus.Warnf("IP in key: %s", kvp.Value)
+			default:
+				Expect(kvp.Key).To(BeAssignableToTypeOf(model.HostConfigKey{}))
+			}
+		case isGlobalBgpConfig:
+			Expect(kvp.Key).To(BeAssignableToTypeOf(model.GlobalBGPConfigKey{}))
+			name = kvp.Key.(model.GlobalBGPConfigKey).Name
+		case isNodeBgpConfig:
+			Expect(kvp.Key).To(BeAssignableToTypeOf(model.NodeBGPConfigKey{}))
+			node := kvp.Key.(model.NodeBGPConfigKey).Nodename
+			Expect(node).To(Equal("bgpnode1"))
+			name = kvp.Key.(model.NodeBGPConfigKey).Name
+		}
+
+		// Validate and track the expected values.
+		if v, ok := ev[name]; ok {
+			if v == nil {
+				Expect(kvp.Value).To(BeNil(), "Field: "+name)
+			} else {
+				Expect(kvp.Value).To(Equal(v), "Field: "+name)
+			}
+			delete(ev, name)
+		} else {
+			Expect(kvp.Value).To(BeNil(), "Field: "+name)
+		}
+
+		// Validate the fields we have seen, checking for duplicates.
+		_, ok := allNames[name]
+		Expect(ok).To(BeFalse(), fmt.Sprintf("config name is repeated in response: %s", name))
+		allNames[name] = struct{}{}
+	}
+
+	By(" - checking all expected values were accounted for")
+	Expect(ev).To(HaveLen(0), fmt.Sprintf("config name missing in response"))
+}

--- a/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc.go
+++ b/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"fmt"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+// ConflictResolvingNameCacheProcessor implements a cached update processor that may be used
+// to handle resources where the indexing has changed between the v2 and v1 models.  In v2
+// all resources have a single name field which in some cases may be unlinked to the v1 indexes.
+// This means it's potentially possible to have multiple v2 resources that share a common set of
+// indexes when converted to the v1 model - e.g. IPPools in v2 are indexed by arbitrary name, and in
+// v1 by the Pool CIDR, it would be possible to have multiple pools configured with the same
+// CIDR.
+//
+// This cache may also be used when name conflicts are not an issue, but there is no direct map
+// between the v1 key and the v2 key, for example HostEndpoints have an additional "node" index
+// in the v1 key, so this cache can be used to resolve between the v2 name and the last set of v1
+// indices to provide the relevant updates.
+//
+// Notes:
+// - this update processor only handles simple 1:1 conversions (i.e. a single v2 model mapping to
+//   a single v1 model).
+// - generally, validation processing would prevent the user from making configuration
+//   changes with conflicting (duplicate) information - but since that operation is not atomic,
+//   we need to handle gracefully these situations whether or not that validation processing is
+//   in place.
+// - since the relationship between the v1 and v2 indexes is not locked, the v1 index
+//   for a given v2 resource may be changed by an update.
+//
+// This cache handles conflicting entries by only syncing the v1 data for the v2 resource with
+// the lowest alphanumeric name.  This means:
+// -  Adding a conflicting resource with a higher alphanumeric name will not result in any
+//    syncer update.
+// -  Deleting the conflicting resource with the lowest alphanumeric name will result in
+//    an update using the configuration of the conflicting resource with the next lowest
+//    alphanumeric name.
+// -  Modifying an existing resource (that is already in our cache) is more complicated.
+//    It is possible that the modification may alter the v1 key - and in which case we need
+//    to effectively treat as a delete (for the old v1 key) and an add for the new v1 key.
+func NewConflictResolvingCacheUpdateProcessor(v2Kind string, converter ConvertV2ToV1) watchersyncer.SyncerUpdateProcessor {
+	return &conflictResolvingCache{
+		v2Kind:              v2Kind,
+		converter:           converter,
+		kvpsByName:          make(map[string]*model.KVPair),
+		orderedNamesByV1Key: make(map[string][]string),
+	}
+}
+
+type ConvertV2ToV1 func(kvp *model.KVPair) (*model.KVPair, error)
+
+// conflictResolvingCache implements the ConflictRecolvingCache interface.
+type conflictResolvingCache struct {
+	v2Kind              string
+	converter           ConvertV2ToV1
+	kvpsByName          map[string]*model.KVPair
+	orderedNamesByV1Key map[string][]string
+}
+
+func (c *conflictResolvingCache) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	// Extract the name of the resource.
+	rk, ok := kvp.Key.(model.ResourceKey)
+	if !ok || rk.Kind != c.v2Kind {
+		return nil, fmt.Errorf("Incorrect key type - expecting resource of kind %s", c.v2Kind)
+	}
+	name := rk.Name
+
+	// If there is no value then this is a delete.
+	if kvp.Value == nil {
+		return c.delete(name)
+	}
+
+	// Convert the v2 resource to the equivalent v1 resource type.
+	kvp, err := c.converter(kvp)
+	if err != nil {
+		// We were unable to convert the resource.  If we have an entry for this resource then we
+		// need to handle this as a delete.  In either case we return the original error.
+		log.Warningf("Unable to convert resource %s(%s) - treating as delete", c.v2Kind, name)
+		if kvp := c.kvpsByName[name]; kvp != nil {
+			res, _ := c.delete(name)
+			return res, err
+		}
+		return nil, err
+	}
+
+	// Construct the new v1Key string (we just use the default path)
+	v1Key, err := model.KeyToDefaultPath(kvp.Key)
+	if err != nil {
+		// If we are unable to convert the key then we need to treat this as a delete - otherwise bad
+		// config will result in stale entries being stuck in the syncer.  This should have been
+		// caught by the converter, but handle here just in case.  Always return the original error
+		// along with the results.
+		log.Warningf("Unable to convert resource %s(%s) - treating as delete", c.v2Kind, name)
+		if kvp := c.kvpsByName[name]; kvp != nil {
+			res, _ := c.delete(name)
+			return res, err
+		}
+		return nil, err
+	}
+
+	logCxt := log.WithFields(log.Fields{
+		"Name": name,
+		"Key":  v1Key,
+	})
+
+	// If we have a value cached for this name, handle the situation where the v1 key has
+	// changed.
+	var response []*model.KVPair
+	if existing := c.kvpsByName[name]; existing != nil {
+		// Get the old key, we know this succeeds because we had to get the default path to put it
+		// in the cache.
+		oldV1Key, err := model.KeyToDefaultPath(existing.Key)
+		cerrors.FatalIfErrored(err)
+
+		// If the key has changed, first handle this as a delete.  This may result in a
+		// delete response that we need to include.
+		if oldV1Key != v1Key {
+			logCxt.WithField("Old key", oldV1Key).Info("key modified, handle delete first")
+			response, err = c.delete(name)
+			cerrors.FatalIfErrored(err)
+		}
+	}
+
+	// Get the current set of names that map to this key, and if this name is not
+	// in the list - add it and sort the list.
+	cns := c.orderedNamesByV1Key[v1Key]
+	inList := false
+	for _, cn := range cns {
+		if cn == name {
+			inList = true
+			break
+		}
+	}
+	if !inList {
+		cns = append(cns, name)
+		sort.Strings(cns)
+	}
+
+	// Update our cache.
+	c.orderedNamesByV1Key[v1Key] = cns
+	c.kvpsByName[name] = kvp
+
+	// If this is the first entry in the list then the kvp should be included in the syncer
+	// response.
+	if cns[0] == name {
+		logCxt.WithField("AllConflictingResourceNames", cns).Debug("non conflicting, or primary resource: sending update")
+		response = append(response, kvp)
+	} else {
+		logCxt.WithField("AllConflictingResourceNames", cns).Warning("conflicting resources and this is not the primary resource: swallowing update")
+	}
+
+	return response, nil
+}
+
+// Deletes an entry in the cache.  The name is the original name of the v2 resource.
+//
+// Returns the effective update(s) to send in the syncer.  A nil value in the KVPair
+// indicates a delete, otherwise it's an add/modify.
+func (c *conflictResolvingCache) delete(name string) ([]*model.KVPair, error) {
+	logCxt := log.WithField("Name", name)
+
+	// Get the data that we currently have stored in our cache for this resource name.
+	kvp := c.kvpsByName[name]
+	if kvp == nil {
+		return nil, fmt.Errorf("delete called for unknown resource: %s", name)
+	}
+
+	// Calculate the key for that resource.  This should succeed because we already called
+	// this to get the entry in the cache.
+	v1Key, err := model.KeyToDefaultPath(kvp.Key)
+	cerrors.FatalIfErrored(err)
+
+	// Get the current set of names that map to this key and use this to determine what
+	// updates to send.
+	cns := c.orderedNamesByV1Key[v1Key]
+
+	// If this is the primary resource in the v1 model then we either need to delete if
+	// there are no conflicting resources, or send an update for the new primary resource.
+	var response []*model.KVPair
+	if cns[0] == name {
+		logCxt.WithField("All conflicting resource names", cns).Debug("non conflicting, or primary resource deleted: sending update")
+
+		if len(cns) == 1 {
+			// There are no conflicting entries, so send a delete for this v1 key.
+			logCxt.Debug("no conflicting entries: sending delete")
+			response = []*model.KVPair{{
+				Key: kvp.Key,
+			}}
+		} else {
+			// There is a new primary resource (the next entry in the ordered list of names) for
+			// the set of conflicting v1 keys.  Send an update using the new primary resource
+			// configuration - looking up the stored details by name.
+			logCxt.WithField("Primary resource", cns[1]).Debug("conflicting entries: sending update for new primary")
+			kvp := c.kvpsByName[cns[1]]
+			response = []*model.KVPair{kvp}
+		}
+	} else {
+		logCxt.WithFields(log.Fields{
+			"All conflicting resource names": cns,
+		}).Warning("conflicting resources and this is not the primary resource: swallowing update")
+	}
+
+	// Update the cache.
+	delete(c.kvpsByName, name)
+
+	if len(cns) == 1 {
+		// Ours was the only entry in the conflicting names list, so just remove the set
+		// in its entirety.
+		delete(c.orderedNamesByV1Key, v1Key)
+	} else {
+		// Ours was not the only entry in the conflicting names list, so remove our entry
+		// and update the cache (keeping the list ordered).
+		newCns := make([]string, len(cns)-1)
+		i := 0
+		for _, cn := range cns {
+			if cn != name {
+				newCns[i] = cn
+				i++
+			}
+		}
+		c.orderedNamesByV1Key[v1Key] = newCns
+	}
+
+	return response, nil
+}
+
+// ClearCache removes all entries from the cache.
+func (c *conflictResolvingCache) OnSyncerStarting() {
+	log.Debug("Clearing cache for resync")
+	c.kvpsByName = make(map[string]*model.KVPair)
+	c.orderedNamesByV1Key = make(map[string][]string)
+}

--- a/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc_test.go
+++ b/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+)
+
+// fakeconverter allows us to tune what is returned from the converter to test different
+// error paths.
+type fakeconverter struct {
+	res *model.KVPair
+	err error
+}
+func (fc *fakeconverter) Convert(in *model.KVPair) (*model.KVPair, error) {
+	return fc.res, fc.err
+}
+
+// Most of the tests for the ConflictResolvingCacheUpdateProcessor are handled through the
+// testing of the concrete implementations (BGPPeerProcessor and IPPoolProcessor).  The
+// tests in this file mop up some of the error branches that need more controlled error
+// handling.
+var _ = Describe("Test the conflict resolving cache", func() {
+
+	// Define a common set of keys and values for our tests.  Note the actual value
+	// types are not important - but make sure we have something non-nil to indicate
+	// a value is present.
+	v2PeerKVP := &model.KVPair{
+		Key: model.ResourceKey{
+			Kind: apiv2.KindBGPPeer,
+			Name: "name1",
+		},
+		Value: "foobar",
+		Revision: "12345",
+	}
+	v1Key1 := model.GlobalBGPPeerKey{
+		PeerIP: net.MustParseIP("1.2.3.4"),
+	}
+
+	converter := &fakeconverter{}
+
+	It("should handle converting the resource, but failing to create the v1 key", func() {
+		c := updateprocessors.NewConflictResolvingCacheUpdateProcessor(apiv2.KindBGPPeer, converter.Convert)
+		converter.res = &model.KVPair{
+			Key: v1Key1,
+			Value: "foobarfizz",
+			Revision: "12345",
+		}
+		converter.err = nil
+
+		By("successfully converting a Peer to populate the cache")
+		// Note that we don't need proper values here since this test doesn't touch the conversion
+		// code and instead uses our "fake" converter.
+		kvp, err := c.Process(v2PeerKVP)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvp).To(HaveLen(1))
+		Expect(kvp[0]).To(Equal(
+			&model.KVPair{
+				Key: v1Key1,
+				Value: "foobarfizz",
+				Revision: "12345",
+			},
+		))
+
+		By("Converter successfully converts the KVPair, but returns an invalid Key that cannot be converted - get delete and error")
+		converter.res = &model.KVPair{
+			Key: model.GlobalBGPPeerKey{},
+			Value: "foobarfoo",
+			Revision: "12346",
+		}
+		kvp, err = c.Process(v2PeerKVP)
+		Expect(kvp).To(HaveLen(1))
+		Expect(kvp[0]).To(Equal(
+			&model.KVPair{
+				Key: v1Key1,
+			},
+		))
+		Expect(err).To(HaveOccurred())
+
+		By("Converter successfully converts the KVPair, but returns an invalid Key that cannot be converted - get no actions, just error")
+		converter.res = &model.KVPair{
+			Key: model.GlobalBGPPeerKey{},
+			Value: "foobarfoo",
+			Revision: "12346",
+		}
+		kvp, err = c.Process(v2PeerKVP)
+		Expect(kvp).To(HaveLen(0))
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/doc.go
+++ b/lib/backend/syncersv1/updateprocessors/doc.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+/*
+This package contains the required converters to convert v2 model to the
+v1 model required by Felix and confd.
+*/

--- a/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// Create a new SyncerUpdateProcessor to sync FelixConfiguration data in v1 format for
+// consumption by Felix.
+func NewFelixConfigUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewConfigUpdateProcessor(
+		reflect.TypeOf(apiv2.FelixConfigurationSpec{}),
+		AllowAnnotations,
+		func(node, name string) model.Key { return model.HostConfigKey{Hostname: node, Name: name} },
+		func(name string) model.Key { return model.GlobalConfigKey{Name: name} },
+		map[string]ValueToStringFn{
+			"FailsafeInboundHostPorts":  protoPortStringifier,
+			"FailsafeOutboundHostPorts": protoPortStringifier,
+		},
+	)
+}
+
+// Convert a slice of ProtoPorts to the string representation required by Felix.
+var protoPortStringifier = func(value interface{}) string {
+	pps := value.([]apiv2.ProtoPort)
+	parts := make([]string, len(pps))
+	for i, pp := range pps {
+		parts[i] = fmt.Sprintf("%s:%d", pp.Protocol, pp.Port)
+	}
+	return strings.Join(parts, ",")
+}

--- a/lib/backend/syncersv1/updateprocessors/felixconverters_suite_test.go
+++ b/lib/backend/syncersv1/updateprocessors/felixconverters_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Syncer update processors suite")
+}

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// Create a new SyncerUpdateProcessor to sync Node data in v1 format for
+// consumption by Felix.
+func NewFelixNodeUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return &FelixNodeUpdateProcessor{}
+}
+
+// FelixNodeUpdateProcessor implements the SyncerUpdateProcessor interface.
+// This converts the v2 node configuration into the v1 data types consumed by confd.
+type FelixNodeUpdateProcessor struct {
+}
+
+func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	// Extract the name.
+	name, err := c.extractName(kvp.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the separate bits of BGP config - these are stored as separate keys in the
+	// v1 model.  For a delete these will all be nil.  If we fail to convert any value then
+	// just treat that as a delete on the underlying key and return the error alongside
+	// the updates.
+	var ipv4, ipv4Tunl interface{}
+	if kvp.Value != nil {
+		node, ok := kvp.Value.(*apiv2.Node)
+		if !ok {
+			return nil, errors.New("Incorrect value type - expecting resource of kind Node")
+		}
+
+		if bgp := node.Spec.BGP; bgp != nil {
+			var ip *cnet.IP
+			var cidr *cnet.IPNet
+
+			// Parse the IPv4 address, Felix expects this as a HostIPKey.  If we fail to parse then
+			// treat as a delete (i.e. leave ipv4 as nil).
+			if len(bgp.IPv4Address) != 0 {
+				ip, cidr, err = cnet.ParseCIDROrIP(bgp.IPv4Address)
+				if err == nil {
+					log.WithFields(log.Fields{"ip": ip, "cidr": cidr}).Debug("Parsed IPv4 address")
+					ipv4 = ip
+				} else {
+					log.WithError(err).WithField("IPv4Address", bgp.IPv4Address).Warn("Failed to parse IPv4Address")
+				}
+			}
+
+			// Parse the IPv4 IPIP tunnel address, Felix expects this as a HostConfigKey.  If we fail to parse then
+			// treat as a delete (i.e. leave ipv4Tunl as nil).
+			if len(bgp.IPv4IPIPTunnelAddr) != 0 {
+				ip := cnet.ParseIP(bgp.IPv4IPIPTunnelAddr)
+				if ip != nil {
+					log.WithField("ip", ip).Debug("Parsed IPIP tunnel address")
+					ipv4Tunl = ip.String()
+				} else {
+					log.WithField("IPv4IPIPTunnelAddr", bgp.IPv4IPIPTunnelAddr).Warn("Failed to parse IPv4IPIPTunnelAddr")
+					err = fmt.Errorf("failed to parsed IPv4IPIPTunnelAddr as an IP address")
+				}
+			}
+		}
+	}
+
+	// Return the add/delete updates and any errors.
+	return []*model.KVPair{
+		{
+			Key: model.HostIPKey{
+				Hostname: name,
+			},
+			Value:    ipv4,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.HostConfigKey{
+				Hostname: name,
+				Name:     "IpInIpTunnelAddr",
+			},
+			Value:    ipv4Tunl,
+			Revision: kvp.Revision,
+		},
+	}, err
+}
+
+// Sync is restarting - nothing to do for this processor.
+func (c *FelixNodeUpdateProcessor) OnSyncerStarting() {
+	log.Debug("Sync starting called on Felix node update processor")
+}
+
+func (c *FelixNodeUpdateProcessor) extractName(k model.Key) (string, error) {
+	rk, ok := k.(model.ResourceKey)
+	if !ok || rk.Kind != apiv2.KindNode {
+		return "", errors.New("Incorrect key type - expecting resource of kind Node")
+	}
+	return rk.Name, nil
+}

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+var _ = Describe("Test the (Felix) Node update processor", func() {
+	v2NodeKey1 := model.ResourceKey{
+		Kind: apiv2.KindNode,
+		Name: "mynode",
+	}
+	numFelixConfigs := 2
+	up := updateprocessors.NewFelixNodeUpdateProcessor()
+
+	BeforeEach(func() {
+		up.OnSyncerStarting()
+	})
+
+	// The Node contains a bunch of v1 per-node Felix configuration - so we can simply use the
+	// checkExpectedConfigs() function defined in the configurationprocessor_test to perform
+	// our validation [with a minor hack to treat HostIP as a HostConfig type].  Note that it
+	// expects a node name of mynode.
+	It("should handle conversion of valid Nodes", func() {
+		By("converting a zero-ed Node")
+		res := apiv2.NewNode()
+		res.Name = "mynode"
+		expected := map[string]interface{}{
+			hostIPMarker:       nil,
+			"IpInIpTunnelAddr": nil,
+		}
+		kvps, err := up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+
+		By("converting a zero-ed but non-nil BGPNodeSpec")
+		res = apiv2.NewNode()
+		res.Name = "mynode"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// same expected results as the fully zeroed struct.
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+
+		By("converting a Node with an IPv4 (specified without the network) only")
+		res = apiv2.NewNode()
+		res.Name = "mynode"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4",
+		}
+		ip := net.MustParseIP("1.2.3.4")
+		expected = map[string]interface{}{
+			hostIPMarker:       &ip,
+			"IpInIpTunnelAddr": nil,
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+
+		By("converting a Node with IPv4 and IPv6 networks and no other config")
+		res = apiv2.NewNode()
+		res.Name = "mynode"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "100.200.100.200/24",
+			IPv6Address: "aa:bb::cc/120",
+		}
+		ip = net.MustParseIP("100.200.100.200")
+		expected = map[string]interface{}{
+			hostIPMarker:       &ip,
+			"IpInIpTunnelAddr": nil,
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+
+		By("converting a Node with IPv6 networks and an IPv4 tunnel address and no other config")
+		res = apiv2.NewNode()
+		res.Name = "mynode"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv6Address:        "aa:bb::cc/120",
+			IPv4IPIPTunnelAddr: "192.100.100.100",
+		}
+		expected = map[string]interface{}{
+			hostIPMarker:       nil,
+			"IpInIpTunnelAddr": "192.100.100.100",
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewNode()
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalConfigKey{
+				Name: "foobar",
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewBGPPeer()
+		_, err = up.Process(&model.KVPair{
+			Key:      v2NodeKey1,
+			Value:    wres,
+			Revision: "abcdef",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with an invalid IPv4 address - expect delete for that key")
+		res = apiv2.NewNode()
+		res.Name = "mynode"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/240",
+			IPv4IPIPTunnelAddr: "192.100.100.100",
+		}
+		kvps, err := up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).To(HaveOccurred())
+		expected := map[string]interface{}{
+			hostIPMarker:       nil,
+			"IpInIpTunnelAddr": "192.100.100.100",
+		}
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+
+		By("trying to convert with a tunnel address specified as a network - expect delete for that key")
+		res = apiv2.NewNode()
+		res.Name = "mynode"
+		res.Spec.BGP = &apiv2.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/24",
+			IPv4IPIPTunnelAddr: "192.100.100.100/24",
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NodeKey1,
+			Value: res,
+		})
+		Expect(err).To(HaveOccurred())
+		ip := net.MustParseIP("1.2.3.4")
+		expected = map[string]interface{}{
+			hostIPMarker:       &ip,
+			"IpInIpTunnelAddr": nil,
+		}
+		checkExpectedConfigs(
+			kvps,
+			isNodeFelixConfig,
+			numFelixConfigs,
+			expected,
+		)
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/ippoolprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/ippoolprocessor.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	"github.com/projectcalico/libcalico-go/lib/converter/modelv2v1"
+)
+
+// Create a new SyncerUpdateProcessor to sync IPPool data in v1 format for
+// consumption by both Felix and the BGP daemon.
+func NewIPPoolUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	ipc := modelv2v1.IPPoolConverter{}
+	return NewConflictResolvingCacheUpdateProcessor(apiv2.KindIPPool, ipc.ConvertV2ToV1)
+}

--- a/lib/backend/syncersv1/updateprocessors/ippoolprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/ippoolprocessor_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	"github.com/projectcalico/libcalico-go/lib/ipip"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+var _ = Describe("Test the IPPool update processor", func() {
+	v2PoolKey1 := model.ResourceKey{
+		Kind: apiv2.KindIPPool,
+		Name: "name1",
+	}
+	v2PoolKey2 := model.ResourceKey{
+		Kind: apiv2.KindIPPool,
+		Name: "name2",
+	}
+	cidr1str := "1.2.3.0/24"
+	cidr2str := "aa:bb:cc::/120"
+	v1PoolKeyCidr1 := model.IPPoolKey{
+		CIDR: net.MustParseCIDR(cidr1str),
+	}
+	v1PoolKeyCidr2 := model.IPPoolKey{
+		CIDR: net.MustParseCIDR(cidr2str),
+	}
+
+	It("should handle conversion of valid IPPools", func() {
+		up := updateprocessors.NewIPPoolUpdateProcessor()
+
+		By("converting an IP Pool with minimum configuration")
+		res := apiv2.NewIPPool()
+		res.Name = v2PoolKey1.Name
+		res.Spec.CIDR = cidr1str
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2PoolKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1PoolKeyCidr1,
+			Value: &model.IPPool{
+				CIDR:          v1PoolKeyCidr1.CIDR,
+				IPIPInterface: "tunl0",
+				IPIPMode:      ipip.Always,
+				Masquerade:    false,
+				IPAM:          true,
+				Disabled:      false,
+			},
+			Revision: "abcde",
+		}))
+
+		By("adding another IP IPPool with the same CIDR (but higher alphanumeric name - no update expected")
+		res = apiv2.NewIPPool()
+		res.Name = v2PoolKey2.Name
+		res.Spec.CIDR = cidr1str
+		res.Spec.IPIP = &apiv2.IPIPConfiguration{
+			Mode: apiv2.IPIPModeOff,
+		}
+		res.Spec.NATOutgoing = true
+		res.Spec.Disabled = true
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PoolKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(0))
+
+		By("updating the first IPPool to have a different CIDR - expect updates for both pools")
+		res = apiv2.NewIPPool()
+		res.Name = v2PoolKey1.Name
+		res.Spec.CIDR = cidr2str
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2PoolKey1,
+			Value:    res,
+			Revision: "abcdef",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1PoolKeyCidr1,
+				Value: &model.IPPool{
+					CIDR:          v1PoolKeyCidr1.CIDR,
+					IPIPInterface: "",
+					IPIPMode:      ipip.Undefined,
+					Masquerade:    true,
+					IPAM:          false,
+					Disabled:      true,
+				},
+				Revision: "1234",
+			},
+			{
+				Key: v1PoolKeyCidr2,
+				Value: &model.IPPool{
+					CIDR:          v1PoolKeyCidr2.CIDR,
+					IPIPInterface: "tunl0",
+					IPIPMode:      ipip.Always,
+					Masquerade:    false,
+					IPAM:          true,
+					Disabled:      false,
+				},
+				Revision: "abcdef",
+			},
+		}))
+
+		By("deleting the first pool")
+		kvps, err = up.Process(&model.KVPair{
+			Key: v2PoolKey1,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1PoolKeyCidr2,
+			},
+		}))
+
+		By("clearing the cache (by starting sync) and failing to delete the second pool")
+		up.OnSyncerStarting()
+		kvps, err = up.Process(&model.KVPair{
+			Key: v2PoolKey2,
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewIPPoolUpdateProcessor()
+
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewIPPool()
+		res.Spec.CIDR = cidr1str
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: net.MustParseIP("1.2.3.4"),
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewBGPPeer()
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2PoolKey1,
+			Value:    wres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/clientv2/bgpconfig.go
+++ b/lib/clientv2/bgpconfig.go
@@ -58,7 +58,7 @@ func (r bgpConfigurations) Create(ctx context.Context, res *apiv2.BGPConfigurati
 // Returns the stored representation of the BGPConfiguration, and an error
 // if there is any.
 func (r bgpConfigurations) Update(ctx context.Context, res *apiv2.BGPConfiguration, opts options.SetOptions) (*apiv2.BGPConfiguration, error) {
-	// Check that NodeToNodeMeshEnabled and DefaultNodeASNumber are set. Can only be set on "default".
+	// Check that NodeToNodeMeshEnabled and ASNumber are set. Can only be set on "default".
 	if err := r.ValidateDefaultOnlyFields(res); err != nil {
 		return nil, err
 	}
@@ -119,9 +119,9 @@ func (r bgpConfigurations) ValidateDefaultOnlyFields(res *apiv2.BGPConfiguration
 			})
 		}
 
-		if res.Spec.DefaultNodeASNumber != nil {
+		if res.Spec.ASNumber != nil {
 			errFields = append(errFields, cerrors.ErroredField{
-				Name:   "BGPConfiguration.Spec.DefaultNodeASNumber",
+				Name:   "BGPConfiguration.Spec.ASNumber",
 				Reason: "Cannot set defaultNodeASNumber on a non default BGP Configuration.",
 			})
 		}

--- a/lib/clientv2/bgpconfig_e2e_test.go
+++ b/lib/clientv2/bgpconfig_e2e_test.go
@@ -47,12 +47,12 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 	specDefault1 := apiv2.BGPConfigurationSpec{
 		LogSeverityScreen:     "Info",
 		NodeToNodeMeshEnabled: &ptrTrue,
-		DefaultNodeASNumber:   &nodeASNumber1,
+		ASNumber:              &nodeASNumber1,
 	}
 	specDefault2 := apiv2.BGPConfigurationSpec{
 		LogSeverityScreen:     "Warning",
 		NodeToNodeMeshEnabled: &ptrFalse,
-		DefaultNodeASNumber:   &nodeASNumber2,
+		ASNumber:              &nodeASNumber2,
 	}
 	specInfo := apiv2.BGPConfigurationSpec{
 		LogSeverityScreen: "Info",

--- a/lib/converter/modelv2v1/bgppeer.go
+++ b/lib/converter/modelv2v1/bgppeer.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelv2v1
+
+import (
+	"errors"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// BGPPeerConverter implements a set of functions used for converting between
+// API and backend representations of the BGPPeer resource.
+type BGPPeerConverter struct{}
+
+// Convert v2 KVPair to the equivalent v1 KVPair.
+func (uc BGPPeerConverter) ConvertV2ToV1(kvp *model.KVPair) (*model.KVPair, error) {
+	// Validate against incorrect key/value kinds.  This indicates a code bug rather
+	// than a user error.
+	v2key, ok := kvp.Key.(model.ResourceKey)
+	if !ok || v2key.Kind != apiv2.KindBGPPeer {
+		return nil, errors.New("Key is not a valid IPPool resource key")
+	}
+	v2res, ok := kvp.Value.(*apiv2.BGPPeer)
+	if !ok {
+		return nil, errors.New("Value is not a valid IPPool resource key")
+	}
+
+	// Correct data types.  Handle the conversion.  Start with the v1 key.  The PeerIP and
+	// the Node are now in the Spec - if a Node is not specified then this is a global
+	// peer.
+	ip := cnet.ParseIP(v2res.Spec.PeerIP)
+	if ip == nil {
+		return nil, errors.New("PeerIP is not assigned or is malformed")
+	}
+	var v1key model.Key
+	if node := v2res.Spec.Node; len(node) == 0 {
+		v1key = model.GlobalBGPPeerKey{
+			PeerIP: *ip,
+		}
+	} else {
+		v1key = model.NodeBGPPeerKey{
+			PeerIP:   *ip,
+			Nodename: node,
+		}
+	}
+
+	return &model.KVPair{
+		Key: v1key,
+		Value: &model.BGPPeer{
+			PeerIP: *ip,
+			ASNum:  v2res.Spec.ASNumber,
+		},
+		Revision: kvp.Revision,
+	}, nil
+}

--- a/lib/converter/modelv2v1/ippool.go
+++ b/lib/converter/modelv2v1/ippool.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelv2v1
+
+import (
+	"errors"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/ipip"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// IPPoolConverter implements a set of functions used for converting between
+// API and backend representations of the IPPool resource.
+type IPPoolConverter struct{}
+
+// Convert v2 KVPair to the equivalent v1 KVPair.
+func (uc IPPoolConverter) ConvertV2ToV1(kvp *model.KVPair) (*model.KVPair, error) {
+	// Validate against incorrect key/value kinds.  This indicates a code bug rather
+	// than a user error.
+	v2key, ok := kvp.Key.(model.ResourceKey)
+	if !ok || v2key.Kind != apiv2.KindIPPool {
+		return nil, errors.New("Key is not a valid BGPPeer resource key")
+	}
+	v2res, ok := kvp.Value.(*apiv2.IPPool)
+	if !ok {
+		return nil, errors.New("Value is not a valid BGPPeer resource key")
+	}
+
+	// Correct data types.  Handle the conversion.
+	_, cidr, err := cnet.ParseCIDR(v2res.Spec.CIDR)
+	if err != nil {
+		return nil, err
+	}
+	v1key := model.IPPoolKey{
+		CIDR: *cidr,
+	}
+	var ipipInterface string
+	var ipipMode ipip.Mode
+	var ipm apiv2.IPIPMode
+	if v2res.Spec.IPIP != nil {
+		ipm = v2res.Spec.IPIP.Mode
+	}
+	switch ipm {
+	case apiv2.IPIPModeOff:
+		ipipInterface = ""
+		ipipMode = ipip.Undefined
+	case apiv2.IPIPModeCrossSubnet:
+		ipipInterface = "tunl0"
+		ipipMode = ipip.CrossSubnet
+	default:
+		ipipInterface = "tunl0"
+		ipipMode = ipip.Always
+	}
+
+	return &model.KVPair{
+		Key: v1key,
+		Value: &model.IPPool{
+			CIDR:          *cidr,
+			IPIPInterface: ipipInterface,
+			IPIPMode:      ipipMode,
+			Masquerade:    v2res.Spec.NATOutgoing,
+			IPAM:          !v2res.Spec.Disabled,
+			Disabled:      v2res.Spec.Disabled,
+		},
+		Revision: kvp.Revision,
+	}, nil
+}

--- a/lib/errors/fatal.go
+++ b/lib/errors/fatal.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import log "github.com/sirupsen/logrus"
+
+// FatalIfErrored logs and panics if the supplied error is non-nil.
+func FatalIfErrored(err error) {
+	if err != nil {
+		log.WithError(err).Fatal("Unexpected code error requiring restart")
+	}
+}

--- a/lib/net/ip.go
+++ b/lib/net/ip.go
@@ -39,7 +39,16 @@ func (i *IP) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	return i.UnmarshalText([]byte(s))
+	if err := i.UnmarshalText([]byte(s)); err != nil {
+		return err
+	}
+	// Always return IPv4 values as 4-bytes to be consistent with IPv4 IPNet
+	// representations.
+	if ipv4 := i.To4(); ipv4 != nil {
+		i.IP = ipv4
+	}
+
+	return nil
 }
 
 // ParseIP returns an IP from a string
@@ -47,6 +56,11 @@ func ParseIP(ip string) *IP {
 	addr := net.ParseIP(ip)
 	if addr == nil {
 		return nil
+	}
+	// Always return IPv4 values as 4-bytes to be consistent with IPv4 IPNet
+	// representations.
+	if addr4 := addr.To4(); addr4 != nil {
+		addr = addr4
 	}
 	return &IP{addr}
 }
@@ -66,8 +80,8 @@ func (i *IP) Network() *IPNet {
 	// Unmarshaling an IPv4 address returns a 16-byte format of the
 	// address, so convert to 4-byte format to match the mask.
 	n := &IPNet{}
-	if i.Version() == 4 {
-		n.IP = i.IP.To4()
+	if ip4 := i.IP.To4(); ip4 != nil {
+		n.IP = ip4
 		n.Mask = net.CIDRMask(net.IPv4len*8, net.IPv4len*8)
 	} else {
 		n.IP = i.IP
@@ -82,6 +96,11 @@ func MustParseIP(i string) IP {
 	err := ip.UnmarshalText([]byte(i))
 	if err != nil {
 		panic(err)
+	}
+	// Always return IPv4 values as 4-bytes to be consistent with IPv4 IPNet
+	// representations.
+	if ip4 := ip.To4(); ip4 != nil {
+		ip.IP = ip4
 	}
 	return ip
 }


### PR DESCRIPTION
This PR adds a BGP syncer to the v3.0 confd tweaks, and also starts building out the Felix Syncer.  Both of these are based on the WatcherSyncer.

The BGP Syncer implementation is complete, with all required v2->v1 conversions implemented.

The Felix Syncer is partially implemented, but still needs to have a bunch of the conversion functions implemented for the v2 to v1 conversions.

Mostly this PR build on the WatcherSyncer generic framework which provides a syncer using an arbitrary set of watchers (specified using the backend ListOptions).  That part of the PR is relatively simple to understand:
-  The BGP syncer is defined in `lib/backend/syncersv1/bgpsyncer`
-  The Felix syncer is defined in `lib/backend/syncersv1/felixsyncer`

For each of those syncers you can see in the code the list of resource types that the syncer watches (it's in the backend data format).  The Update processors map between the format of data in the store and the v1 data that is required by the syncer implementations.   There will eventually be an update process for each resource type that we need to map.

Where this gets tricky are the various update processor implementations.  There are a couple of helper interfaces that provide the complicated logic behind a number of the update processors.  These are:
-  The ConfigurationProcessor (in configurationprocessor.go)
-  The ConflictResolvingCache (in conflictresolvingcache.go)

The ConfigurationProcessor provides a common mechanism for converting a resource with a simple set of struct fields into a set of individual KVPairs for each field, with some optional field name mapping and field conversion.  These are used for the FelixConfiguration, BGPConfiguration, ClusterInformation resources.  It also provides a mechanism for overriding validation or specifying new options using annotations.

The ConflictResolvingCache is a helper cache that handles situations where the indexing has changed between v1 and v2, and where is there is no simple relationship between the v2 name and the v1 indexes.  This is used to provide the logic for IPPools, BGPPeers

We have separate Node resource update processors for the Felix syncer and the BGP syncer, since both are interested in different sets of data, and with different keys.

Code coverage should be at 100% for all of the syncer code.