### PR TITLE
Add OrchRefs to Node object

### DIFF
--- a/lib/apis/v1/node.go
+++ b/lib/apis/v1/node.go
@@ -70,7 +70,7 @@ type NodeSpec struct {
 	OrchRefs []OrchRef `json:"orchRefs,omitempty" validate:"omitempty"`
 }
 
-// OrchRef is used to map a node in etcd to nodes in other orchestrators.
+// OrchRef is used to correlate a Calico node to its corresponding representation in a given orchestrator
 type OrchRef struct {
 	// NodeName represents the name for this node according to the orchestrator.
 	NodeName string `json:"nodeName,omitempty" validate:"omitempty"`

--- a/lib/apis/v1/node.go
+++ b/lib/apis/v1/node.go
@@ -65,6 +65,17 @@ type NodeSpec struct {
 	// BGP configuration for this node.  If this omitted, the Calico node
 	// will be run in policy-only mode.
 	BGP *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
+
+	// OrchRefs for this node.
+	OrchRefs []OrchRef `json:"orchRefs,omitempty" validate:"omitempty"`
+}
+
+// OrchRef is used to map a node in etcd to nodes in other orchestrators.
+type OrchRef struct {
+	// NodeName represents the name for this node according to the orchestrator.
+	NodeName string `json:"nodeName,omitempty" validate:"omitempty"`
+	// Orchestrator represents the orchestrator using this node.
+	Orchestrator string `json:"orchestrator"`
 }
 
 // NodeSpec contains the specification for a Calico Node resource.

--- a/lib/apis/v2/node.go
+++ b/lib/apis/v2/node.go
@@ -41,6 +41,17 @@ type Node struct {
 type NodeSpec struct {
 	// BGP configuration for this node.
 	BGP *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
+
+	// OrchRefs for this node.
+	OrchRefs []OrchRef `json:"orchRefs,omitempty" validate:"omitempty"`
+}
+
+// OrchRef is used to correlate a Calico node to its corresponding representation in a given orchestrator
+type OrchRef struct {
+	// NodeName represents the name for this node according to the orchestrator.
+	NodeName string `json:"nodeName,omitempty" validate:"omitempty"`
+	// Orchestrator represents the orchestrator using this node.
+	Orchestrator string `json:"orchestrator"`
 }
 
 // NodeBGPSpec contains the specification for the Node BGP configuration.

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -492,14 +492,8 @@ func (c *ModelAdaptor) getNodeSubcomponents(ctx context.Context, nk model.NodeKe
 		return err
 	}
 
-	if components, err := c.client.List(model.OrchRefListOptions{Hostname: nk.Hostname}); err == nil {
-		for _, o := range components {
-			orchRef := model.OrchRef{
-				Orchestrator: o.Key.(model.OrchRefKey).Orchestrator,
-				NodeName:     o.Value.(string),
-			}
-			nv.OrchRefs = append(nv.OrchRefs, orchRef)
-		}
+	if component, err := c.client.Get(model.OrchRefKey{Hostname: nk.Hostname}); err == nil {
+		nv.OrchRefs = component.Value.([]model.OrchRef)
 	}
 
 	return nil
@@ -663,15 +657,15 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 		})
 	}
 	if len(n.OrchRefs) > 0 {
-		for _, orchref := range n.OrchRefs {
-			optional = append(optional, &model.KVPair{
-				Key: model.OrchRefKey{
-					Hostname:     nk.Hostname,
-					Orchestrator: orchref.Orchestrator,
-				},
-				Value: orchref.NodeName,
-			})
-		}
+		//v, err := json.Marshal(n.OrchRefs)
+		//fmt.Printf("____%s____", string(v))
+		//if err != nil {
+		//	log.WithError(err).Errorf("Failed to marshal JSON for OrchRefs in Node %s", nk.Hostname)
+		//}
+		optional = append(optional, &model.KVPair{
+			Key:   model.OrchRefKey{Hostname: nk.Hostname},
+			Value: n.OrchRefs,
+		})
 	}
 
 	return primary, optional
@@ -720,8 +714,7 @@ func toNodeDeleteComponents(nk model.NodeKey) (primary *model.KVPair, optional [
 		},
 		&model.KVPair{
 			Key: model.OrchRefKey{
-				Hostname:     nk.Hostname,
-				Orchestrator: "",
+				Hostname: nk.Hostname,
 			},
 		},
 	}

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -492,7 +492,7 @@ func (c *ModelAdaptor) getNodeSubcomponents(ctx context.Context, nk model.NodeKe
 		return err
 	}
 
-	if component, err := c.client.Get(model.OrchRefKey{Hostname: nk.Hostname}); err == nil {
+	if component, err := c.client.Get(ctx, model.OrchRefKey{Hostname: nk.Hostname}, ""); err == nil {
 		nv.OrchRefs = component.Value.([]model.OrchRef)
 	}
 

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -657,11 +657,6 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 		})
 	}
 	if len(n.OrchRefs) > 0 {
-		//v, err := json.Marshal(n.OrchRefs)
-		//fmt.Printf("____%s____", string(v))
-		//if err != nil {
-		//	log.WithError(err).Errorf("Failed to marshal JSON for OrchRefs in Node %s", nk.Hostname)
-		//}
 		optional = append(optional, &model.KVPair{
 			Key:   model.OrchRefKey{Hostname: nk.Hostname},
 			Value: n.OrchRefs,

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -48,6 +48,12 @@ type Node struct {
 	BGPIPv4Net  *net.IPNet
 	BGPIPv6Net  *net.IPNet
 	BGPASNumber *numorstring.ASNumber
+	OrchRefs    []OrchRef
+}
+
+type OrchRef struct {
+	Orchestrator string
+	NodeName     string
 }
 
 type NodeKey struct {

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -187,7 +187,7 @@ type OrchRefKey struct {
 }
 
 func (key OrchRefKey) defaultPath() (string, error) {
-	return fmt.Sprintf("/calico/v1/host/%s/orchestrator",
+	return fmt.Sprintf("/calico/v1/host/%s/orchestrator_refs",
 		key.Hostname), nil
 }
 
@@ -204,7 +204,7 @@ func (key OrchRefKey) valueType() reflect.Type {
 }
 
 func (key OrchRefKey) String() string {
-	return fmt.Sprintf("OrchRef(nodename=%s)", key.Hostname)
+	return fmt.Sprintf("OrchRefs(nodename=%s)", key.Hostname)
 }
 
 type OrchRefListOptions struct {
@@ -212,7 +212,7 @@ type OrchRefListOptions struct {
 }
 
 func (options OrchRefListOptions) defaultPathRoot() string {
-	return fmt.Sprintf("/calico/v1/host/%s/orchestrator", options.Hostname)
+	return fmt.Sprintf("/calico/v1/host/%s/orchestrator_refs", options.Hostname)
 }
 
 func (options OrchRefListOptions) KeyFromDefaultPath(path string) Key {

--- a/lib/backend/model/node.go
+++ b/lib/backend/model/node.go
@@ -34,7 +34,6 @@ var (
 	typeHostIp        = rawIPType
 	matchHostMetadata = regexp.MustCompile(`^/?calico/v1/host/([^/]+)/metadata$`)
 	matchHostIp       = regexp.MustCompile(`^/?calico/v1/host/([^/]+)/bird_ip$`)
-
 )
 
 type Node struct {

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -191,6 +191,13 @@ func (h *nodes) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 		v.BGPASNumber = an.Spec.BGP.ASNumber
 	}
 
+	for _, orchRef := range an.Spec.OrchRefs {
+		v.OrchRefs = append(v.OrchRefs, model.OrchRef{
+			Orchestrator: orchRef.Orchestrator,
+			NodeName:     orchRef.NodeName,
+		})
+	}
+
 	return &model.KVPair{Key: k, Value: &v}, nil
 }
 
@@ -236,6 +243,13 @@ func (h *nodes) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error
 				apiNode.Spec.BGP.IPv6Address = bv.BGPIPv6Addr.Network()
 			}
 		}
+	}
+
+	for _, orchref := range bv.OrchRefs {
+		apiNode.Spec.OrchRefs = append(apiNode.Spec.OrchRefs, api.OrchRef{
+			NodeName:     orchref.NodeName,
+			Orchestrator: orchref.Orchestrator,
+		})
 	}
 
 	return apiNode, nil

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -42,11 +42,31 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 		BGP: &apiv2.NodeBGPSpec{
 			IPv4Address: "1.2.3.4",
 		},
+		OrchRefs: []apiv2.OrchRef{
+			{
+				Orchestrator: "k8s",
+				NodeName:     "node1",
+			},
+			{
+				Orchestrator: "mesos",
+				NodeName:     "node1",
+			},
+		},
 	}
 	spec2 := apiv2.NodeSpec{
 		BGP: &apiv2.NodeBGPSpec{
 			IPv4Address: "10.20.30.40",
 			IPv6Address: "aa:bb:cc::ff",
+		},
+		OrchRefs: []apiv2.OrchRef{
+			{
+				Orchestrator: "k8s",
+				NodeName:     "node2",
+			},
+			{
+				Orchestrator: "mesos",
+				NodeName:     "node2",
+			},
 		},
 	}
 


### PR DESCRIPTION
## Description
Expanding on @ozdanborne PR #562 to add OrchRefs to libcalico-go as a field on the Node.

Add a new field to libcalico-go called `OrchRefs`. This field will allow for association between a k8s node and the etcdNode object that matches it, and allow for cleanup of stale nodes.

This PR includes the needed additions to the compat layer as the Node is a composite object. I'm not extremely familiar with the compat layer so I expect it will need some tweaking.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add the orchRef field to the Node data model.
```
