### PR TITLE
Pass the namespace when performing a Get with a pod Name

### DIFF
--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -122,8 +122,9 @@ func (c *WorkloadEndpointClient) List(ctx context.Context, list model.ListInterf
 	// workload endpoint.
 	if l.Name != "" {
 		kvp, err := c.Get(ctx, model.ResourceKey{
-			Name: l.Name,
-			Kind: l.Kind,
+			Name:      l.Name,
+			Namespace: l.Namespace,
+			Kind:      l.Kind,
 		}, revision)
 		if err != nil {
 			switch err.(type) {


### PR DESCRIPTION
## Description
Pass the Namespace from the ListOptions when looking up a WorkloadEndpoint resource by name.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
