### PR TITLE
Add the logic to set UID and Creation Time on the resources, add storage prefixes on policies, and store Calico metadata in the K8s annotations.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -142,7 +142,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: dcabb60a477c2b6f456df65037cb6708210fbb02
+  version: c893efa28eb45626cdaa76c9f653b62488858837
   subpackages:
   - format
   - internal/assertion
@@ -155,6 +155,8 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/projectcalico/go-json
@@ -198,7 +200,7 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -226,7 +228,6 @@ imports:
   version: e48874b42435b4347fc52bdee0424a52abc974d7
   subpackages:
   - unix
-  - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
@@ -351,6 +352,7 @@ imports:
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -85,6 +85,7 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 func (c *etcdV3Client) Create(ctx context.Context, d *model.KVPair) (*model.KVPair, error) {
 	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
 	logCxt.Debug("Processing Create request")
+
 	key, value, err := getKeyValueStrings(d)
 	if err != nil {
 		return nil, err

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -1271,8 +1271,13 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			updFC, err = c.Create(ctx, fc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updFC.Key.(model.ResourceKey).Name).To(Equal("myfelixconfig"))
+			// Set the ResourceVersion (since it is auto populated by the Kubernetes datastore) to make it easier to compare objects.
+			Expect(fc.Value.(*capiv2.FelixConfiguration).GetObjectMeta().GetResourceVersion()).To(Equal(""))
+			fc.Value.(*capiv2.FelixConfiguration).GetObjectMeta().SetResourceVersion(updFC.Value.(*capiv2.FelixConfiguration).GetObjectMeta().GetResourceVersion())
 			Expect(updFC.Value.(*capiv2.FelixConfiguration)).To(Equal(fc.Value.(*capiv2.FelixConfiguration)))
 			Expect(updFC.Revision).NotTo(BeNil())
+			// Unset the ResourceVersion for the original resource since we modified it just for the sake of comparing in the tests.
+			fc.Value.(*capiv2.FelixConfiguration).GetObjectMeta().SetResourceVersion("")
 		})
 
 		By("getting an existing object", func() {

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -135,6 +135,7 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 					IPv6Address: "aa:bb::cc/120",
 				}
 				node, err = c.Nodes().Update(ctx, node, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
 
 				// This will add two network entries, and the existing two IP entries will be
 				// updated.

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -116,6 +116,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 					IPv6Address: "aa:bb::cc/120",
 				}
 				node, err = c.Nodes().Update(ctx, node, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
 			} else {
 				// For non-Kubernetes, add a new node with valid BGP configuration.
 				By("Creating a node with an IP address")

--- a/lib/backend/watchersyncer/watchercache.go
+++ b/lib/backend/watchersyncer/watchercache.go
@@ -52,7 +52,7 @@ var (
 
 // cacheEntry is an entry in our cache.  It groups the a key with the last known
 // revision that we processed.  We store the revision so that we can determine
-// if an entry has been updated (adn therefore whether we need to send an update
+// if an entry has been updated (and therefore whether we need to send an update
 // event in the syncer callback).
 type cacheEntry struct {
 	revision string

--- a/lib/clientv2/clusterinfo_e2e_test.go
+++ b/lib/clientv2/clusterinfo_e2e_test.go
@@ -57,7 +57,7 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 
 			By("Updating the ClusterInformation before it is created")
 			_, outError := c.ClusterInformation().Update(ctx, &apiv2.ClusterInformation{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-clusterinfo"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -120,6 +120,24 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 			res1, outError = c.ClusterInformation().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindClusterInformation, testutils.ExpectNoNamespace, name, spec2)
+
+			By("Attempting to update the ClusterInformation without a Creation Timestamp")
+			res, outError = c.ClusterInformation().Update(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: "test-fail-clusterinfo"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the ClusterInformation without a UID")
+			res, outError = c.ClusterInformation().Update(ctx, &apiv2.ClusterInformation{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
 
 			// Track the version of the updated name data.
 			rv1_2 := res1.ResourceVersion

--- a/lib/clientv2/felixconfig_e2e_test.go
+++ b/lib/clientv2/felixconfig_e2e_test.go
@@ -64,7 +64,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 
 			By("Updating the FelixConfiguration before it is created")
 			_, outError := c.FelixConfigurations().Update(ctx, &apiv2.FelixConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-felixconfig"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -140,6 +140,24 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 			res1, outError = c.FelixConfigurations().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindFelixConfiguration, testutils.ExpectNoNamespace, name1, spec2)
+
+			By("Attempting to update the FelixConfiguration without a Creation Timestamp")
+			res, outError = c.FelixConfigurations().Update(ctx, &apiv2.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-felixconfig"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the FelixConfiguration without a UID")
+			res, outError = c.FelixConfigurations().Update(ctx, &apiv2.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
 
 			// Track the version of the updated name1 data.
 			rv1_2 := res1.ResourceVersion

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -82,11 +82,11 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 
 			By("Updating the GlobalNetworkPolicy before it is created")
 			_, outError := c.GlobalNetworkPolicies().Update(ctx, &apiv2.GlobalNetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-globalnetworkpolicy"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name1 + ")"))
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name1 + ")"))
 
 			By("Attempting to creating a new GlobalNetworkPolicy with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
@@ -114,7 +114,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				Spec:       spec2,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource already exists: GlobalNetworkPolicy(" + name1 + ")"))
+			Expect(outError.Error()).To(Equal("resource already exists: GlobalNetworkPolicy(default." + name1 + ")"))
 
 			By("Getting GlobalNetworkPolicy (name1) and comparing the output against spec1")
 			res, outError := c.GlobalNetworkPolicies().Get(ctx, name1, options.GetOptions{})
@@ -125,7 +125,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			By("Getting GlobalNetworkPolicy (name2) before it is created")
 			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
 
 			By("Listing all the GlobalNetworkPolicies, expecting a single result with name1/spec1")
 			outList, outError := c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
@@ -161,6 +161,24 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindGlobalNetworkPolicy, testutils.ExpectNoNamespace, name1, spec2)
 
+			By("Attempting to update the GlobalNetworkPolicy without a Creation Timestamp")
+			res, outError = c.GlobalNetworkPolicies().Update(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-globalnetworkpolicy"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the GlobalNetworkPolicy without a UID")
+			res, outError = c.GlobalNetworkPolicies().Update(ctx, &apiv2.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
+
 			// Track the version of the updated name1 data.
 			rv1_2 := res1.ResourceVersion
 
@@ -176,7 +194,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			res1.ResourceVersion = rv1_1
 			_, outError = c.GlobalNetworkPolicies().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(" + name1 + ")"))
+			Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(default." + name1 + ")"))
 
 			if config.Spec.DatastoreType != apiconfig.Kubernetes {
 				By("Getting GlobalNetworkPolicy (name1) with the original resource version and comparing the output against spec1")
@@ -211,7 +229,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				By("Deleting GlobalNetworkPolicy (name1) with the old resource version")
 				_, outError = c.GlobalNetworkPolicies().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(" + name1 + ")"))
+				Expect(outError.Error()).To(Equal("update conflict: GlobalNetworkPolicy(default." + name1 + ")"))
 			}
 
 			By("Deleting GlobalNetworkPolicy (name1) with the new resource version")
@@ -229,7 +247,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				time.Sleep(2 * time.Second)
 				_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
 
 				By("Creating GlobalNetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.GlobalNetworkPolicies().Create(ctx, &apiv2.GlobalNetworkPolicy{
@@ -243,20 +261,20 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				time.Sleep(2 * time.Second)
 				_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
-				By("Attempting to deleting GlobalNetworkPolicy (name2) again")
+				By("Deleting GlobalNetworkPolicy (name2) for KDD that does not support TTL")
 				dres, outError = c.GlobalNetworkPolicies().Delete(ctx, name2, options.DeleteOptions{})
 				Expect(outError).NotTo(HaveOccurred())
 				testutils.ExpectResource(dres, apiv2.KindGlobalNetworkPolicy, testutils.ExpectNoNamespace, name2, spec2)
 			}
 
-			By("Attempting to deleting GlobalNetworkPolicy (name2) again")
+			By("Attempting to delete GlobalNetworkPolicy (name2) again")
 			_, outError = c.GlobalNetworkPolicies().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
 
 			By("Listing all GlobalNetworkPolicies and expecting no items")
 			outList, outError = c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
@@ -266,7 +284,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			By("Getting GlobalNetworkPolicy (name2) and expecting an error")
 			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(" + name2 + ")"))
+			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
 		},
 
 		// Pass two fully populated GlobalNetworkPolicySpecs and expect the series of operations to succeed.
@@ -302,6 +320,8 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				options.SetOptions{},
 			)
 			rev1 := outRes1.ResourceVersion
+			// Update the name to reflect the underlying data returned from the watcher
+			outRes1.GetObjectMeta().SetName("default." + name1)
 
 			By("Configuring a GlobalNetworkPolicy name2/spec2 and storing the response")
 			outRes2, err := c.GlobalNetworkPolicies().Create(
@@ -312,6 +332,8 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				},
 				options.SetOptions{},
 			)
+			// Update the name to reflect the underlying data returned from the watcher
+			outRes2.GetObjectMeta().SetName("default." + name2)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
 			w, err := c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
@@ -343,6 +365,8 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
+			// Update the name to reflect the name that would be passed in from calicoctl
+			outRes2.GetObjectMeta().SetName(name2)
 			outRes3, err := c.GlobalNetworkPolicies().Update(
 				ctx,
 				&apiv2.GlobalNetworkPolicy{
@@ -352,6 +376,9 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				options.SetOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())
+			// Update the name to reflect the underlying data returned from the watcher
+			outRes2.GetObjectMeta().SetName("default." + name2)
+			outRes3.GetObjectMeta().SetName("default." + name2)
 			testWatcher2.ExpectEvents(apiv2.KindGlobalNetworkPolicy, []watch.Event{
 				{
 					Type:   watch.Added,
@@ -376,7 +403,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			// Only etcdv3 supports watching a specific instance of a resource.
 			if config.Spec.DatastoreType == apiconfig.EtcdV3 {
 				By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
-				w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+				w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{Name: "default." + name1, ResourceVersion: rev0})
 				Expect(err).NotTo(HaveOccurred())
 				testWatcher2_1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
 				defer testWatcher2_1.Stop()
@@ -415,6 +442,8 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				},
 				options.SetOptions{},
 			)
+			// Update the name to reflect the underlying data returned from the watcher
+			outRes1.GetObjectMeta().SetName("default." + name1)
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{})

--- a/lib/clientv2/ippool_e2e_test.go
+++ b/lib/clientv2/ippool_e2e_test.go
@@ -69,7 +69,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 
 			By("Updating the IPPool before it is created")
 			_, outError := c.IPPools().Update(ctx, &apiv2.IPPool{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-ippool"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -145,6 +145,24 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			res1, outError = c.IPPools().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindIPPool, testutils.ExpectNoNamespace, name1, spec1_2)
+
+			By("Attempting to update the IPPool without a Creation Timestamp")
+			res, outError = c.IPPools().Update(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-ippool"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the IPPool without a UID")
+			res, outError = c.IPPools().Update(ctx, &apiv2.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
 
 			// Track the version of the updated name1 data.
 			rv1_2 := res1.ResourceVersion

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -61,7 +61,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 
 			By("Updating the Node before it is created")
 			_, outError := c.Nodes().Update(ctx, &apiv2.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-node"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -137,6 +137,24 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 			res1, outError = c.Nodes().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindNode, testutils.ExpectNoNamespace, name1, spec2)
+
+			By("Attempting to update the Node without a Creation Timestamp")
+			res, outError = c.Nodes().Update(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-workload-endpoint"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the Node without a UID")
+			res, outError = c.Nodes().Update(ctx, &apiv2.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
 
 			// Track the version of the updated name1 data.
 			rv1_2 := res1.ResourceVersion

--- a/lib/clientv2/profile_e2e_test.go
+++ b/lib/clientv2/profile_e2e_test.go
@@ -60,7 +60,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 
 			By("Updating the Profile before it is created")
 			_, outError := c.Profiles().Update(ctx, &apiv2.Profile{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-profile"},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -136,6 +136,24 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			res1, outError = c.Profiles().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindProfile, testutils.ExpectNoNamespace, name1, spec2)
+
+			By("Attempting to update the Profile without a Creation Timestamp")
+			res, outError = c.Profiles().Update(ctx, &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-profile"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the Profile without a UID")
+			res, outError = c.Profiles().Update(ctx, &apiv2.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
 
 			// Track the version of the updated name1 data.
 			rv1_2 := res1.ResourceVersion


### PR DESCRIPTION
## Description
Added the handling for UID and CreationTimestamp to be added to the resources. Also added logic for prefixing the names internally on policies as well as logic for storing Calico metadata in the K8s annotations field.

## Todos
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
