### PR TITLE
Add orchrefs to libcalico-go

### DIFF
--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -65,6 +65,17 @@ type NodeSpec struct {
 	// BGP configuration for this node.  If this omitted, the Calico node
 	// will be run in policy-only mode.
 	BGP *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
+
+	// OrchRefs for this node.
+	OrchRefs []OrchRef `json:"orchRefs,omitempty" validate:"omitempty"`
+}
+
+// OrchRef is used to correlate a Calico node to its corresponding representation in a given orchestrator
+type OrchRef struct {
+	// NodeName represents the name for this node according to the orchestrator.
+	NodeName string `json:"nodeName,omitempty" validate:"omitempty"`
+	// Orchestrator represents the orchestrator using this node.
+	Orchestrator string `json:"orchestrator"`
 }
 
 // NodeSpec contains the specification for a Calico Node resource.

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -486,6 +486,10 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
+	if component, err := c.client.Get(model.OrchRefKey{Hostname: nk.Hostname}); err == nil {
+		nv.OrchRefs = component.Value.([]model.OrchRef)
+	}
+
 	return nil
 }
 
@@ -646,6 +650,12 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 			},
 		})
 	}
+	if len(n.OrchRefs) > 0 {
+		optional = append(optional, &model.KVPair{
+			Key:   model.OrchRefKey{Hostname: nk.Hostname},
+			Value: n.OrchRefs,
+		})
+	}
 
 	return primary, optional
 }
@@ -691,6 +701,11 @@ func toNodeDeleteComponents(d *model.KVPair) (primary *model.KVPair, optional []
 			Key: model.NodeBGPConfigKey{
 				Nodename: nk.Hostname,
 				Name:     "network_v6",
+			},
+		},
+		&model.KVPair{
+			Key: model.OrchRefKey{
+				Hostname: nk.Hostname,
 			},
 		},
 	}

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -189,6 +189,13 @@ func (h *nodes) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 		v.BGPASNumber = an.Spec.BGP.ASNumber
 	}
 
+	for _, orchRef := range an.Spec.OrchRefs {
+		v.OrchRefs = append(v.OrchRefs, model.OrchRef{
+			Orchestrator: orchRef.Orchestrator,
+			NodeName:     orchRef.NodeName,
+		})
+	}
+
 	return &model.KVPair{Key: k, Value: &v}, nil
 }
 
@@ -234,6 +241,13 @@ func (h *nodes) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error
 				apiNode.Spec.BGP.IPv6Address = bv.BGPIPv6Addr.Network()
 			}
 		}
+	}
+
+	for _, orchref := range bv.OrchRefs {
+		apiNode.Spec.OrchRefs = append(apiNode.Spec.OrchRefs, api.OrchRef{
+			NodeName:     orchref.NodeName,
+			Orchestrator: orchref.Orchestrator,
+		})
 	}
 
 	return apiNode, nil

--- a/lib/client/node_e2e_test.go
+++ b/lib/client/node_e2e_test.go
@@ -96,9 +96,9 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV2, 
 			_, err = c.Nodes().Update(&api.Node{Metadata: meta1, Spec: spec2})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Apply node2 with spec1.
+			// Applying node2 with spec1.
 			By("Applying node2 with spec1")
-			_, err = c.Nodes().Update(&api.Node{Metadata: meta2, Spec: spec1})
+			_, err = c.Nodes().Apply(&api.Node{Metadata: meta2, Spec: spec1})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get node with meta1.
@@ -166,11 +166,31 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV2, 
 				BGP: &api.NodeBGPSpec{
 					IPv4Address: &cidrv4,
 				},
+				OrchRefs: []api.OrchRef{
+					{
+						Orchestrator: "k8s",
+						NodeName:     "node1",
+					},
+					{
+						Orchestrator: "mesos",
+						NodeName:     "node1",
+					},
+				},
 			},
 			api.NodeSpec{
 				BGP: &api.NodeBGPSpec{
 					IPv6Address: &cidrv6,
 					ASNumber:    &asn,
+				},
+				OrchRefs: []api.OrchRef{
+					{
+						Orchestrator: "k8s",
+						NodeName:     "node2",
+					},
+					{
+						Orchestrator: "mesos",
+						NodeName:     "node2",
+					},
 				},
 			}),
 


### PR DESCRIPTION
## Description

Added OrchRefs into the Node model and Node Spec in order to help track Nodes. This will help us sort out what k8s Nodes are tied to what Calico Nodes, and possibly for other orchestrators as well. 

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added OrchRefs to the Node model to help track Nodes.
```
