### PR TITLE
Default v2 PolicySpec.Types field similarly as for v1

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
@@ -67,24 +67,7 @@ func convertPolicyV2ToV1Spec(spec apiv2.PolicySpec) (interface{}, error) {
 		PreDNAT:       spec.PreDNAT,
 		Types:         policyTypesAPIV2ToBackend(spec.Types),
 	}
-	if len(spec.Types) == 0 {
-		// Default the Types field according to what inbound and outbound rules are present
-		// in the policy.
-		if len(spec.EgressRules) == 0 {
-			// Policy has no egress rules, so apply this policy to ingress only.  (Note:
-			// intentionally including the case where the policy also has no ingress
-			// rules.)
-			v1value.Types = []string{string(apiv2.PolicyTypeIngress)}
-		} else if len(spec.IngressRules) == 0 {
-			// Policy has egress rules but no ingress rules, so apply this policy to
-			// egress only.
-			v1value.Types = []string{string(apiv2.PolicyTypeEgress)}
-		} else {
-			// Policy has both ingress and egress rules, so apply this policy to both
-			// ingress and egress.
-			v1value.Types = []string{string(apiv2.PolicyTypeIngress), string(apiv2.PolicyTypeEgress)}
-		}
-	}
+
 	return v1value, nil
 }
 

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
@@ -67,7 +67,24 @@ func convertPolicyV2ToV1Spec(spec apiv2.PolicySpec) (interface{}, error) {
 		PreDNAT:       spec.PreDNAT,
 		Types:         policyTypesAPIV2ToBackend(spec.Types),
 	}
-
+	if len(spec.Types) == 0 {
+		// Default the Types field according to what inbound and outbound rules are present
+		// in the policy.
+		if len(spec.EgressRules) == 0 {
+			// Policy has no egress rules, so apply this policy to ingress only.  (Note:
+			// intentionally including the case where the policy also has no ingress
+			// rules.)
+			v1value.Types = []string{string(apiv2.PolicyTypeIngress)}
+		} else if len(spec.IngressRules) == 0 {
+			// Policy has egress rules but no ingress rules, so apply this policy to
+			// egress only.
+			v1value.Types = []string{string(apiv2.PolicyTypeEgress)}
+		} else {
+			// Policy has both ingress and egress rules, so apply this policy to both
+			// ingress and egress.
+			v1value.Types = []string{string(apiv2.PolicyTypeIngress), string(apiv2.PolicyTypeEgress)}
+		}
+	}
 	return v1value, nil
 }
 

--- a/lib/clientv2/globalnetworkpolicy.go
+++ b/lib/clientv2/globalnetworkpolicy.go
@@ -40,6 +40,7 @@ type globalnetworkpolicies struct {
 // Create takes the representation of a GlobalNetworkPolicy and creates it.  Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
 func (r globalnetworkpolicies) Create(ctx context.Context, res *apiv2.GlobalNetworkPolicy, opts options.SetOptions) (*apiv2.GlobalNetworkPolicy, error) {
+	r.defaultTypesField(res)
 	out, err := r.client.resources.Create(ctx, opts, apiv2.KindGlobalNetworkPolicy, res)
 	if out != nil {
 		return out.(*apiv2.GlobalNetworkPolicy), err
@@ -89,4 +90,25 @@ func (r globalnetworkpolicies) List(ctx context.Context, opts options.ListOption
 // supplied options.
 func (r globalnetworkpolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
 	return r.client.resources.Watch(ctx, opts, apiv2.KindGlobalNetworkPolicy)
+}
+
+func (r globalnetworkpolicies) defaultTypesField(res *apiv2.GlobalNetworkPolicy) {
+	if len(res.Spec.Types) == 0 {
+		// Default the Types field according to what inbound and outbound rules are present
+		// in the policy.
+		if len(res.Spec.EgressRules) == 0 {
+			// Policy has no egress rules, so apply this policy to ingress only.  (Note:
+			// intentionally including the case where the policy also has no ingress
+			// rules.)
+			res.Spec.Types = []apiv2.PolicyType{apiv2.PolicyTypeIngress}
+		} else if len(res.Spec.IngressRules) == 0 {
+			// Policy has egress rules but no ingress rules, so apply this policy to
+			// egress only.
+			res.Spec.Types = []apiv2.PolicyType{apiv2.PolicyTypeEgress}
+		} else {
+			// Policy has both ingress and egress rules, so apply this policy to both
+			// ingress and egress.
+			res.Spec.Types = []apiv2.PolicyType{apiv2.PolicyTypeIngress, apiv2.PolicyTypeEgress}
+		}
+	}
 }

--- a/lib/clientv2/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv2/globalnetworkpolicy_e2e_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/watch"
 )
 
+var ingressEgress = []apiv2.PolicyType{apiv2.PolicyTypeIngress, apiv2.PolicyTypeEgress}
+
 var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
 	ctx := context.Background()
@@ -55,7 +57,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 	}
 
 	DescribeTable("GlobalNetworkPolicy e2e CRUD tests",
-		func(name1, name2 string, spec1, spec2 apiv2.PolicySpec) {
+		func(name1, name2 string, spec1, spec2 apiv2.PolicySpec, types1, types2 []apiv2.PolicyType) {
 			c, err := clientv2.New(config)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -87,6 +89,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
+			spec1.Types = types1
 			testutils.ExpectResource(res1, apiv2.KindGlobalNetworkPolicy, testutils.ExpectNoNamespace, name1, spec1)
 
 			// Track the version of the original data for name1.
@@ -126,6 +129,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				Spec:       spec2,
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
+			spec2.Types = types2
 			testutils.ExpectResource(res2, apiv2.KindGlobalNetworkPolicy, testutils.ExpectNoNamespace, name2, spec2)
 
 			By("Getting GlobalNetworkPolicy (name2) and comparing the output against spec2")
@@ -258,7 +262,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 		},
 
 		// Test 1: Pass two fully populated GlobalNetworkPolicySpecs and expect the series of operations to succeed.
-		Entry("Two fully populated GlobalNetworkPolicySpecs", name1, name2, spec1, spec2),
+		Entry("Two fully populated GlobalNetworkPolicySpecs", name1, name2, spec1, spec2, ingressEgress, ingressEgress),
 	)
 
 	Describe("GlobalNetworkPolicy watch functionality", func() {


### PR DESCRIPTION
Default the Types field for v2 PolicySpec similarly as we do for v1 at https://github.com/projectcalico/libcalico-go/blob/master/lib/converter/policy.go#L60