### PR TITLE
Use ParseCIDROrIP so that we don't have to deal with IP strings directly

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -158,7 +158,7 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 	// a DELETE update will not include an IP.
 	ipNets := []string{}
 	if c.HasIPAddress(pod) {
-		_, ipNet, err := cnet.ParseCIDR(fmt.Sprintf("%s/32", pod.Status.PodIP))
+		_, ipNet, err := cnet.ParseCIDROrIP(pod.Status.PodIP)
 		if err != nil {
 			log.WithFields(log.Fields{"ip": pod.Status.PodIP, "pod": pod.Name}).WithError(err).Error("Failed to parse pod IP")
 			return nil, err


### PR DESCRIPTION
## Description
The previous use of `ParseCIDR` is error prone in some cases when the PodIP is a string already of the form "/32". `ParseCIDROrIP` works better here and takes care of the nitty gritty IP parsing within.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
