### PR TITLE
Fix workload endpoints in KDD mode

### DIFF
--- a/lib/backend/k8s/conversion/conversion_suite_test.go
+++ b/lib/backend/k8s/conversion/conversion_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversion_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestConversion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conversion Suite")
+}

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -128,12 +128,12 @@ func NewKubeClient(kc *apiconfig.KubeConfig) (api.Client, error) {
 	}
 
 	kubeClient := &KubeClient{
-		clientSet:               cs,
-		crdClientV1:             crdClientV1,
-		disableNodePoll:         kc.K8sDisableNodePoll,
+		clientSet:             cs,
+		crdClientV1:           crdClientV1,
+		disableNodePoll:       kc.K8sDisableNodePoll,
 		clientsByResourceKind: make(map[string]resources.K8sResourceClient),
-		clientsByKeyType: make(map[reflect.Type]resources.K8sResourceClient),
-		clientsByListType: make(map[reflect.Type]resources.K8sResourceClient),
+		clientsByKeyType:      make(map[reflect.Type]resources.K8sResourceClient),
+		clientsByListType:     make(map[reflect.Type]resources.K8sResourceClient),
 	}
 
 	// Create the Calico sub-clients and register them.
@@ -184,6 +184,12 @@ func NewKubeClient(kc *apiconfig.KubeConfig) (api.Client, error) {
 		reflect.TypeOf(model.ResourceListOptions{}),
 		apiv2.KindProfile,
 		resources.NewProfileClient(cs),
+	)
+	kubeClient.registerResourceClient(
+		reflect.TypeOf(model.ResourceKey{}),
+		reflect.TypeOf(model.ResourceListOptions{}),
+		apiv2.KindWorkloadEndpoint,
+		resources.NewWorkloadEndpointClient(cs),
 	)
 	kubeClient.registerResourceClient(
 		reflect.TypeOf(model.BlockAffinityKey{}),

--- a/lib/names/workloadendpoint_test.go
+++ b/lib/names/workloadendpoint_test.go
@@ -196,3 +196,47 @@ var _ = DescribeTable("WorkloadEndpoint name matching",
 		Endpoint:     "eth0",
 	}, "node--1-k8s-pod-eth0-extra", false, ""),
 )
+
+var _ = DescribeTable("WorkloadEndpoint name parsing",
+	func(name string, expectError bool, expectedWeid names.WorkloadEndpointIdentifiers) {
+		weid, err := names.ParseWorkloadEndpointName(name)
+		if expectError {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(weid).To(Equal(expectedWeid))
+		}
+	},
+	Entry("Empty string", "", true, names.WorkloadEndpointIdentifiers{}),
+	Entry("Fully populated k8s wep name", "node-k8s-pod-eth0", false, names.WorkloadEndpointIdentifiers{
+		Node:         "node",
+		Orchestrator: "k8s",
+		Pod:          "pod",
+		Endpoint:     "eth0",
+	}),
+	Entry("K8s prefix match with only node", "node-", false, names.WorkloadEndpointIdentifiers{
+		Node: "node",
+	}),
+	Entry("K8s prefix match with node and pod", "node-k8s-pod--name-", false, names.WorkloadEndpointIdentifiers{
+		Node:         "node",
+		Orchestrator: "k8s",
+		Pod:          "pod-name",
+	}),
+	Entry("Fully populated cni", "node-cni-xyz-eth0", false, names.WorkloadEndpointIdentifiers{
+		Node:         "node",
+		Orchestrator: "cni",
+		ContainerID:  "xyz",
+		Endpoint:     "eth0",
+	}),
+	Entry("Fully populated libnetwork", "node-libnetwork-libnetwork-eth0", false, names.WorkloadEndpointIdentifiers{
+		Node:         "node",
+		Orchestrator: "libnetwork",
+		Endpoint:     "eth0",
+	}),
+	Entry("Fully populated other orchestrators", "node-foo--orch-workload-eth0", false, names.WorkloadEndpointIdentifiers{
+		Node:         "node",
+		Orchestrator: "foo-orch",
+		Workload:     "workload",
+		Endpoint:     "eth0",
+	}),
+)


### PR DESCRIPTION
## Description

Adds and fixes support for WorkloadEndpoints. 

- Adds Get/List support.
- Fixes WEP name parsing
- Adds watcher boilerplate

The thing that I am not 100% sure is this: earlier we used on `Apply()`, we used to patch the k8s `Pod` with an IP address. I've put this as part of the `Update` call.

## Todos
- [ ] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
