### PR TITLE
Add the V2 to V1 converters for Workload Endpoint, Profile, NetworkPolicy, and GlobalNetworkPolicy

### DIFF
--- a/lib/apiv2/hostendpoint.go
+++ b/lib/apiv2/hostendpoint.go
@@ -55,8 +55,9 @@ type HostEndpointSpec struct {
 	// A list of identifiers of security Profile objects that apply to this endpoint. Each
 	// profile is applied in the order that they appear in this list.  Profile rules are applied
 	// after the selector-based security policy.
-	Profiles []string       `json:"profiles,omitempty" validate:"omitempty,dive,namespacedname"`
-	Ports    []EndpointPort `json:"ports,omitempty" validate:"dive"`
+	Profiles []string `json:"profiles,omitempty" validate:"omitempty,dive,namespacedname"`
+	// Ports contains the endpoint's named ports, which may be referenced in security policy rules.
+	Ports []EndpointPort `json:"ports,omitempty" validate:"dive"`
 }
 
 type EndpointPort struct {

--- a/lib/apiv2/workloadendpoint.go
+++ b/lib/apiv2/workloadendpoint.go
@@ -67,6 +67,8 @@ type WorkloadEndpointSpec struct {
 	InterfaceName string `json:"interfaceName,omitempty" validate:"interface"`
 	// MAC is the MAC address of the endpoint interface.
 	MAC string `json:"mac,omitempty" validate:"omitempty,mac"`
+	// Ports contains the endpoint's named ports, which may be referenced in security policy rules.
+	Ports []EndpointPort `json:"ports,omitempty" validate:"dive,omitempty"`
 }
 
 // IPNat contains a single NAT mapping for a WorkloadEndpoint resource.

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
@@ -38,7 +38,8 @@ func New(client api.Client, callbacks api.SyncerCallbacks) api.Syncer {
 			UpdateProcessor: updateprocessors.NewFelixConfigUpdateProcessor(),
 		},
 		{
-			ListInterface: model.ResourceListOptions{Kind: apiv2.KindGlobalNetworkPolicy},
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindGlobalNetworkPolicy},
+			UpdateProcessor: updateprocessors.NewGlobalNetworkPolicyUpdateProcessor(),
 		},
 		{
 			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindHostEndpoint},
@@ -49,17 +50,20 @@ func New(client api.Client, callbacks api.SyncerCallbacks) api.Syncer {
 			UpdateProcessor: updateprocessors.NewIPPoolUpdateProcessor(),
 		},
 		{
-			ListInterface: model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindNetworkPolicy},
+			UpdateProcessor: updateprocessors.NewNetworkPolicyUpdateProcessor(),
 		},
 		{
 			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindNode},
 			UpdateProcessor: updateprocessors.NewFelixNodeUpdateProcessor(),
 		},
 		{
-			ListInterface: model.ResourceListOptions{Kind: apiv2.KindProfile},
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindProfile},
+			UpdateProcessor: updateprocessors.NewProfileUpdateProcessor(),
 		},
 		{
-			ListInterface: model.ResourceListOptions{Kind: apiv2.KindWorkloadEndpoint},
+			ListInterface:   model.ResourceListOptions{Kind: apiv2.KindWorkloadEndpoint},
+			UpdateProcessor: updateprocessors.NewWorkloadEndpointUpdateProcessor(),
 		},
 	}
 

--- a/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// Create a new SyncerUpdateProcessor to sync GlobalNetworkPolicy data in v1 format for
+// consumption by Felix.
+func NewGlobalNetworkPolicyUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewSimpleUpdateProcessor(apiv2.KindGlobalNetworkPolicy, convertGlobalNetworkPolicyV2ToV1Key, convertGlobalNetworkPolicyV2ToV1Value)
+}
+
+func convertGlobalNetworkPolicyV2ToV1Key(v2key model.ResourceKey) (model.Key, error) {
+	if v2key.Name == "" {
+		return model.PolicyKey{}, errors.New("Missing Name field to create a v1 NetworkPolicy Key")
+	}
+	return model.PolicyKey{
+		Name: v2key.Name,
+	}, nil
+
+}
+
+func convertGlobalNetworkPolicyV2ToV1Value(val interface{}) (interface{}, error) {
+	v2res, ok := val.(*apiv2.GlobalNetworkPolicy)
+	if !ok {
+		return nil, errors.New("Value is not a valid GlobalNetworkPolicy resource value")
+	}
+	return convertPolicyV2ToV1Spec(v2res.Spec)
+}

--- a/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var _ = Describe("Test the GlobalNetworkPolicy update processor", func() {
+	name1 := "name1"
+	name2 := "name2"
+
+	v2GlobalNetworkPolicyKey1 := model.ResourceKey{
+		Kind: apiv2.KindGlobalNetworkPolicy,
+		Name: name1,
+	}
+	v2GlobalNetworkPolicyKey2 := model.ResourceKey{
+		Kind: apiv2.KindGlobalNetworkPolicy,
+		Name: name2,
+	}
+	v1GlobalNetworkPolicyKey1 := model.PolicyKey{
+		Name: name1,
+	}
+	v1GlobalNetworkPolicyKey2 := model.PolicyKey{
+		Name: name2,
+	}
+
+	It("should handle conversion of valid GlobalNetworkPolicys", func() {
+		up := updateprocessors.NewGlobalNetworkPolicyUpdateProcessor()
+
+		By("converting a GlobalNetworkPolicy with minimum configuration")
+		res := apiv2.NewGlobalNetworkPolicy()
+		res.Spec.PreDNAT = true
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2GlobalNetworkPolicyKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1GlobalNetworkPolicyKey1,
+			Value: &model.Policy{
+				PreDNAT: true,
+			},
+			Revision: "abcde",
+		}))
+
+		By("adding another GlobalNetworkPolicy with a full configuration")
+		res = apiv2.NewGlobalNetworkPolicy()
+
+		v4 := 4
+		itype := 1
+		intype := 3
+		icode := 4
+		incode := 6
+		iproto := numorstring.ProtocolFromString("tcp")
+		inproto := numorstring.ProtocolFromString("udp")
+		port80 := numorstring.SinglePort(uint16(80))
+		port443 := numorstring.SinglePort(uint16(443))
+		irule := apiv2.Rule{
+			Action:    apiv2.Allow,
+			IPVersion: &v4,
+			Protocol:  &iproto,
+			ICMP: &apiv2.ICMPFields{
+				Type: &itype,
+				Code: &icode,
+			},
+			NotProtocol: &inproto,
+			NotICMP: &apiv2.ICMPFields{
+				Type: &intype,
+				Code: &incode,
+			},
+			Source: apiv2.EntityRule{
+				Tag:         "tag1",
+				Nets:        []string{"10.100.10.1"},
+				Selector:    "calico/k8s_ns == selector1",
+				Ports:       []numorstring.Port{port80},
+				NotTag:      "nottag1",
+				NotNets:     []string{"192.168.40.1"},
+				NotSelector: "has(label1)",
+				NotPorts:    []numorstring.Port{port443},
+			},
+			Destination: apiv2.EntityRule{
+				Tag:         "tag2",
+				Nets:        []string{"10.100.1.1"},
+				Selector:    "calico/k8s_ns == selector2",
+				Ports:       []numorstring.Port{port443},
+				NotTag:      "nottag2",
+				NotNets:     []string{"192.168.80.1"},
+				NotSelector: "has(label2)",
+				NotPorts:    []numorstring.Port{port80},
+			},
+		}
+
+		etype := 2
+		entype := 7
+		ecode := 5
+		encode := 8
+		eproto := numorstring.ProtocolFromInt(uint8(30))
+		enproto := numorstring.ProtocolFromInt(uint8(62))
+		erule := apiv2.Rule{
+			Action:    apiv2.Allow,
+			IPVersion: &v4,
+			Protocol:  &eproto,
+			ICMP: &apiv2.ICMPFields{
+				Type: &etype,
+				Code: &ecode,
+			},
+			NotProtocol: &enproto,
+			NotICMP: &apiv2.ICMPFields{
+				Type: &entype,
+				Code: &encode,
+			},
+			Source: apiv2.EntityRule{
+				Tag:         "tag2",
+				Nets:        []string{"10.100.1.1"},
+				Selector:    "calico/k8s_ns == selector2",
+				Ports:       []numorstring.Port{port443},
+				NotTag:      "nottag2",
+				NotNets:     []string{"192.168.80.1"},
+				NotSelector: "has(label2)",
+				NotPorts:    []numorstring.Port{port80},
+			},
+			Destination: apiv2.EntityRule{
+				Tag:         "tag1",
+				Nets:        []string{"10.100.10.1"},
+				Selector:    "calico/k8s_ns == selector1",
+				Ports:       []numorstring.Port{port80},
+				NotTag:      "nottag1",
+				NotNets:     []string{"192.168.40.1"},
+				NotSelector: "has(label1)",
+				NotPorts:    []numorstring.Port{port443},
+			},
+		}
+		order := float64(101)
+		selector := "calico/k8s_ns == selectme"
+
+		res.Spec.Order = &order
+		res.Spec.IngressRules = []apiv2.Rule{irule}
+		res.Spec.EgressRules = []apiv2.Rule{erule}
+		res.Spec.Selector = selector
+		res.Spec.DoNotTrack = true
+		res.Spec.PreDNAT = false
+		res.Spec.Types = []apiv2.PolicyType{apiv2.PolicyTypeIngress}
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2GlobalNetworkPolicyKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		v1irule := updateprocessors.RuleAPIV2ToBackend(irule)
+		v1erule := updateprocessors.RuleAPIV2ToBackend(erule)
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1GlobalNetworkPolicyKey2,
+				Value: &model.Policy{
+					Order:         &order,
+					InboundRules:  []model.Rule{v1irule},
+					OutboundRules: []model.Rule{v1erule},
+					Selector:      selector,
+					DoNotTrack:    true,
+					PreDNAT:       false,
+					Types:         []string{"ingress"},
+				},
+				Revision: "1234",
+			},
+		}))
+
+		By("deleting the first network policy")
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2GlobalNetworkPolicyKey1,
+			Value: nil,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1GlobalNetworkPolicyKey1,
+				Value: nil,
+			},
+		}))
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewGlobalNetworkPolicyUpdateProcessor()
+
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewGlobalNetworkPolicy()
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: cnet.MustParseIP("1.2.3.4"),
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewHostEndpoint()
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2GlobalNetworkPolicyKey1,
+			Value:    wres,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1GlobalNetworkPolicyKey1,
+				Value: nil,
+			},
+		}))
+
+		By("trying to convert without enough information to create a v1 key")
+		eres := apiv2.NewGlobalNetworkPolicy()
+		v2GlobalNetworkPolicyKeyEmpty := model.ResourceKey{
+			Kind: apiv2.KindGlobalNetworkPolicy,
+		}
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2GlobalNetworkPolicyKeyEmpty,
+			Value:    eres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+)
+
+// Create a new SyncerUpdateProcessor to sync NetworkPolicy data in v1 format for
+// consumption by Felix.
+func NewNetworkPolicyUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewSimpleUpdateProcessor(apiv2.KindNetworkPolicy, convertNetworkPolicyV2ToV1Key, convertNetworkPolicyV2ToV1Value)
+}
+
+func convertNetworkPolicyV2ToV1Key(v2key model.ResourceKey) (model.Key, error) {
+	if v2key.Name == "" || v2key.Namespace == "" {
+		return model.PolicyKey{}, errors.New("Missing Name or Namespace field to create a v1 NetworkPolicy Key")
+	}
+	return model.PolicyKey{
+		Name: v2key.Namespace + "/" + v2key.Name,
+	}, nil
+
+}
+
+func convertNetworkPolicyV2ToV1Value(val interface{}) (interface{}, error) {
+	v2res, ok := val.(*apiv2.NetworkPolicy)
+	if !ok {
+		return nil, errors.New("Value is not a valid NetworkPolicy resource value")
+	}
+	return convertPolicyV2ToV1Spec(v2res.Spec)
+}
+
+func convertPolicyV2ToV1Spec(spec apiv2.PolicySpec) (interface{}, error) {
+	var irules []model.Rule
+	for _, irule := range spec.IngressRules {
+		irules = append(irules, RuleAPIV2ToBackend(irule))
+	}
+
+	var erules []model.Rule
+	for _, erule := range spec.EgressRules {
+		erules = append(erules, RuleAPIV2ToBackend(erule))
+	}
+
+	v1value := &model.Policy{
+		Order:         spec.Order,
+		InboundRules:  irules,
+		OutboundRules: erules,
+		Selector:      spec.Selector,
+		DoNotTrack:    spec.DoNotTrack,
+		PreDNAT:       spec.PreDNAT,
+		Types:         policyTypesAPIV2ToBackend(spec.Types),
+	}
+
+	return v1value, nil
+}
+
+// policyTypesAPIV2ToBackend converts the policy type field value from the API
+// value to the equivalent backend value.
+func policyTypesAPIV2ToBackend(ptypes []apiv2.PolicyType) []string {
+	var v1ptypes []string
+	for _, ptype := range ptypes {
+		v1ptypes = append(v1ptypes, policyTypeAPIV2ToBackend(ptype))
+	}
+	return v1ptypes
+}
+
+func policyTypeAPIV2ToBackend(ptype apiv2.PolicyType) string {
+	return strings.ToLower(string(ptype))
+}

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var _ = Describe("Test the NetworkPolicy update processor", func() {
+	name1 := "name1"
+	name2 := "name2"
+	ns1 := "namespace1"
+	ns2 := "namespace2"
+
+	v2NetworkPolicyKey1 := model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Name:      name1,
+		Namespace: ns1,
+	}
+	v2NetworkPolicyKey2 := model.ResourceKey{
+		Kind:      apiv2.KindNetworkPolicy,
+		Name:      name2,
+		Namespace: ns2,
+	}
+	v1NetworkPolicyKey1 := model.PolicyKey{
+		Name: ns1 + "/" + name1,
+	}
+	v1NetworkPolicyKey2 := model.PolicyKey{
+		Name: ns2 + "/" + name2,
+	}
+
+	It("should handle conversion of valid NetworkPolicys", func() {
+		up := updateprocessors.NewNetworkPolicyUpdateProcessor()
+
+		By("converting a NetworkPolicy with minimum configuration")
+		res := apiv2.NewNetworkPolicy()
+		res.Spec.PreDNAT = true
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2NetworkPolicyKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1NetworkPolicyKey1,
+			Value: &model.Policy{
+				PreDNAT: true,
+			},
+			Revision: "abcde",
+		}))
+
+		By("adding another NetworkPolicy with a full configuration")
+		res = apiv2.NewNetworkPolicy()
+
+		v4 := 4
+		itype := 1
+		intype := 3
+		icode := 4
+		incode := 6
+		iproto := numorstring.ProtocolFromString("tcp")
+		inproto := numorstring.ProtocolFromString("udp")
+		port80 := numorstring.SinglePort(uint16(80))
+		port443 := numorstring.SinglePort(uint16(443))
+		irule := apiv2.Rule{
+			Action:    apiv2.Allow,
+			IPVersion: &v4,
+			Protocol:  &iproto,
+			ICMP: &apiv2.ICMPFields{
+				Type: &itype,
+				Code: &icode,
+			},
+			NotProtocol: &inproto,
+			NotICMP: &apiv2.ICMPFields{
+				Type: &intype,
+				Code: &incode,
+			},
+			Source: apiv2.EntityRule{
+				Tag:         "tag1",
+				Nets:        []string{"10.100.10.1"},
+				Selector:    "calico/k8s_ns == selector1",
+				Ports:       []numorstring.Port{port80},
+				NotTag:      "nottag1",
+				NotNets:     []string{"192.168.40.1"},
+				NotSelector: "has(label1)",
+				NotPorts:    []numorstring.Port{port443},
+			},
+			Destination: apiv2.EntityRule{
+				Tag:         "tag2",
+				Nets:        []string{"10.100.1.1"},
+				Selector:    "calico/k8s_ns == selector2",
+				Ports:       []numorstring.Port{port443},
+				NotTag:      "nottag2",
+				NotNets:     []string{"192.168.80.1"},
+				NotSelector: "has(label2)",
+				NotPorts:    []numorstring.Port{port80},
+			},
+		}
+
+		etype := 2
+		entype := 7
+		ecode := 5
+		encode := 8
+		eproto := numorstring.ProtocolFromInt(uint8(30))
+		enproto := numorstring.ProtocolFromInt(uint8(62))
+		erule := apiv2.Rule{
+			Action:    apiv2.Allow,
+			IPVersion: &v4,
+			Protocol:  &eproto,
+			ICMP: &apiv2.ICMPFields{
+				Type: &etype,
+				Code: &ecode,
+			},
+			NotProtocol: &enproto,
+			NotICMP: &apiv2.ICMPFields{
+				Type: &entype,
+				Code: &encode,
+			},
+			Source: apiv2.EntityRule{
+				Tag:         "tag2",
+				Nets:        []string{"10.100.1.1"},
+				Selector:    "calico/k8s_ns == selector2",
+				Ports:       []numorstring.Port{port443},
+				NotTag:      "nottag2",
+				NotNets:     []string{"192.168.80.1"},
+				NotSelector: "has(label2)",
+				NotPorts:    []numorstring.Port{port80},
+			},
+			Destination: apiv2.EntityRule{
+				Tag:         "tag1",
+				Nets:        []string{"10.100.10.1"},
+				Selector:    "calico/k8s_ns == selector1",
+				Ports:       []numorstring.Port{port80},
+				NotTag:      "nottag1",
+				NotNets:     []string{"192.168.40.1"},
+				NotSelector: "has(label1)",
+				NotPorts:    []numorstring.Port{port443},
+			},
+		}
+		order := float64(101)
+		selector := "calico/k8s_ns == selectme"
+
+		res.Spec.Order = &order
+		res.Spec.IngressRules = []apiv2.Rule{irule}
+		res.Spec.EgressRules = []apiv2.Rule{erule}
+		res.Spec.Selector = selector
+		res.Spec.DoNotTrack = true
+		res.Spec.PreDNAT = false
+		res.Spec.Types = []apiv2.PolicyType{apiv2.PolicyTypeIngress}
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2NetworkPolicyKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		v1irule := updateprocessors.RuleAPIV2ToBackend(irule)
+		v1erule := updateprocessors.RuleAPIV2ToBackend(erule)
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1NetworkPolicyKey2,
+				Value: &model.Policy{
+					Order:         &order,
+					InboundRules:  []model.Rule{v1irule},
+					OutboundRules: []model.Rule{v1erule},
+					Selector:      selector,
+					DoNotTrack:    true,
+					PreDNAT:       false,
+					Types:         []string{"ingress"},
+				},
+				Revision: "1234",
+			},
+		}))
+
+		By("deleting the first network policy")
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2NetworkPolicyKey1,
+			Value: nil,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1NetworkPolicyKey1,
+				Value: nil,
+			},
+		}))
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewNetworkPolicyUpdateProcessor()
+
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewNetworkPolicy()
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: cnet.MustParseIP("1.2.3.4"),
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewHostEndpoint()
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2NetworkPolicyKey1,
+			Value:    wres,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1NetworkPolicyKey1,
+				Value: nil,
+			},
+		}))
+
+		By("trying to convert without enough information to create a v1 key")
+		eres := apiv2.NewNetworkPolicy()
+		v2NetworkPolicyKeyEmpty := model.ResourceKey{
+			Kind: apiv2.KindNetworkPolicy,
+		}
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2NetworkPolicyKeyEmpty,
+			Value:    eres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/processor.go
+++ b/lib/backend/syncersv1/updateprocessors/processor.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	log "github.com/sirupsen/logrus"
+)
+
+// NewSimpleUpdateProcessor implements an update processor that only needs to take in
+// a conversion function. This is only meant to be used in cases where the Process and
+// OnSyncerStarting methods do not have any special handling.
+//
+// One of the main differences between the simple update processor and the conflict
+// resolving name cache processor is that the conflict resolving name cache processor
+// uses a cache to handle conflicts when v1 objects cannot be built up using only the
+// resource key. The simple update processor is for converting objects that can create
+// the v1 key using only the information available in the resource key.
+
+type ConvertV2ToV1Key func(v2Key model.ResourceKey) (model.Key, error)
+type ConvertV2ToV1Value func(interface{}) (interface{}, error)
+
+func NewSimpleUpdateProcessor(v2Kind string, kConverter ConvertV2ToV1Key, vConverter ConvertV2ToV1Value) watchersyncer.SyncerUpdateProcessor {
+	return &simpleUpdateProcessor{
+		v2Kind:         v2Kind,
+		keyConverter:   kConverter,
+		valueConverter: vConverter,
+	}
+}
+
+type simpleUpdateProcessor struct {
+	v2Kind         string
+	keyConverter   ConvertV2ToV1Key
+	valueConverter ConvertV2ToV1Value
+}
+
+func (sup *simpleUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	// Check the v2 resource is the correct type.
+	rk, ok := kvp.Key.(model.ResourceKey)
+	if !ok || rk.Kind != sup.v2Kind {
+		return nil, fmt.Errorf("Incorrect key type - expecting resource of kind %s", sup.v2Kind)
+	}
+
+	// Convert the v2 resource to the equivalent v1 resource type.
+	v2key, ok := kvp.Key.(model.ResourceKey)
+	if !ok {
+		return nil, errors.New("Key is not a valid V2 resource key")
+	}
+	v1key, err := sup.keyConverter(v2key)
+	if err != nil {
+		return nil, err
+	}
+
+	var v1value interface{}
+	// Deletion events will have a value of nil. Do not convert anything for a deletion event.
+	if kvp.Value != nil {
+		v1value, err = sup.valueConverter(kvp.Value)
+		if err != nil {
+			// Currently treat any values that fail to convert properly as a deletion event.
+			log.WithField("Resource", kvp.Key).Warn("Unable to process resource data - treating as deleted")
+			return []*model.KVPair{
+				&model.KVPair{
+					Key: v1key,
+				},
+			}, nil
+		}
+	}
+
+	return []*model.KVPair{
+		&model.KVPair{
+			Key:      v1key,
+			Value:    v1value,
+			Revision: kvp.Revision,
+		},
+	}, nil
+}
+
+func (sup *simpleUpdateProcessor) OnSyncerStarting() {
+	// Do nothing
+}

--- a/lib/backend/syncersv1/updateprocessors/profileprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/profileprocessor.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	log "github.com/sirupsen/logrus"
+)
+
+// Create a new SyncerUpdateProcessor to sync Profile data in v1 format for
+// consumption by Felix.
+func NewProfileUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return &profileUpdateProcessor{
+		v2Kind: apiv2.KindProfile,
+	}
+}
+
+// Need to create custom logic for Profile since it breaks the values into 3 separate KV Pairs:
+// Tags, Labels, and Rules.
+type profileUpdateProcessor struct {
+	v2Kind string
+}
+
+func (pup *profileUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, error) {
+	// Check the v2 resource is the correct type.
+	rk, ok := kvp.Key.(model.ResourceKey)
+	if !ok || rk.Kind != pup.v2Kind {
+		return nil, fmt.Errorf("Incorrect key type - expecting resource of kind %s", pup.v2Kind)
+	}
+
+	// Convert the v2 resource to the equivalent v1 resource type.
+	v2key, ok := kvp.Key.(model.ResourceKey)
+	if !ok {
+		return nil, errors.New("Key is not a valid V2 resource key")
+	}
+
+	if v2key.Name == "" {
+		return nil, errors.New("Missing Name field to create a v1 Profile Key")
+	}
+
+	pk := model.ProfileKey{
+		Name: v2key.Name,
+	}
+
+	v1labelsKey := model.ProfileLabelsKey{pk}
+	v1rulesKey := model.ProfileRulesKey{pk}
+
+	var v1profile *model.Profile
+	var err error
+	// Deletion events will have a value of nil. Do not convert anything for a deletion event.
+	if kvp.Value != nil {
+		v1profile, err = convertProfileV2ToV1Value(kvp.Value)
+		if err != nil {
+			// Currently treat any errors as a deletion event.
+			log.WithField("Resource", kvp.Key).Warn("Unable to process resource data - treating as deleted")
+		}
+	}
+
+	labelskvp := &model.KVPair{
+		Key: v1labelsKey,
+	}
+	ruleskvp := &model.KVPair{
+		Key: v1rulesKey,
+	}
+
+	if v1profile != nil {
+		labelskvp.Value = v1profile.Labels
+		labelskvp.Revision = kvp.Revision
+		ruleskvp.Value = &v1profile.Rules
+		ruleskvp.Revision = kvp.Revision
+	}
+
+	return []*model.KVPair{labelskvp, ruleskvp}, nil
+}
+
+func (pup *profileUpdateProcessor) OnSyncerStarting() {
+	// Do nothing
+}
+
+func convertProfileV2ToV1Value(val interface{}) (*model.Profile, error) {
+	v2res, ok := val.(*apiv2.Profile)
+	if !ok {
+		return nil, errors.New("Value is not a valid Profile resource value")
+	}
+
+	var irules []model.Rule
+	for _, irule := range v2res.Spec.IngressRules {
+		irules = append(irules, RuleAPIV2ToBackend(irule))
+	}
+
+	var erules []model.Rule
+	for _, erule := range v2res.Spec.EgressRules {
+		erules = append(erules, RuleAPIV2ToBackend(erule))
+	}
+
+	rules := model.ProfileRules{
+		InboundRules:  irules,
+		OutboundRules: erules,
+	}
+
+	v1value := &model.Profile{
+		Rules:  rules,
+		Labels: v2res.Spec.LabelsToApply,
+	}
+
+	return v1value, nil
+}

--- a/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var _ = Describe("Test the Profile update processor", func() {
+	name1 := "name1"
+	name2 := "name2"
+	nilRules := &model.ProfileRules{}
+
+	v2ProfileKey1 := model.ResourceKey{
+		Kind: apiv2.KindProfile,
+		Name: name1,
+	}
+	v2ProfileKey2 := model.ResourceKey{
+		Kind: apiv2.KindProfile,
+		Name: name2,
+	}
+	v1ProfileKey1 := model.ProfileKey{
+		Name: name1,
+	}
+	v1ProfileKey2 := model.ProfileKey{
+		Name: name2,
+	}
+
+	It("should handle conversion of valid Profiles", func() {
+		up := updateprocessors.NewProfileUpdateProcessor()
+
+		By("converting a Profile with minimum configuration")
+		res := apiv2.NewProfile()
+		res.Spec.LabelsToApply = map[string]string{"testLabel": "label"}
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2ProfileKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(2))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key:      model.ProfileLabelsKey{v1ProfileKey1},
+			Value:    map[string]string{"testLabel": "label"},
+			Revision: "abcde",
+		}))
+		Expect(kvps[1]).To(Equal(&model.KVPair{
+			Key:      model.ProfileRulesKey{v1ProfileKey1},
+			Value:    nilRules,
+			Revision: "abcde",
+		}))
+
+		By("adding another Profile with a full configuration")
+		res = apiv2.NewProfile()
+		res.Spec.LabelsToApply = map[string]string{"testLabel": "label2"}
+
+		v4 := 4
+		itype := 1
+		intype := 3
+		icode := 4
+		incode := 6
+		iproto := numorstring.ProtocolFromString("tcp")
+		inproto := numorstring.ProtocolFromString("udp")
+		port80 := numorstring.SinglePort(uint16(80))
+		port443 := numorstring.SinglePort(uint16(443))
+		irule := apiv2.Rule{
+			Action:    apiv2.Allow,
+			IPVersion: &v4,
+			Protocol:  &iproto,
+			ICMP: &apiv2.ICMPFields{
+				Type: &itype,
+				Code: &icode,
+			},
+			NotProtocol: &inproto,
+			NotICMP: &apiv2.ICMPFields{
+				Type: &intype,
+				Code: &incode,
+			},
+			Source: apiv2.EntityRule{
+				Tag:         "tag1",
+				Nets:        []string{"10.100.10.1"},
+				Selector:    "calico/k8s_ns == selector1",
+				Ports:       []numorstring.Port{port80},
+				NotTag:      "nottag1",
+				NotNets:     []string{"192.168.40.1"},
+				NotSelector: "has(label1)",
+				NotPorts:    []numorstring.Port{port443},
+			},
+			Destination: apiv2.EntityRule{
+				Tag:         "tag2",
+				Nets:        []string{"10.100.1.1"},
+				Selector:    "calico/k8s_ns == selector2",
+				Ports:       []numorstring.Port{port443},
+				NotTag:      "nottag2",
+				NotNets:     []string{"192.168.80.1"},
+				NotSelector: "has(label2)",
+				NotPorts:    []numorstring.Port{port80},
+			},
+		}
+
+		etype := 2
+		entype := 7
+		ecode := 5
+		encode := 8
+		eproto := numorstring.ProtocolFromInt(uint8(30))
+		enproto := numorstring.ProtocolFromInt(uint8(62))
+		erule := apiv2.Rule{
+			Action:    apiv2.Allow,
+			IPVersion: &v4,
+			Protocol:  &eproto,
+			ICMP: &apiv2.ICMPFields{
+				Type: &etype,
+				Code: &ecode,
+			},
+			NotProtocol: &enproto,
+			NotICMP: &apiv2.ICMPFields{
+				Type: &entype,
+				Code: &encode,
+			},
+			Source: apiv2.EntityRule{
+				Tag:         "tag2",
+				Nets:        []string{"10.100.1.1"},
+				Selector:    "calico/k8s_ns == selector2",
+				Ports:       []numorstring.Port{port443},
+				NotTag:      "nottag2",
+				NotNets:     []string{"192.168.80.1"},
+				NotSelector: "has(label2)",
+				NotPorts:    []numorstring.Port{port80},
+			},
+			Destination: apiv2.EntityRule{
+				Tag:         "tag1",
+				Nets:        []string{"10.100.10.1"},
+				Selector:    "calico/k8s_ns == selector1",
+				Ports:       []numorstring.Port{port80},
+				NotTag:      "nottag1",
+				NotNets:     []string{"192.168.40.1"},
+				NotSelector: "has(label1)",
+				NotPorts:    []numorstring.Port{port443},
+			},
+		}
+
+		res.Spec.IngressRules = []apiv2.Rule{irule}
+		res.Spec.EgressRules = []apiv2.Rule{erule}
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2ProfileKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		v1irule := updateprocessors.RuleAPIV2ToBackend(irule)
+		v1erule := updateprocessors.RuleAPIV2ToBackend(erule)
+		Expect(kvps).To(HaveLen(2))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key:      model.ProfileLabelsKey{v1ProfileKey2},
+			Value:    map[string]string{"testLabel": "label2"},
+			Revision: "1234",
+		}))
+		Expect(kvps[1]).To(Equal(&model.KVPair{
+			Key: model.ProfileRulesKey{v1ProfileKey2},
+			Value: &model.ProfileRules{
+				InboundRules:  []model.Rule{v1irule},
+				OutboundRules: []model.Rule{v1erule},
+			},
+			Revision: "1234",
+		}))
+
+		By("deleting the first profile")
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2ProfileKey1,
+			Value: nil,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   model.ProfileLabelsKey{v1ProfileKey1},
+				Value: nil,
+			},
+			{
+				Key:   model.ProfileRulesKey{v1ProfileKey1},
+				Value: nil,
+			},
+		}))
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewProfileUpdateProcessor()
+
+		By("trying to convert with the wrong key type")
+		res := apiv2.NewProfile()
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: cnet.MustParseIP("1.2.3.4"),
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type")
+		wres := apiv2.NewHostEndpoint()
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2ProfileKey1,
+			Value:    wres,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   model.ProfileLabelsKey{v1ProfileKey1},
+				Value: nil,
+			},
+			{
+				Key:   model.ProfileRulesKey{v1ProfileKey1},
+				Value: nil,
+			},
+		}))
+
+		By("trying to convert without enough information to create a v1 key")
+		eres := apiv2.NewProfile()
+		v2ProfileKeyEmpty := model.ResourceKey{
+			Kind: apiv2.KindProfile,
+		}
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2ProfileKeyEmpty,
+			Value:    eres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"strings"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+func RulesAPIV2ToBackend(ars []apiv2.Rule) []model.Rule {
+	if ars == nil {
+		return []model.Rule{}
+	}
+
+	brs := make([]model.Rule, len(ars))
+	for idx, ar := range ars {
+		brs[idx] = RuleAPIV2ToBackend(ar)
+	}
+	return brs
+}
+
+// RuleAPIToBackend converts an API Rule structure to a Backend Rule structure.
+func RuleAPIV2ToBackend(ar apiv2.Rule) model.Rule {
+	var icmpCode, icmpType, notICMPCode, notICMPType *int
+	if ar.ICMP != nil {
+		icmpCode = ar.ICMP.Code
+		icmpType = ar.ICMP.Type
+	}
+
+	if ar.NotICMP != nil {
+		notICMPCode = ar.NotICMP.Code
+		notICMPType = ar.NotICMP.Type
+	}
+
+	return model.Rule{
+		Action:      ruleActionAPIV2ToBackend(ar.Action),
+		IPVersion:   ar.IPVersion,
+		Protocol:    ar.Protocol,
+		ICMPCode:    icmpCode,
+		ICMPType:    icmpType,
+		NotProtocol: ar.NotProtocol,
+		NotICMPCode: notICMPCode,
+		NotICMPType: notICMPType,
+
+		SrcTag:      ar.Source.Tag,
+		SrcNets:     convertStringsToNets(ar.Source.Nets),
+		SrcSelector: ar.Source.Selector,
+		SrcPorts:    ar.Source.Ports,
+		DstTag:      ar.Destination.Tag,
+		DstNets:     normalizeIPNets(ar.Destination.Nets),
+		DstSelector: ar.Destination.Selector,
+		DstPorts:    ar.Destination.Ports,
+
+		NotSrcTag:      ar.Source.NotTag,
+		NotSrcNets:     convertStringsToNets(ar.Source.NotNets),
+		NotSrcSelector: ar.Source.NotSelector,
+		NotSrcPorts:    ar.Source.NotPorts,
+		NotDstTag:      ar.Destination.NotTag,
+		NotDstNets:     normalizeIPNets(ar.Destination.NotNets),
+		NotDstSelector: ar.Destination.NotSelector,
+		NotDstPorts:    ar.Destination.NotPorts,
+	}
+}
+
+// normalizeIPNet converts an IPNet to a network by ensuring the IP address is correctly masked.
+func normalizeIPNet(n string) *cnet.IPNet {
+	if n == "" {
+		return nil
+	}
+	_, ipn, err := cnet.ParseCIDROrIP(n)
+	if err != nil {
+		return nil
+	}
+	return ipn.Network()
+}
+
+// normalizeIPNets converts an []*IPNet to a slice of networks by ensuring the IP addresses
+// are correctly masked.
+func normalizeIPNets(nets []string) []*cnet.IPNet {
+	if len(nets) == 0 {
+		return nil
+	}
+	out := make([]*cnet.IPNet, len(nets))
+	for i, n := range nets {
+		out[i] = normalizeIPNet(n)
+	}
+	return out
+}
+
+// ruleActionAPIV2ToBackend converts the rule action field value from the API
+// value to the equivalent backend value.
+func ruleActionAPIV2ToBackend(action apiv2.Action) string {
+	if action == apiv2.Pass {
+		return "next-tier"
+	}
+	return strings.ToLower(string(action))
+}
+
+func convertStringsToNets(strs []string) []*cnet.IPNet {
+	var nets []*cnet.IPNet
+	for _, str := range strs {
+		_, ipn, err := cnet.ParseCIDROrIP(str)
+		if err != nil {
+			continue
+		}
+		nets = append(nets, ipn)
+	}
+	return nets
+}

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors
+
+import (
+	"errors"
+	"net"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	"github.com/projectcalico/libcalico-go/lib/names"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// Create a new SyncerUpdateProcessor to sync WorkloadEndpoint data in v1 format for
+// consumption by Felix.
+func NewWorkloadEndpointUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
+	return NewSimpleUpdateProcessor(apiv2.KindWorkloadEndpoint, convertWorkloadEndpointV2ToV1Key, convertWorkloadEndpointV2ToV1Value)
+}
+
+func convertWorkloadEndpointV2ToV1Key(v2key model.ResourceKey) (model.Key, error) {
+	parts := names.ExtractDashSeparatedParms(v2key.Name, 4)
+	if len(parts) != 4 || v2key.Namespace == "" {
+		return model.WorkloadEndpointKey{}, errors.New("Not enough information provided to create v1 Workload Endpoint Key")
+	}
+	return model.WorkloadEndpointKey{
+		Hostname:       parts[0],
+		OrchestratorID: parts[1],
+		WorkloadID:     v2key.Namespace + "/" + parts[2],
+		EndpointID:     parts[3],
+	}, nil
+
+}
+
+func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
+	v2res, ok := val.(*apiv2.WorkloadEndpoint)
+	if !ok {
+		return nil, errors.New("Value is not a valid WorkloadEndpoint resource value")
+	}
+	var ipv4Nets []cnet.IPNet
+	var ipv6Nets []cnet.IPNet
+	for _, ipnString := range v2res.Spec.IPNetworks {
+		_, ipn, err := cnet.ParseCIDROrIP(ipnString)
+		if err != nil {
+			return nil, err
+		}
+		ipnet := *(ipn.Network())
+		if ipnet.Version() == 4 {
+			ipv4Nets = append(ipv4Nets, ipnet)
+		} else {
+			ipv6Nets = append(ipv6Nets, ipnet)
+		}
+	}
+
+	var ipv4NAT []model.IPNAT
+	var ipv6NAT []model.IPNAT
+	for _, ipnat := range v2res.Spec.IPNATs {
+		nat := ConvertV2ToV1IPNAT(ipnat)
+		if nat != nil {
+			if nat.IntIP.Version() == 4 {
+				ipv4NAT = append(ipv4NAT, *nat)
+			} else {
+				ipv6NAT = append(ipv6NAT, *nat)
+			}
+		}
+	}
+
+	var ipv4Gateway *cnet.IP
+	var err error
+	if v2res.Spec.IPv4Gateway != "" {
+		ipv4Gateway, _, err = cnet.ParseCIDROrIP(v2res.Spec.IPv4Gateway)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var ipv6Gateway *cnet.IP
+	if v2res.Spec.IPv6Gateway != "" {
+		ipv6Gateway, _, err = cnet.ParseCIDROrIP(v2res.Spec.IPv6Gateway)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var cmac *cnet.MAC
+	if v2res.Spec.MAC != "" {
+		mac, err := net.ParseMAC(v2res.Spec.MAC)
+		if err != nil {
+			return nil, err
+		}
+		cmac = &cnet.MAC{mac}
+	}
+
+	// Convert the EndpointPort type from the API pkg to the v1 model equivalent type
+	ports := []model.EndpointPort{}
+	for _, port := range v2res.Spec.Ports {
+		ports = append(ports, model.EndpointPort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     port.Port,
+		})
+	}
+
+	v1value := &model.WorkloadEndpoint{
+		State:            "active",
+		Name:             v2res.Spec.InterfaceName,
+		ActiveInstanceID: v2res.Spec.ContainerID,
+		Mac:              cmac,
+		ProfileIDs:       v2res.Spec.Profiles,
+		IPv4Nets:         ipv4Nets,
+		IPv6Nets:         ipv6Nets,
+		IPv4NAT:          ipv4NAT,
+		IPv6NAT:          ipv6NAT,
+		Labels:           v2res.GetLabels(),
+		IPv4Gateway:      ipv4Gateway,
+		IPv6Gateway:      ipv6Gateway,
+		Ports:            ports,
+	}
+
+	return v1value, nil
+}
+
+func ConvertV2ToV1IPNAT(ipnat apiv2.IPNAT) *model.IPNAT {
+	internalip := cnet.ParseIP(ipnat.InternalIP)
+	externalip := cnet.ParseIP(ipnat.ExternalIP)
+	if internalip != nil && externalip != nil {
+		return &model.IPNAT{
+			IntIP: *internalip,
+			ExtIP: *externalip,
+		}
+	}
+	return nil
+}

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updateprocessors_test
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/apiv2"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/updateprocessors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+var _ = Describe("Test the WorkloadEndpoint update processor", func() {
+	hn1 := "host1"
+	hn2 := "host2"
+	oid1 := "orchestrator1"
+	oid2 := "orchestrator2"
+	wid1 := "workload1"
+	wid2 := "workload2"
+	eid1 := "endpoint1"
+	eid2 := "endpoint2"
+	ns1 := "namespace1"
+	ns2 := "namespace2"
+	name1 := "host1-orchestrator1-workload1-endpoint1"
+	name2 := "host2-orchestrator2-workload2-endpoint2"
+	iface1 := "iface1"
+	iface2 := "iface2"
+
+	v2WorkloadEndpointKey1 := model.ResourceKey{
+		Kind:      apiv2.KindWorkloadEndpoint,
+		Name:      name1,
+		Namespace: ns1,
+	}
+	v2WorkloadEndpointKey2 := model.ResourceKey{
+		Kind:      apiv2.KindWorkloadEndpoint,
+		Name:      name2,
+		Namespace: ns2,
+	}
+	v1WorkloadEndpointKey1 := model.WorkloadEndpointKey{
+		Hostname:       hn1,
+		OrchestratorID: oid1,
+		WorkloadID:     ns1 + "/" + wid1,
+		EndpointID:     eid1,
+	}
+	v1WorkloadEndpointKey2 := model.WorkloadEndpointKey{
+		Hostname:       hn2,
+		OrchestratorID: oid2,
+		WorkloadID:     ns2 + "/" + wid2,
+		EndpointID:     eid2,
+	}
+
+	It("should handle conversion of valid WorkloadEndpoints", func() {
+		netmac2, err := net.ParseMAC("01:23:45:67:89:ab")
+		Expect(err).NotTo(HaveOccurred())
+		mac2 := cnet.MAC{netmac2}
+
+		up := updateprocessors.NewWorkloadEndpointUpdateProcessor()
+
+		By("converting a WorkloadEndpoint with minimum configuration")
+		res := apiv2.NewWorkloadEndpoint()
+		res.Spec.InterfaceName = iface1
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey1,
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(HaveLen(1))
+		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key: v1WorkloadEndpointKey1,
+			Value: &model.WorkloadEndpoint{
+				State: "active",
+				Name:  iface1,
+				Ports: []model.EndpointPort{},
+			},
+			Revision: "abcde",
+		}))
+
+		By("adding another WorkloadEndpoint with a full configuration")
+		res = apiv2.NewWorkloadEndpoint()
+		res.Labels = map[string]string{"testLabel": "label"}
+		res.Spec.InterfaceName = iface2
+		res.Spec.ContainerID = "container2"
+		res.Spec.MAC = "01:23:45:67:89:ab"
+		res.Spec.Profiles = []string{"testProfile"}
+		res.Spec.IPNetworks = []string{"10.100.10.1"}
+		_, ipn, err := cnet.ParseCIDROrIP("10.100.10.1")
+		Expect(err).NotTo(HaveOccurred())
+		expectedIPv4Net := *(ipn.Network())
+		res.Spec.IPNATs = []apiv2.IPNAT{
+			apiv2.IPNAT{
+				InternalIP: "10.100.1.1",
+				ExternalIP: "10.1.10.1",
+			},
+		}
+		expectedIPv4NAT := *updateprocessors.ConvertV2ToV1IPNAT(res.Spec.IPNATs[0])
+		res.Spec.IPv4Gateway = "10.10.10.1"
+		expectedIPv4Gateway, _, err := cnet.ParseCIDROrIP("10.10.10.1")
+		res.Spec.IPv6Gateway = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+		expectedIPv6Gateway, _, err := cnet.ParseCIDROrIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+		res.Spec.Ports = []apiv2.EndpointPort{
+			apiv2.EndpointPort{
+				Name:     "portname",
+				Protocol: numorstring.ProtocolFromInt(uint8(30)),
+				Port:     uint16(8080),
+			},
+		}
+
+		kvps, err = up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey2,
+			Value:    res,
+			Revision: "1234",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key: v1WorkloadEndpointKey2,
+				Value: &model.WorkloadEndpoint{
+					State:            "active",
+					Name:             iface2,
+					ActiveInstanceID: "container2",
+					Mac:              &mac2,
+					ProfileIDs:       []string{"testProfile"},
+					IPv4Nets:         []cnet.IPNet{expectedIPv4Net},
+					IPv4NAT:          []model.IPNAT{expectedIPv4NAT},
+					Labels:           map[string]string{"testLabel": "label"},
+					IPv4Gateway:      expectedIPv4Gateway,
+					IPv6Gateway:      expectedIPv6Gateway,
+					Ports: []model.EndpointPort{
+						model.EndpointPort{
+							Name:     "portname",
+							Protocol: numorstring.ProtocolFromInt(uint8(30)),
+							Port:     uint16(8080),
+						},
+					},
+				},
+				Revision: "1234",
+			},
+		}))
+
+		By("deleting the first workload endpoint")
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v2WorkloadEndpointKey1,
+			Value: nil,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1WorkloadEndpointKey1,
+				Value: nil,
+			},
+		}))
+	})
+
+	It("should fail to convert an invalid resource", func() {
+		up := updateprocessors.NewWorkloadEndpointUpdateProcessor()
+
+		By("trying to convert with the wrong key type.")
+		res := apiv2.NewWorkloadEndpoint()
+		res.Name = name1
+		res.Namespace = ns1
+
+		_, err := up.Process(&model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: cnet.MustParseIP("1.2.3.4"),
+			},
+			Value:    res,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+
+		By("trying to convert with the wrong value type and get a valid key with a nil value.")
+		wres := apiv2.NewHostEndpoint()
+
+		kvps, err := up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey1,
+			Value:    wres,
+			Revision: "abcde",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   v1WorkloadEndpointKey1,
+				Value: nil,
+			},
+		}))
+
+		By("trying to convert without enough information to create a v1 key.")
+		eres := apiv2.NewWorkloadEndpoint()
+		v2WorkloadEndpointKey1 := model.ResourceKey{
+			Kind: apiv2.KindWorkloadEndpoint,
+			Name: name1,
+		}
+
+		_, err = up.Process(&model.KVPair{
+			Key:      v2WorkloadEndpointKey1,
+			Value:    eres,
+			Revision: "abcde",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/lib/names/workloadendpoint.go
+++ b/lib/names/workloadendpoint.go
@@ -64,7 +64,7 @@ func (ids WorkloadEndpointIdentifiers) NameMatches(name string) (bool, error) {
 	}
 
 	// Extract the parameters from the name.
-	parts := extractDashSeparatedParms(name, len(req))
+	parts := ExtractDashSeparatedParms(name, len(req))
 	if len(parts) == 0 {
 		return false, nil
 	}
@@ -190,7 +190,7 @@ func escapeDashes(seg segment) (string, *cerrors.ErroredField) {
 
 // Extract the dash separated parms from the name.  Each parm will have had their dashes escaped,
 // this also removes that escaping.  Returns nil if the parameters could not be extracted.
-func extractDashSeparatedParms(name string, numParms int) []string {
+func ExtractDashSeparatedParms(name string, numParms int) []string {
 	// The name must be at least as long as the number of parameters plus the separators.
 	if len(name) < (2*numParms - 1) {
 		return nil


### PR DESCRIPTION
## Description
Add the conversion code and tests for Workload Endpoint, Profile, NetworkPolicy, and GlobalNetworkPolicy resources.

## Todos
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
