### PR TITLE
Add orchrefs to libcalico-go

### DIFF
--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -65,6 +65,17 @@ type NodeSpec struct {
 	// BGP configuration for this node.  If this omitted, the Calico node
 	// will be run in policy-only mode.
 	BGP *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
+
+	// OrchRefs for this node.
+	OrchRefs []OrchRef `json:"orchRefs,omitempty" validate:"omitempty"`
+}
+
+// OrchRef is used to map a node in etcd to nodes in other orchestrators.
+type OrchRef struct {
+	// NodeName represents the name for this node according to the orchestrator.
+	NodeName string `json:"nodeName,omitempty" validate:"omitempty"`
+	// Orchestrator represents the orchestrator using this node.
+	Orchestrator string `json:"orchestrator"`
 }
 
 // NodeSpec contains the specification for a Calico Node resource.

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -48,6 +48,12 @@ type Node struct {
 	BGPIPv4Net  *net.IPNet
 	BGPIPv6Net  *net.IPNet
 	BGPASNumber *numorstring.ASNumber
+	OrchRefs    []OrchRef
+}
+
+type OrchRef struct {
+	Orchestrator string
+	NodeName     string
 }
 
 type NodeKey struct {

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -189,6 +189,13 @@ func (h *nodes) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 		v.BGPASNumber = an.Spec.BGP.ASNumber
 	}
 
+	for _, orchRef := range an.Spec.OrchRefs {
+		v.OrchRefs = append(v.OrchRefs, model.OrchRef{
+			Orchestrator: orchRef.Orchestrator,
+			NodeName:     orchRef.NodeName,
+		})
+	}
+
 	return &model.KVPair{Key: k, Value: &v}, nil
 }
 
@@ -234,6 +241,13 @@ func (h *nodes) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error
 				apiNode.Spec.BGP.IPv6Address = bv.BGPIPv6Addr.Network()
 			}
 		}
+	}
+
+	for _, orchref := range bv.OrchRefs {
+		apiNode.Spec.OrchRefs = append(apiNode.Spec.OrchRefs, api.OrchRef{
+			NodeName:     orchref.NodeName,
+			Orchestrator: orchref.Orchestrator,
+		})
 	}
 
 	return apiNode, nil

--- a/lib/client/node_e2e_test.go
+++ b/lib/client/node_e2e_test.go
@@ -166,6 +166,12 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV2, 
 				BGP: &api.NodeBGPSpec{
 					IPv4Address: &cidrv4,
 				},
+				OrchRefs: []api.OrchRef{
+					{
+						Orchestrator: "k8s",
+						NodeName:     "k8snodename",
+					},
+				},
 			},
 			api.NodeSpec{
 				BGP: &api.NodeBGPSpec{


### PR DESCRIPTION
## Description

Add a new field to libcalico-go called `orchRefs`. This field will allow for association between a k8s node and the etcdNode object that matches it, and allow for cleanup of stale nodes.


## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add the orchRef field to the Node data model.
```
