### PR TITLE
Port named ports to the v2 datamodel.

### DIFF
--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -156,20 +156,19 @@ var _ = Describe("Test Pod conversion", func() {
 		expectedLabels := map[string]string{"labelA": "valueA", "labelB": "valueB", "calico/k8s_ns": "default"}
 		Expect(wep.Value.(*apiv2.WorkloadEndpoint).ObjectMeta.Labels).To(Equal(expectedLabels))
 
-		// TODO(doublek): Named ports?
-		//nsProtoTCP := numorstring.ProtocolFromString("tcp")
-		//nsProtoUDP := numorstring.ProtocolFromString("udp")
-		//Expect(wep.Value.(*model.WorkloadEndpoint).Ports).To(ConsistOf(
-		//	// No proto defaults to TCP (as defined in k8s API spec)
-		//	model.EndpointPort{Name: "no-proto", Port: 1234, Protocol: nsProtoTCP},
-		//	// Explicit TCP proto is OK too.
-		//	model.EndpointPort{Name: "tcp-proto", Port: 1024, Protocol: nsProtoTCP},
-		//	// Host port should be ignored.
-		//	model.EndpointPort{Name: "tcp-proto-with-host-port", Port: 8080, Protocol: nsProtoTCP},
-		//	// UDP is also an option.
-		//	model.EndpointPort{Name: "udp-proto", Port: 432, Protocol: nsProtoUDP},
-		//	// Unknown protocol port is ignored.
-		//))
+		nsProtoTCP := numorstring.ProtocolFromString("tcp")
+		nsProtoUDP := numorstring.ProtocolFromString("udp")
+		Expect(wep.Value.(*apiv2.WorkloadEndpoint).Spec.Ports).To(ConsistOf(
+			// No proto defaults to TCP (as defined in k8s API spec)
+			apiv2.EndpointPort{Name: "no-proto", Port: 1234, Protocol: nsProtoTCP},
+			// Explicit TCP proto is OK too.
+			apiv2.EndpointPort{Name: "tcp-proto", Port: 1024, Protocol: nsProtoTCP},
+			// Host port should be ignored.
+			apiv2.EndpointPort{Name: "tcp-proto-with-host-port", Port: 8080, Protocol: nsProtoTCP},
+			// UDP is also an option.
+			apiv2.EndpointPort{Name: "udp-proto", Port: 432, Protocol: nsProtoUDP},
+			// Unknown protocol port is ignored.
+		))
 
 		// Assert ResourceVersion is present.
 		Expect(wep.Revision).To(Equal("1234"))

--- a/lib/clientv2/hostendpoint_e2e_test.go
+++ b/lib/clientv2/hostendpoint_e2e_test.go
@@ -28,6 +28,7 @@ import (
 	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
 	"github.com/projectcalico/libcalico-go/lib/backend"
 	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 	"github.com/projectcalico/libcalico-go/lib/watch"
@@ -41,10 +42,29 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 	spec1 := apiv2.HostEndpointSpec{
 		Node:          "node1",
 		InterfaceName: "eth0",
+		Ports: []apiv2.EndpointPort{
+			{
+				Port:     1234,
+				Name:     "foobar",
+				Protocol: numorstring.ProtocolFromString("tcp"),
+			},
+			{
+				Port:     5432,
+				Name:     "bop",
+				Protocol: numorstring.ProtocolFromString("tcp"),
+			},
+		},
 	}
 	spec2 := apiv2.HostEndpointSpec{
 		Node:          "node2",
 		InterfaceName: "eth1",
+		Ports: []apiv2.EndpointPort{
+			{
+				Port:     5678,
+				Name:     "bazzbiff",
+				Protocol: numorstring.ProtocolFromString("udp"),
+			},
+		},
 	}
 
 	DescribeTable("HostEndpoint e2e CRUD tests",

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -28,6 +28,7 @@ import (
 	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
 	"github.com/projectcalico/libcalico-go/lib/backend"
 	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 	"github.com/projectcalico/libcalico-go/lib/watch"
@@ -48,6 +49,18 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 		ContainerID:   "a12345a",
 		Endpoint:      "eth0",
 		InterfaceName: "cali09123",
+		Ports: []apiv2.EndpointPort{
+			{
+				Port:     1234,
+				Name:     "foobar",
+				Protocol: numorstring.ProtocolFromString("tcp"),
+			},
+			{
+				Port:     5432,
+				Name:     "bop",
+				Protocol: numorstring.ProtocolFromString("tcp"),
+			},
+		},
 	}
 	spec1_2 := apiv2.WorkloadEndpointSpec{
 		Node:          "node-1",
@@ -56,6 +69,13 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 		ContainerID:   "a12345a",
 		Endpoint:      "eth0",
 		InterfaceName: "foobar",
+		Ports: []apiv2.EndpointPort{
+			{
+				Port:     5678,
+				Name:     "bazzbiff",
+				Protocol: numorstring.ProtocolFromString("udp"),
+			},
+		},
 	}
 	spec2_1 := apiv2.WorkloadEndpointSpec{
 		Node:          "node-2",
@@ -528,7 +548,6 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
-
 
 	Describe("WorkloadEndpoint names based on primary identifiers in Spec", func() {
 		It("should handle prefix lists of workload endpoints", func() {

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -17,6 +17,7 @@ package testutils
 import (
 	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	"github.com/sirupsen/logrus"
 )
 
 var ipv4 = 4
@@ -24,6 +25,18 @@ var ipv6 = 6
 var strProtocol1 = numorstring.ProtocolFromString("icmp")
 var strProtocol2 = numorstring.ProtocolFromString("udp")
 var numProtocol1 = numorstring.ProtocolFromInt(240)
+
+var portRange, singlePort, namedPort numorstring.Port
+
+func init() {
+	var err error
+	portRange, err = numorstring.PortFromRange(10, 20)
+	if err != nil {
+		logrus.WithError(err).Panic("Failed to create port range")
+	}
+	singlePort = numorstring.SinglePort(1024)
+	namedPort = numorstring.NamedPort("named-port")
+}
 
 var icmpType1 = 100
 var icmpCode1 = 200
@@ -47,6 +60,11 @@ var InRule1 = apiv2.Rule{
 		Tag:      "tag1",
 		Nets:     []string{cidr1},
 		Selector: "label1 == 'value1'",
+		Ports: []numorstring.Port{
+			portRange,
+			singlePort,
+			namedPort,
+		},
 	},
 }
 


### PR DESCRIPTION
## Description
Add named ports to the v2->backend conversion and port tests to v2 API.  (The struct definitions had already been ported across in one of the general merges).

## Todos
- [x] Tests
- [x] Documentation (will be handled as part of the general v2 changes)
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
