### PR TITLE
Update k8s version used for testing to v1.8.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ default: all
 all: test
 test: ut
 
-K8S_VERSION=v1.8.0-beta.1
-KUBECTL_VERSION=v1.7.3
+K8S_VERSION=v1.8.1
 CALICO_BUILD?=calico/go-build
 PACKAGE_NAME?=projectcalico/libcalico-go
 LOCAL_USER_ID?=$(shell id -u $$USER)
@@ -84,7 +83,7 @@ run-kubernetes-master: stop-kubernetes-master
 	    --net=host \
 	    --rm \
 		-v  $(CURDIR):/manifests \
-		lachlanevenson/k8s-kubectl:${KUBECTL_VERSION} \
+		lachlanevenson/k8s-kubectl:${K8S_VERSION} \
 		--server=http://127.0.0.1:8080 \
 		apply -f manifests/test/crds.yaml
 
@@ -93,7 +92,7 @@ run-kubernetes-master: stop-kubernetes-master
 	    --net=host \
 	    --rm \
 		-v  $(CURDIR):/manifests \
-		lachlanevenson/k8s-kubectl:${KUBECTL_VERSION} \
+		lachlanevenson/k8s-kubectl:${K8S_VERSION} \
 		--server=http://127.0.0.1:8080 \
 		apply -f manifests/test/mock-node.yaml
 


### PR DESCRIPTION
## Description
Update k8s version used for testing to v1.8.1. I added KUBECTL_VERSION variable while merging egress rule support. Now that `lachlanevenson/k8s-kubectl` publishes a tag for v1.8.1, we no longer need a separate KUBECTL_VERSION variable.

## Todos
- [X] Tests

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
