### PR TITLE
Renamed and moved IPInIPTunnelAddr field

### DIFF
--- a/lib/apiv2/node.go
+++ b/lib/apiv2/node.go
@@ -37,8 +37,7 @@ type Node struct {
 // NodeSpec contains the specification for a Node resource.
 type NodeSpec struct {
 	// BGP configuration for this node.
-	BGP              *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
-	IpInIpTunnelAddr string       `json:"ipInIPTunnelAddr,omitempty" validate:"omitempty,ipv4"`
+	BGP *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
 }
 
 // NodeBGPSpec contains the specification for the Node BGP configuration.
@@ -52,6 +51,8 @@ type NodeBGPSpec struct {
 	// IPv6Address is the IPv6 address and network of this node.  At least
 	// one of the IPv4 and IPv6 addresses should be specified.
 	IPv6Address string `json:"ipv6Address,omitempty" validate:"omitempty,ipv6"`
+	// IPv4IPIPTunnelAddr is the IPv4 address of the IP in IP tunnel.
+	IPv4IPIPTunnelAddr string `json:"ipv4IPIPTunnelAddr,omitempty" validate:"omitempty,ipv4"`
 }
 
 // NodeList contains a list of Node resources.


### PR DESCRIPTION
## Description
Moved the `IPinIPTunnelAddr` to the `NodeBGPSpec` and renamed the attribute to specify IPv4.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
