### PR TITLE
Tolerate named ports with duplicate names on the same endpoint.

### DIFF
--- a/lib/validator/validator.go
+++ b/lib/validator/validator.go
@@ -123,8 +123,6 @@ func init() {
 	// Backend model types.
 	registerStructValidator(validateBackendRule, model.Rule{})
 	registerStructValidator(validateBackendEndpointPort, model.EndpointPort{})
-	registerStructValidator(validateBackendWorkloadEndpoint, model.WorkloadEndpoint{})
-	registerStructValidator(validateBackendHostEndpoint, model.HostEndpoint{})
 }
 
 // reason returns the provided error reason prefixed with an identifier that
@@ -337,20 +335,6 @@ func validateWorkloadEndpointSpec(v *validator.Validate, structLevel *validator.
 				"IPNATs", "", reason("NAT is not in the endpoint networks"))
 		}
 	}
-
-	// Check for duplicate named ports.
-	seenPortNames := map[string]bool{}
-	for _, port := range w.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
-	}
 }
 
 func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.StructLevel) {
@@ -360,20 +344,6 @@ func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.Stru
 	if h.InterfaceName == "" && len(h.ExpectedIPs) == 0 {
 		structLevel.ReportError(reflect.ValueOf(h.InterfaceName),
 			"InterfaceName", "", reason("no interface or expected IPs have been specified"))
-	}
-
-	// Check for duplicate named ports.
-	seenPortNames := map[string]bool{}
-	for _, port := range h.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
 	}
 }
 
@@ -585,40 +555,6 @@ func validateEndpointPort(v *validator.Validate, structLevel *validator.StructLe
 			"",
 			reason("EndpointPort protocol must be 'tcp' or 'udp'."),
 		)
-	}
-}
-
-func validateBackendWorkloadEndpoint(v *validator.Validate, structLevel *validator.StructLevel) {
-	ep := structLevel.CurrentStruct.Interface().(model.WorkloadEndpoint)
-
-	seenPortNames := map[string]bool{}
-	for _, port := range ep.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"WorkloadEndpoint.Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
-	}
-}
-
-func validateBackendHostEndpoint(v *validator.Validate, structLevel *validator.StructLevel) {
-	ep := structLevel.CurrentStruct.Interface().(model.HostEndpoint)
-
-	seenPortNames := map[string]bool{}
-	for _, port := range ep.Ports {
-		if seenPortNames[port.Name] {
-			structLevel.ReportError(
-				reflect.ValueOf(port.Name),
-				"HostEndpoint.Ports",
-				"",
-				reason("Ports list contains duplicate named port."),
-			)
-		}
-		seenPortNames[port.Name] = true
 	}
 }
 

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -246,7 +246,7 @@ func init() {
 			},
 			false,
 		),
-		Entry("should reject WorkloadEndpoint with name-clashing ports (m)",
+		Entry("should accept WorkloadEndpoint with name-clashing ports (m)",
 			model.WorkloadEndpoint{
 				Ports: []model.EndpointPort{
 					{
@@ -261,7 +261,7 @@ func init() {
 					},
 				},
 			},
-			false,
+			true,
 		),
 
 		// (API) WorkloadEndpointSpec.
@@ -290,7 +290,7 @@ func init() {
 			},
 			false,
 		),
-		Entry("should reject WorkloadEndpointSpec with name-clashing ports (m)",
+		Entry("should accept WorkloadEndpointSpec with name-clashing ports (m)",
 			api.WorkloadEndpointSpec{
 				InterfaceName: "eth0",
 				Ports: []api.EndpointPort{
@@ -306,7 +306,7 @@ func init() {
 					},
 				},
 			},
-			false,
+			true,
 		),
 
 		// (Backend model) HostEndpoint.
@@ -333,7 +333,7 @@ func init() {
 			},
 			false,
 		),
-		Entry("should reject HostEndpoint with name-clashing ports (m)",
+		Entry("should accept HostEndpoint with name-clashing ports (m)",
 			model.HostEndpoint{
 				Ports: []model.EndpointPort{
 					{
@@ -348,7 +348,7 @@ func init() {
 					},
 				},
 			},
-			false,
+			true,
 		),
 
 		// (API) HostEndpointSpec.
@@ -377,7 +377,7 @@ func init() {
 			},
 			false,
 		),
-		Entry("should reject HostEndpointSpec with name-clashing ports (m)",
+		Entry("should accept HostEndpointSpec with name-clashing ports (m)",
 			api.HostEndpointSpec{
 				InterfaceName: "eth0",
 				Ports: []api.EndpointPort{
@@ -393,7 +393,7 @@ func init() {
 					},
 				},
 			},
-			false,
+			true,
 		),
 
 		// (API) IP version.


### PR DESCRIPTION
## Description
Cherry-pick #608 to master.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
