### PR TITLE
Fix v2 Networkpolicy support for KDD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,16 @@ run-kubernetes-master: stop-kubernetes-master
 		--server=http://127.0.0.1:8080 \
 		apply -f manifests/test/mock-node.yaml
 
+	# Create Namespaces required by namespaced Calico `NetworkPolicy`
+	# tests from the manifests namespaces.yaml.
+	docker run \
+	    --net=host \
+	    --rm \
+		-v  $(CURDIR):/manifests \
+		lachlanevenson/k8s-kubectl:${K8S_VERSION} \
+		--server=http://localhost:8080 \
+		apply -f manifests/test/namespaces.yaml
+
 ## Stop the local kubernetes master
 stop-kubernetes-master:
 	# Delete the cluster role binding.

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -291,19 +291,19 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		// Check the selector is correct, and that the matches are sorted.
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal(
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal(
 			"calico/k8s_ns == 'default' && label == 'value' && label2 == 'value2'"))
 		protoTCP := numorstring.ProtocolFromString("tcp")
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules).To(ConsistOf(
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules).To(ConsistOf(
 			apiv2.Rule{
 				Action:   "allow",
 				Protocol: &protoTCP, // Defaulted to TCP.
@@ -327,11 +327,11 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with no rules", func() {
@@ -349,23 +349,23 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with multiple peers", func() {
@@ -408,28 +408,28 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		var pol *model.KVPair
 		var err error
 		By("parsing the policy", func() {
-			pol, err = c.NetworkPolicyToPolicy(&np)
+			pol, err = c.K8sNetworkPolicyToCalico(&np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
-			Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
+			Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		})
 
 		By("having the correct endpoint selector", func() {
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
 		})
 
 		By("having the correct peer selectors", func() {
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(2))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(2))
 
 			// There should be no EgressRules
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 			// Check that Types field exists and has only 'ingress'
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
 		})
 	})
 
@@ -485,39 +485,39 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		var pol *model.KVPair
 		var err error
 		By("parsing the policy", func() {
-			pol, err = c.NetworkPolicyToPolicy(&np)
+			pol, err = c.K8sNetworkPolicyToCalico(&np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
-			Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
+			Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		})
 
 		By("having the correct endpoint selector", func() {
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
 		})
 
 		By("having the correct peer selectors", func() {
 			eighty, _ := numorstring.PortFromString("80")
 			ninety, _ := numorstring.PortFromString("90")
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(4))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(4))
 
 			// There should be no EgressRules
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 			// Check that Types field exists and has only 'ingress'
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[1].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[1].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[2].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[2].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[2].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[2].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[3].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[3].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[3].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[3].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
 		})
 	})
 
@@ -534,23 +534,23 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with an empty namespaceSelector", func() {
@@ -579,24 +579,24 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("has(calico/k8s_ns)"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("has(calico/k8s_ns)"))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with podSelector.MatchExpressions", func() {
@@ -620,23 +620,23 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && k in { 'v1', 'v2' }"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && k in { 'v1', 'v2' }"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with Ports only", func() {
@@ -664,26 +664,26 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Protocol.String()).To(Equal("tcp"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Destination.Ports)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Destination.Ports[0].String()).To(Equal("80"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Protocol.String()).To(Equal("tcp"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Destination.Ports)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Destination.Ports[0].String()).To(Equal("80"))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with an Ingress rule with an IPBlock Peer", func() {
@@ -711,26 +711,26 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Nets[0]).To(Equal("192.168.0.0/16"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.NotNets[0]).To(Equal("192.168.3.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.NotNets[1]).To(Equal("192.168.4.0/24"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Nets[0]).To(Equal("192.168.0.0/16"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.NotNets[0]).To(Equal("192.168.3.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.NotNets[1]).To(Equal("192.168.4.0/24"))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with an Egress rule with an IPBlock Peer", func() {
@@ -758,27 +758,27 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.Nets[0]).To(Equal("192.168.0.0/16"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[0]).To(Equal("192.168.3.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[1]).To(Equal("192.168.4.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[2]).To(Equal("192.168.5.0/24"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.Nets[0]).To(Equal("192.168.0.0/16"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[0]).To(Equal("192.168.3.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[1]).To(Equal("192.168.4.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[2]).To(Equal("192.168.5.0/24"))
 
 		// There should be no IngressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'egress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeEgress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeEgress))
 	})
 
 	It("should parse a NetworkPolicy with an Egress rule with IPBlock and Ports", func() {
@@ -821,7 +821,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
@@ -831,27 +831,27 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		ninetyName, _ := numorstring.PortFromString("90")
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(2))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.Ports).To(Equal([]numorstring.Port{ninetyName}))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.Nets[0]).To(Equal("192.168.0.0/16"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[0]).To(Equal("192.168.3.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[1]).To(Equal("192.168.4.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[2]).To(Equal("192.168.5.0/24"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(2))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.Ports).To(Equal([]numorstring.Port{ninetyName}))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.Nets[0]).To(Equal("192.168.0.0/16"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[0]).To(Equal("192.168.3.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[1]).To(Equal("192.168.4.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[2]).To(Equal("192.168.5.0/24"))
 
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[1].Destination.Ports).To(Equal([]numorstring.Port{eightyName}))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[1].Destination.Nets[0]).To(Equal("192.168.0.0/16"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[1].Destination.NotNets[0]).To(Equal("192.168.3.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[1].Destination.NotNets[1]).To(Equal("192.168.4.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[1].Destination.NotNets[2]).To(Equal("192.168.5.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[1].Destination.Ports).To(Equal([]numorstring.Port{eightyName}))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[1].Destination.Nets[0]).To(Equal("192.168.0.0/16"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[1].Destination.NotNets[0]).To(Equal("192.168.3.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[1].Destination.NotNets[1]).To(Equal("192.168.4.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[1].Destination.NotNets[2]).To(Equal("192.168.5.0/24"))
 
 		// There should be no IngressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'egress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeEgress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeEgress))
 	})
 
 	It("should parse a NetworkPolicy with both an Egress and an Ingress rule", func() {
@@ -890,33 +890,33 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			},
 		}
 
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.Nets[0]).To(Equal("10.10.0.0/16"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[0]).To(Equal("192.168.13.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[1]).To(Equal("192.168.14.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules[0].Destination.NotNets[2]).To(Equal("192.168.15.0/24"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.Nets[0]).To(Equal("10.10.0.0/16"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[0]).To(Equal("192.168.13.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[1]).To(Equal("192.168.14.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules[0].Destination.NotNets[2]).To(Equal("192.168.15.0/24"))
 
 		// There should be one InboundRule
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(1))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
 
 		// Assert InboundRule fields are correct.
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Nets[0]).To(Equal("192.168.0.0/16"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.NotNets[0]).To(Equal("192.168.3.0/24"))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.NotNets[1]).To(Equal("192.168.4.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Nets[0]).To(Equal("192.168.0.0/16"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.NotNets[0]).To(Equal("192.168.3.0/24"))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.NotNets[1]).To(Equal("192.168.4.0/24"))
 
 		// Check that Types field exists and has both 'egress' and 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(2))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[1]).To(Equal(apiv2.PolicyTypeEgress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(2))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[1]).To(Equal(apiv2.PolicyTypeEgress))
 	})
 })
 
@@ -962,19 +962,19 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		// Check the selector is correct, and that the matches are sorted.
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal(
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal(
 			"calico/k8s_ns == 'default' && label == 'value' && label2 == 'value2'"))
 		protoTCP := numorstring.ProtocolFromString("tcp")
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules).To(ConsistOf(apiv2.Rule{
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules).To(ConsistOf(apiv2.Rule{
 			Action:   "allow",
 			Protocol: &protoTCP, // Defaulted to TCP.
 			Source: apiv2.EntityRule{
@@ -986,11 +986,11 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with no rules", func() {
@@ -1007,23 +1007,23 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with multiple peers", func() {
@@ -1065,28 +1065,28 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		var pol *model.KVPair
 		var err error
 		By("parsing the policy", func() {
-			pol, err = c.NetworkPolicyToPolicy(&np)
+			pol, err = c.K8sNetworkPolicyToCalico(&np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
-			Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
+			Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		})
 
 		By("having the correct endpoint selector", func() {
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
 		})
 
 		By("having the correct peer selectors", func() {
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(2))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(2))
 
 			// There should be no EgressRules
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 			// Check that Types field exists and has only 'ingress'
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
 		})
 	})
 
@@ -1141,39 +1141,39 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		var pol *model.KVPair
 		var err error
 		By("parsing the policy", func() {
-			pol, err = c.NetworkPolicyToPolicy(&np)
+			pol, err = c.K8sNetworkPolicyToCalico(&np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
-			Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
+			Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		})
 
 		By("having the correct endpoint selector", func() {
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
 		})
 
 		By("having the correct peer selectors", func() {
 			eighty, _ := numorstring.PortFromString("80")
 			ninety, _ := numorstring.PortFromString("90")
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(4))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(4))
 
 			// There should be no EgressRules
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 			// Check that Types field exists and has only 'ingress'
-			Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+			Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[1].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[1].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[1].Destination.Ports).To(Equal([]numorstring.Port{ninety}))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[2].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[2].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[2].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k == 'v'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[2].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
 
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[3].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
-			Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[3].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[3].Source.Selector).To(Equal("calico/k8s_ns == 'default' && k2 == 'v2'"))
+			Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[3].Destination.Ports).To(Equal([]numorstring.Port{eighty}))
 		})
 	})
 
@@ -1189,23 +1189,23 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with an empty namespaceSelector", func() {
@@ -1233,24 +1233,24 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("has(calico/k8s_ns)"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("has(calico/k8s_ns)"))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with podSelector.MatchExpressions", func() {
@@ -1273,23 +1273,23 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && k in { 'v1', 'v2' }"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(0))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default' && k in { 'v1', 'v2' }"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 
 	It("should parse a NetworkPolicy with Ports only", func() {
@@ -1316,26 +1316,26 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		}
 
 		// Parse the policy.
-		pol, err := c.NetworkPolicyToPolicy(&np)
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields are correct.
 		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.default.testPolicy"))
 
 		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Protocol.String()).To(Equal("tcp"))
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Destination.Ports)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.IngressRules[0].Destination.Ports[0].String()).To(Equal("80"))
+		Expect(int(*pol.Value.(*apiv2.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Protocol.String()).To(Equal("tcp"))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Destination.Ports)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.IngressRules[0].Destination.Ports[0].String()).To(Equal("80"))
 
 		// There should be no EgressRules
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.EgressRules)).To(Equal(0))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
 
 		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv2.GlobalNetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
+		Expect(len(pol.Value.(*apiv2.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv2.NetworkPolicy).Spec.Types[0]).To(Equal(apiv2.PolicyTypeIngress))
 	})
 })
 

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -152,6 +152,12 @@ func NewKubeClient(kc *apiconfig.KubeConfig) (api.Client, error) {
 	kubeClient.registerResourceClient(
 		reflect.TypeOf(model.ResourceKey{}),
 		reflect.TypeOf(model.ResourceListOptions{}),
+		apiv2.KindNetworkPolicy,
+		resources.NewNetworkPolicyClient(cs, crdClientV1),
+	)
+	kubeClient.registerResourceClient(
+		reflect.TypeOf(model.ResourceKey{}),
+		reflect.TypeOf(model.ResourceListOptions{}),
 		apiv2.KindBGPPeer,
 		resources.NewBGPPeerClient(cs, crdClientV1),
 	)
@@ -358,6 +364,8 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 				&apiv2.ClusterInformationList{},
 				&apiv2.GlobalNetworkPolicy{},
 				&apiv2.GlobalNetworkPolicyList{},
+				&apiv2.NetworkPolicy{},
+				&apiv2.NetworkPolicyList{},
 			)
 			return nil
 		})

--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -1,0 +1,294 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+
+	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	NetworkPolicyResourceName = "NetworkPolicies"
+	NetworkPolicyCRDName      = "networkpolicies.crd.projectcalico.org"
+)
+
+func NewNetworkPolicyClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	crdClient := &customK8sResourceClient{
+		restClient:      r,
+		name:            NetworkPolicyCRDName,
+		resource:        NetworkPolicyResourceName,
+		description:     "Calico Network Policies",
+		k8sResourceType: reflect.TypeOf(apiv2.NetworkPolicy{}),
+		k8sListType:     reflect.TypeOf(apiv2.NetworkPolicyList{}),
+		converter:       NetworkPolicyConverter{},
+		namespaced:      true,
+	}
+	return &networkPolicyClient{
+		clientSet: c,
+		crdClient: crdClient,
+		converter: conversion.Converter{},
+	}
+}
+
+// Implements the api.Client interface for NetworkPolicys.
+type networkPolicyClient struct {
+	clientSet *kubernetes.Clientset
+	crdClient *customK8sResourceClient
+	converter conversion.Converter
+}
+
+func (c *networkPolicyClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Debug("Received Create request on NetworkPolicy type")
+	key := kvp.Key.(model.ResourceKey)
+	if strings.HasPrefix(key.Name, "knp.default.") {
+		// We don't support Create of a Kubernetes NetworkPolicy.
+		return nil, cerrors.ErrorOperationNotSupported{
+			Identifier: kvp.Key,
+			Operation:  "Create",
+		}
+	}
+	return c.crdClient.Create(ctx, kvp)
+}
+
+func (c *networkPolicyClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Debug("Received Update request on NetworkPolicy type")
+	key := kvp.Key.(model.ResourceKey)
+	if strings.HasPrefix(key.Name, "knp.default.") {
+		// We don't support Update of a Kubernetes NetworkPolicy.
+		return nil, cerrors.ErrorOperationNotSupported{
+			Identifier: kvp.Key,
+			Operation:  "Update",
+		}
+	}
+	return c.crdClient.Update(ctx, kvp)
+}
+
+func (c *networkPolicyClient) Apply(kvp *model.KVPair) (*model.KVPair, error) {
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "Apply",
+	}
+}
+
+func (c *networkPolicyClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	log.Debug("Received Delete request on NetworkPolicy type")
+	k := key.(model.ResourceKey)
+	if strings.HasPrefix(k.Name, "knp.default.") {
+		// We don't support Delete of a Kubernetes NetworkPolicy.
+		return nil, cerrors.ErrorOperationNotSupported{
+			Identifier: key,
+			Operation:  "Delete",
+		}
+	}
+	return c.crdClient.Delete(ctx, key, revision)
+}
+
+func (c *networkPolicyClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	log.Debug("Received Get request on NetworkPolicy type")
+	k := key.(model.ResourceKey)
+	if k.Name == "" {
+		return nil, errors.New("Missing policy name")
+	}
+
+	// Check to see if this is backed by a NetworkPolicy.
+	if strings.HasPrefix(k.Name, "knp.default.") {
+		// Backed by a NetworkPolicy. Parse out the namespace / name.
+		namespace, policyName, err := c.converter.ParsePolicyNameNetworkPolicy(k.Name)
+		if err != nil {
+			return nil, cerrors.ErrorResourceDoesNotExist{Err: err, Identifier: k}
+		}
+
+		// Get the NetworkPolicy from the API and convert it.
+		networkPolicy := extensions.NetworkPolicy{}
+		err = c.clientSet.Extensions().RESTClient().
+			Get().
+			Resource("networkpolicies").
+			Namespace(namespace).
+			Name(policyName).
+			Timeout(10 * time.Second).
+			Do().Into(&networkPolicy)
+		if err != nil {
+			return nil, K8sErrorToCalico(err, k)
+		}
+		return c.converter.K8sNetworkPolicyToCalico(&networkPolicy)
+	} else {
+		return c.crdClient.Get(ctx, k, revision)
+	}
+}
+
+func (c *networkPolicyClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	log.Debug("Received List request on NetworkPolicy type")
+	l := list.(model.ResourceListOptions)
+	if l.Name != "" {
+		// Exact lookup on a NetworkPolicy.
+		kvp, err := c.Get(ctx, model.ResourceKey{Name: l.Name, Namespace: l.Namespace, Kind: l.Kind}, revision)
+		if err != nil {
+			// Return empty slice of KVPair if the object doesn't exist, return the error otherwise.
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+				return &model.KVPairList{
+					KVPairs:  []*model.KVPair{},
+					Revision: revision,
+				}, nil
+			} else {
+				return nil, err
+			}
+		}
+
+		return &model.KVPairList{
+			KVPairs:  []*model.KVPair{kvp},
+			Revision: revision,
+		}, nil
+	}
+
+	// Otherwise, list all NetworkPolicy objects in all Namespaces.
+	networkPolicies := extensions.NetworkPolicyList{}
+	err := c.clientSet.Extensions().RESTClient().
+		Get().
+		Resource("networkpolicies").
+		Timeout(10 * time.Second).
+		Do().Into(&networkPolicies)
+	if err != nil {
+		return nil, K8sErrorToCalico(err, l)
+	}
+
+	// For each policy, turn it into a Policy and generate the list.
+	ret := []*model.KVPair{}
+	for _, p := range networkPolicies.Items {
+		kvp, err := c.converter.K8sNetworkPolicyToCalico(&p)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, kvp)
+	}
+
+	// List all Namespaced Calico Network Policies.
+	nps, err := c.crdClient.List(ctx, l, revision)
+	if err != nil {
+		return nil, err
+	}
+	ret = append(ret, nps.KVPairs...)
+
+	return &model.KVPairList{
+		KVPairs:  ret,
+		Revision: revision,
+	}, nil
+}
+
+func (c *networkPolicyClient) EnsureInitialized() error {
+	return nil
+}
+
+func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+	// TODO(doublek): We are only watching k8s backed NetworkPolicy. Will need to add
+	// the ability to watch both CRD and k8s NetworkPolicy.
+	resl := list.(model.ResourceListOptions)
+	if len(resl.Name) != 0 {
+		return nil, fmt.Errorf("cannot watch specific resource instance: %s", list.(model.ResourceListOptions).Name)
+	}
+
+	k8sWatchClient := cache.NewListWatchFromClient(
+		c.clientSet.ExtensionsV1beta1().RESTClient(),
+		"networkpolicies",
+		resl.Namespace,
+		fields.Everything())
+	k8sWatch, err := k8sWatchClient.WatchFunc(metav1.ListOptions{ResourceVersion: revision})
+	if err != nil {
+		return nil, K8sErrorToCalico(err, list)
+	}
+	converter := func(r Resource) (*model.KVPair, error) {
+		np, ok := r.(*extensions.NetworkPolicy)
+		if !ok {
+			return nil, errors.New("NetworkPolicy conversion with incorrect k8s resource type")
+		}
+		return c.converter.K8sNetworkPolicyToCalico(np)
+	}
+	return newK8sWatcherConverter(ctx, converter, k8sWatch), nil
+	// return c.crdClient.Watch(ctx, list, revision)
+}
+
+// NetworkPolicyConverter implements the K8sResourceConverter interface.
+type NetworkPolicyConverter struct {
+}
+
+func (_ NetworkPolicyConverter) ListInterfaceToKey(l model.ListInterface) model.Key {
+	pl := l.(model.ResourceListOptions)
+	if pl.Name != "" {
+		return model.ResourceKey{Name: pl.Name, Kind: pl.Kind, Namespace: pl.Namespace}
+	}
+	return nil
+}
+
+func (_ NetworkPolicyConverter) KeyToName(k model.Key) (string, error) {
+	return k.(model.ResourceKey).Name, nil
+}
+
+func (_ NetworkPolicyConverter) NameToKey(name string) (model.Key, error) {
+	return model.ResourceKey{
+		Name: name,
+		Kind: apiv2.KindNetworkPolicy,
+	}, nil
+}
+
+func (c NetworkPolicyConverter) ToKVPair(r Resource) (*model.KVPair, error) {
+	t := r.(*apiv2.NetworkPolicy)
+
+	// Clear any CRD TypeMeta fields and then create a KVPair.
+	conf := apiv2.NewNetworkPolicy()
+	conf.ObjectMeta.Name = t.ObjectMeta.Name
+	conf.ObjectMeta.Namespace = t.ObjectMeta.Namespace
+	conf.Spec = t.Spec
+	return &model.KVPair{
+		Key: model.ResourceKey{
+			Name:      t.ObjectMeta.Name,
+			Namespace: t.ObjectMeta.Namespace,
+			Kind:      apiv2.KindNetworkPolicy,
+		},
+		Value:    conf,
+		Revision: t.ObjectMeta.ResourceVersion,
+	}, nil
+}
+
+func (c NetworkPolicyConverter) FromKVPair(kvp *model.KVPair) (Resource, error) {
+	v := kvp.Value.(*apiv2.NetworkPolicy)
+
+	crd := apiv2.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            v.ObjectMeta.Name,
+			Namespace:       v.ObjectMeta.Namespace,
+			ResourceVersion: kvp.Revision,
+		},
+		Spec: v.Spec,
+	}
+	return &crd, nil
+}

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"time"
 
+	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/compat"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	log "github.com/sirupsen/logrus"
 
 	k8sapi "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
-	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
-	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
@@ -678,7 +678,7 @@ func (syn *kubeSyncer) performSnapshot(versions *resourceVersions) (map[string][
 
 			versions.networkPolicyVersion = npList.ListMeta.ResourceVersion
 			for _, np := range npList.Items {
-				pol, _ := syn.converter.NetworkPolicyToPolicy(&np)
+				pol, _ := syn.converter.K8sNetworkPolicyToCalico(&np)
 				snap[KEY_NP] = append(snap[KEY_NP], *pol)
 				keys[KEY_NP][pol.Key.String()] = true
 			}
@@ -1023,7 +1023,7 @@ func (syn *kubeSyncer) parseNetworkPolicyEvent(e watch.Event) *model.KVPair {
 	}
 
 	// Convert the received NetworkPolicy into a profile KVPair.
-	kvp, err := syn.converter.NetworkPolicyToPolicy(np)
+	kvp, err := syn.converter.K8sNetworkPolicyToCalico(np)
 	if err != nil {
 		log.Panicf("%s", err)
 	}

--- a/test/README.md
+++ b/test/README.md
@@ -11,11 +11,16 @@ crds.yaml creates the following CRDs:
   - IPPool
   - GlobalNetworkPolicy
   - ClusterInfo
+  - NetworkPolicy
 
 These CRDs must be created in advance for any Calico deployment with Kubernetes backend,
 typically as part of the same manifest used to setup Calico.
 
-
 ## Create Mock Nodes
 
 mock-node.yaml creates mock node object for the tests.
+
+## Create Namespaces
+
+`NetworkPolicy` CRD is a Namespace scoped resource and requires some Kubernetes Namespaces
+to exists before it can be used so.

--- a/test/crds.yaml
+++ b/test/crds.yaml
@@ -1,3 +1,4 @@
+---
 kind: List
 metadata:
 apiVersion: v1
@@ -109,3 +110,16 @@ items:
       kind: ClusterInformation
       plural: clusterinformations
       singular: clusterinformation
+- apiVersion: apiextensions.k8s.io/v1beta1
+  description: Calico Network Policies
+  kind: CustomResourceDefinition
+  metadata:
+    name: networkpolicies.crd.projectcalico.org
+  spec:
+    scope: Namespaced
+    group: crd.projectcalico.org
+    version: v1
+    names:
+      kind: NetworkPolicy
+      plural: networkpolicies
+      singular: networkpolicy

--- a/test/namespaces.yaml
+++ b/test/namespaces.yaml
@@ -1,0 +1,13 @@
+# Create namespaces required for namespaced NetworkPolicy tests.
+kind: List
+metadata:
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: namespace-1
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: namespace-2


### PR DESCRIPTION
## Description
This PR fixes NetworkPolicy support for the v2 client when using a Kubernetes backend.

- Creates and uses a new CRD: `NetworkPolicy`.
- Create/Update/Delete works with this new CRD.
- Get/List will combine the CRD backed NetworkPolicy with K8s NetworkPolicy.

Combined Watcher for K8s backed Network Policy and CRD backed Network Policy will be done as a separate PR. This PR only implements the NetworkPolicy watcher for k8s backed NetworkPolicy.

## Todos
- [x] Scope of NetworkPolicy CRD - Namespace vs Cluster scoped.
- [x] Tests


## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
