### PR TITLE
Added v2 to v1 converters for Workload Endpoint resources

### DIFF
--- a/lib/apiv2/workloadendpoint.go
+++ b/lib/apiv2/workloadendpoint.go
@@ -66,7 +66,8 @@ type WorkloadEndpointSpec struct {
 	// InterfaceName the name of the Linux interface on the host: for example, tap80.
 	InterfaceName string `json:"interfaceName,omitempty" validate:"interface"`
 	// MAC is the MAC address of the endpoint interface.
-	MAC string `json:"mac,omitempty" validate:"omitempty,mac"`
+	MAC   string         `json:"mac,omitempty" validate:"omitempty,mac"`
+	Ports []EndpointPort `json:"ports,omitempty" validate:"dive,omitempty"`
 }
 
 // IPNat contains a single NAT mapping for a WorkloadEndpoint resource.

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
@@ -59,7 +59,8 @@ func New(client api.Client, callbacks api.SyncerCallbacks) api.Syncer {
 			ListInterface: model.ResourceListOptions{Kind: apiv2.KindProfile},
 		},
 		{
-			ListInterface: model.ResourceListOptions{Kind: apiv2.KindWorkloadEndpoint},
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindWorkloadEndpoint},
+			UpdateProcessor: updateprocessors.NewWorkloadEndpointUpdateProcessor(),
 		},
 	}
 

--- a/lib/backend/syncersv1/updateprocessors/processor.go
+++ b/lib/backend/syncersv1/updateprocessors/processor.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// NewGeneralUpdateProcessor implements an update processor that only needs to take in
+// a conversion function. This is only meant to be used in cases where the Process and
+// OnSyncerStarting methods do not have any special handling.
+//
+// One of the main differences between the general update processor and the conflict
+// resolving name cache processor is that the conflict resolving name cache processor
+// handles deletes by inspecting the value in the key-value pair. The general update processor
+// will strictly convert the information it is given, whether the value is nil or not.
+
+func NewGeneralUpdateProcessor(v2Kind string, converter ConvertV2ToV1) watchersyncer.SyncerUpdateProcessor {
+	return &generalUpdateProcessor{
+		v2Kind:    v2Kind,
+		converter: converter,
+	}
+}
+
+type generalUpdateProcessor struct {
+	v2Kind    string
+	converter ConvertV2ToV1
+}
+
+func (gup *generalUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	// Extract the name of the resource.
+	rk, ok := kvp.Key.(model.ResourceKey)
+	if !ok || rk.Kind != gup.v2Kind {
+		return nil, fmt.Errorf("Incorrect key type - expecting resource of kind %s", gup.v2Kind)
+	}
+
+	// Convert the v2 resource to the equivalent v1 resource type.
+	var response []*model.KVPair
+	kvp, err := gup.converter(kvp)
+	if err != nil {
+		return response, err
+	}
+
+	response = append(response, kvp)
+	return response, nil
+}
+
+func (gup *generalUpdateProcessor) OnSyncerStarting() {
+	// Do nothing
+}

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointproccessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointproccessor_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var _ = Describe("Test the WorkloadEndpoint update processor", func() {
+	hn1 := "host1"
+	hn2 := "host2"
+	oid1 := "orchestrator1"
+	oid2 := "orchestrator2"
+	wid1 := "workload1"
+	wid2 := "workload2"
+	eid1 := "endpoint1"
+	eid2 := "endpoint2"
+	ns1 := "namespace1"
+	ns2 := "namespace2"
+	name1 := "host1-orchestrator1-workload1-endpoint1"
+	name2 := "host2-orchestrator2-workload2-endpoint2"
+	iface1 := "iface1"
+	iface2 := "iface2"
+
+	v2WorkloadEndpointKey1 := model.ResourceKey{
+		Kind: apiv2.KindWorkloadEndpoint,
+		Name: name1,
+	}
+	v2WorkloadEndpointKey2 := model.ResourceKey{
+		Kind: apiv2.KindWorkloadEndpoint,
+		Name: name2,
+	}
+	v1WorkloadEndpointKey1 := model.WorkloadEndpointKey{
+		Hostname:       hn1,
+		OrchestratorID: oid1,
+		WorkloadID:     ns1 + "/" + wid1,
+		EndpointID:     eid1,
+	}
+	v1WorkloadEndpointKey2 := model.WorkloadEndpointKey{
+		Hostname:       hn2,
+		OrchestratorID: oid2,
+		WorkloadID:     ns2 + "/" + wid2,
+		EndpointID:     eid2,
+	}
+
+	It("should handle conversion of valid WorkloadEndpoints", func() {
+		netmac2, err := net.ParseMAC("01:23:45:67:89:ab")
+		Expect(err).NotTo(HaveOccurred())
+		mac2 := cnet.MAC{netmac2}
+
+		up := updateprocessors.NewWorkloadEndpointUpdateProcessor()
+
+		By("converting a WorkloadEndpoint with minimum configuration")
+		res := apiv2.NewWorkloadEndpoint()
+		res.Name = name1
+		res.Namespace = ns1
+		res.Spec.InterfaceName = iface1
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1WorkloadEndpointKey1,
+			Value: &model.WorkloadEndpoint{
+				State: "active",
+				Name:  iface1,
+				Ports: []model.EndpointPort{},
+			},
+			Revision: "abcde",
+		}))
+
+		By("adding another WorkloadEndpoint with a full configuration")
+		res = apiv2.NewWorkloadEndpoint()
+		res.Name = name2
+		res.Namespace = ns2
+		res.Labels = map[string]string{"testLabel": "label"}
+		res.Spec.InterfaceName = iface2
+		res.Spec.ContainerID = "container2"
+		res.Spec.MAC = "01:23:45:67:89:ab"
+		res.Spec.Profiles = []string{"testProfile"}
+		res.Spec.IPNetworks = []string{"10.100.10.1"}
+		_, ipn, err := cnet.ParseCIDROrIP("10.100.10.1")
+		Expect(err).NotTo(HaveOccurred())
+		expectedIPv4Net := *(ipn.Network())
+		res.Spec.IPNATs = []apiv2.IPNAT{
+			apiv2.IPNAT{
+				InternalIP: "10.100.1.1",
+				ExternalIP: "10.1.10.1",
+			},
+		}
+		expectedIPv4NAT := *updateprocessors.ConvertV2ToV1IPNAT(res.Spec.IPNATs[0])
+		res.Spec.IPv4Gateway = "10.10.10.1"
+		expectedIPv4Gateway, _, err := cnet.ParseCIDROrIP("10.10.10.1")
+		res.Spec.IPv6Gateway = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+		expectedIPv6Gateway, _, err := cnet.ParseCIDROrIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+		res.Spec.Ports = []apiv2.EndpointPort{
+			apiv2.EndpointPort{
+				Name:     "portname",
+				Protocol: numorstring.ProtocolFromInt(uint8(30)),
+				Port:     uint16(8080),
+			},
+		}
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1WorkloadEndpointKey2,
+				Value: &model.WorkloadEndpoint{
+					State:            "active",
+					Name:             iface2,
+					ActiveInstanceID: "container2",
+					Mac:              &mac2,
+					ProfileIDs:       []string{"testProfile"},
+					IPv4Nets:         []cnet.IPNet{expectedIPv4Net},
+					IPv4NAT:          []model.IPNAT{expectedIPv4NAT},
+					Labels:           map[string]string{"testLabel": "label"},
+					IPv4Gateway:      expectedIPv4Gateway,
+					IPv6Gateway:      expectedIPv6Gateway,
+					Ports: []model.EndpointPort{
+						model.EndpointPort{
+							Name:     "portname",
+							Protocol: numorstring.ProtocolFromInt(uint8(30)),
+							Port:     uint16(8080),
+						},
+					},
+				},
+				Revision: "1234",
+			},
+		}))
+
+		By("attempting to delete the first workload endpoint")
+		kvps, err = up.Process(&model.KVPair{
+			Key: v2WorkloadEndpointKey1,
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("deleting the first workload endpoint")
+		res = apiv2.NewWorkloadEndpoint()
+		res.Name = name1
+		res.Namespace = ns1
+		res.Spec.Node = hn1
+		res.Spec.Orchestrator = oid1
+		res.Spec.Workload = wid1
+		res.Spec.Endpoint = eid1
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2WorkloadEndpointKey2,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		var nilVal *model.WorkloadEndpoint
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1WorkloadEndpointKey1,
+				Value: nilVal,
+			},
+		}))
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewWorkloadEndpointUpdateProcessor()
+
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewWorkloadEndpoint()
+		res.Name = name1
+		res.Namespace = ns1
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: cnet.MustParseIP("1.2.3.4"),
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewHostEndpoint()
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey1,
+			Value:    wres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert without enough information to create a v1 key")
+		eres := apiv2.NewWorkloadEndpoint()
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey1,
+			Value:    eres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"net"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	"github.com/projectcalico/libcalico-go/lib/names"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// Create a new SyncerUpdateProcessor to sync WorkloadEndpoint data in v1 format for
+// consumption by Felix.
+func NewWorkloadEndpointUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewGeneralUpdateProcessor(apiv2.KindWorkloadEndpoint, convertWorkloadEndpointV2ToV1)
+}
+
+// Convert v2 KVPair to the equivalent v1 KVPair.
+func convertWorkloadEndpointV2ToV1(kvp *model.KVPair) (*model.KVPair, error) {
+	// Validate against incorrect key/value kinds.  This indicates a code bug rather
+	// than a user error.
+	v2key, ok := kvp.Key.(model.ResourceKey)
+	if !ok || v2key.Kind != apiv2.KindWorkloadEndpoint {
+		return nil, errors.New("Key is not a valid WorkloadEndpoint resource key")
+	}
+
+	if kvp.Value == nil {
+		return nil, errors.New("Deletion attempted without enough information to form a v1 WorkloadEndpoint key")
+	}
+
+	v2res, ok := kvp.Value.(*apiv2.WorkloadEndpoint)
+	if !ok {
+		return nil, errors.New("Value is not a valid WorkloadEndpoint resource value")
+	}
+
+	v1key, err := convertWorkloadEndpointV2ToV1Key(v2res)
+	if err != nil {
+		return nil, err
+	}
+
+	v1value, err := convertWorkloadEndpointV2ToV1Value(v2res)
+	if err != nil {
+		// Currently ignore the error so that incorrect values get skipped instead of erroring out
+		return &model.KVPair{
+			Key: v1key,
+		}, nil
+	}
+
+	return &model.KVPair{
+		Key:      v1key,
+		Value:    v1value,
+		Revision: kvp.Revision,
+	}, nil
+}
+
+func convertWorkloadEndpointV2ToV1Key(v2res *apiv2.WorkloadEndpoint) (model.WorkloadEndpointKey, error) {
+	parts := names.ExtractDashSeparatedParms(v2res.GetName(), 4)
+	if len(parts) != 4 {
+		return model.WorkloadEndpointKey{}, errors.New("Not enough information provided to create v1 Workload Endpoint Key")
+	}
+	return model.WorkloadEndpointKey{
+		Hostname:       parts[0],
+		OrchestratorID: parts[1],
+		WorkloadID:     v2res.GetNamespace() + "/" + parts[2],
+		EndpointID:     parts[3],
+	}, nil
+
+}
+
+func convertWorkloadEndpointV2ToV1Value(v2res *apiv2.WorkloadEndpoint) (*model.WorkloadEndpoint, error) {
+	var v1value *model.WorkloadEndpoint
+	// Deletion operations will have empty values so skip if empty
+	if !v1FieldsEmpty(v2res) {
+		var ipv4Nets []cnet.IPNet
+		var ipv6Nets []cnet.IPNet
+		for _, ipnString := range v2res.Spec.IPNetworks {
+			_, ipn, err := cnet.ParseCIDROrIP(ipnString)
+			if err != nil {
+				return nil, err
+			}
+			ipnet := *(ipn.Network())
+			if ipnet.Version() == 4 {
+				ipv4Nets = append(ipv4Nets, ipnet)
+			} else {
+				ipv6Nets = append(ipv6Nets, ipnet)
+			}
+		}
+
+		var ipv4NAT []model.IPNAT
+		var ipv6NAT []model.IPNAT
+		for _, ipnat := range v2res.Spec.IPNATs {
+			nat := ConvertV2ToV1IPNAT(ipnat)
+			if nat != nil {
+				if nat.IntIP.Version() == 4 {
+					ipv4NAT = append(ipv4NAT, *nat)
+				} else {
+					ipv6NAT = append(ipv6NAT, *nat)
+				}
+			}
+		}
+
+		var ipv4Gateway *cnet.IP
+		var err error
+		if v2res.Spec.IPv4Gateway != "" {
+			ipv4Gateway, _, err = cnet.ParseCIDROrIP(v2res.Spec.IPv4Gateway)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var ipv6Gateway *cnet.IP
+		if v2res.Spec.IPv6Gateway != "" {
+			ipv6Gateway, _, err = cnet.ParseCIDROrIP(v2res.Spec.IPv6Gateway)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var cmac *cnet.MAC
+		if v2res.Spec.MAC != "" {
+			mac, err := net.ParseMAC(v2res.Spec.MAC)
+			if err != nil {
+				return nil, err
+			}
+			cmac = &cnet.MAC{mac}
+		}
+
+		// Convert the EndpointPort type from the API pkg to the v1 model equivalent type
+		ports := []model.EndpointPort{}
+		for _, port := range v2res.Spec.Ports {
+			ports = append(ports, model.EndpointPort{
+				Name:     port.Name,
+				Protocol: port.Protocol,
+				Port:     port.Port,
+			})
+		}
+
+		v1value = &model.WorkloadEndpoint{
+			State:            "active",
+			Name:             v2res.Spec.InterfaceName,
+			ActiveInstanceID: v2res.Spec.ContainerID,
+			Mac:              cmac,
+			ProfileIDs:       v2res.Spec.Profiles,
+			IPv4Nets:         ipv4Nets,
+			IPv6Nets:         ipv6Nets,
+			IPv4NAT:          ipv4NAT,
+			IPv6NAT:          ipv6NAT,
+			Labels:           v2res.GetLabels(),
+			IPv4Gateway:      ipv4Gateway,
+			IPv6Gateway:      ipv6Gateway,
+			Ports:            ports,
+		}
+	}
+
+	return v1value, nil
+}
+
+func v1FieldsEmpty(v2res *apiv2.WorkloadEndpoint) bool {
+	empty := true
+	empty = empty && v2res.Spec.InterfaceName == ""
+	empty = empty && len(v2res.Spec.IPNetworks) == 0
+	empty = empty && len(v2res.Spec.IPNATs) == 0
+	empty = empty && v2res.Spec.IPv4Gateway == ""
+	empty = empty && v2res.Spec.IPv6Gateway == ""
+	empty = empty && v2res.Spec.MAC == ""
+	empty = empty && v2res.Spec.InterfaceName == ""
+	empty = empty && v2res.Spec.ContainerID == ""
+	empty = empty && len(v2res.Spec.Profiles) == 0
+	empty = empty && len(v2res.GetLabels()) == 0
+	empty = empty && len(v2res.Spec.Ports) == 0
+	return empty
+}
+
+func ConvertV2ToV1IPNAT(ipnat apiv2.IPNAT) *model.IPNAT {
+	internalip := cnet.ParseIP(ipnat.InternalIP)
+	externalip := cnet.ParseIP(ipnat.ExternalIP)
+	if internalip != nil && externalip != nil {
+		return &model.IPNAT{
+			IntIP: *internalip,
+			ExtIP: *externalip,
+		}
+	}
+	return nil
+}

--- a/lib/names/workloadendpoint.go
+++ b/lib/names/workloadendpoint.go
@@ -64,7 +64,7 @@ func (ids WorkloadEndpointIdentifiers) NameMatches(name string) (bool, error) {
 	}
 
 	// Extract the parameters from the name.
-	parts := extractDashSeparatedParms(name, len(req))
+	parts := ExtractDashSeparatedParms(name, len(req))
 	if len(parts) == 0 {
 		return false, nil
 	}
@@ -190,7 +190,7 @@ func escapeDashes(seg segment) (string, *cerrors.ErroredField) {
 
 // Extract the dash separated parms from the name.  Each parm will have had their dashes escaped,
 // this also removes that escaping.  Returns nil if the parameters could not be extracted.
-func extractDashSeparatedParms(name string, numParms int) []string {
+func ExtractDashSeparatedParms(name string, numParms int) []string {
 	// The name must be at least as long as the number of parameters plus the separators.
 	if len(name) < (2*numParms - 1) {
 		return nil


### PR DESCRIPTION
## Description
Added the converter for changing v2 Workload Endpoints to their v1 equivalents.

## Todos
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
