### PR TITLE
Various fixes/workarounds to kdd based policy and namespace selection

### DIFF
--- a/lib/apis/v2/constants.go
+++ b/lib/apis/v2/constants.go
@@ -27,4 +27,17 @@ const (
 
 	// AllNames is used for List or Watch queries to wildcard the name.
 	AllNames = ""
+
+	// Label used to denote the Namespace.  This is added to the workload endpoints by Calico
+	// and may be used for label matches by Policy selectors.
+	LabelNamespace = "projectcalico.org/namespace"
+
+	// Label used to denote the Orchestrator.  This is added to the workload endpoints by an
+	// orchestrator.
+	LabelOrchestrator = "projectcalico.org/orchestrator"
+
+	// Known orchestrators.  Orchestrators are not limited to this list.
+	OrchestratorKubernetes = "k8s"
+	OrchestratorCNI        = "cni"
+	OrchestratorDocker     = "libnetwork"
 )

--- a/lib/apis/v2/policy.go
+++ b/lib/apis/v2/policy.go
@@ -142,10 +142,6 @@ type ICMPFields struct {
 // A source EntityRule matches the source endpoint and originating traffic.
 // A destination EntityRule matches the destination endpoint and terminating traffic.
 type EntityRule struct {
-	// Tag is an optional field that restricts the rule to only apply to traffic that
-	// originates from (or terminates at) endpoints that have profiles with the given tag
-	// in them.
-	Tag string `json:"tag,omitempty" validate:"omitempty,tag"`
 	// Nets is an optional field that restricts the rule to only apply to traffic that
 	// originates from (or terminates at) IP addresses in any of the given subnets.
 	Nets []string `json:"nets,omitempty" validate:"omitempty,dive,cidr"`
@@ -174,9 +170,6 @@ type EntityRule struct {
 	// Protocol match in the Rule to be set to "tcp" or "udp".
 	Ports []numorstring.Port `json:"ports,omitempty" validate:"omitempty,dive"`
 	// NotTag is the negated version of the Tag field.
-	NotTag string `json:"notTag,omitempty" validate:"omitempty,tag"`
-	// NotNets is an optional field that restricts the rule to only apply to traffic that
-	// does not originate from (or terminate at) an IP address in any of the given subnets.
 	NotNets []string `json:"notNets,omitempty" validate:"omitempty,dive,cidr"`
 	// NotSelector is the negated version of the Selector field.  See Selector field for
 	// subtleties with negated selectors.

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -48,7 +48,7 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 	}
 
 	if len(etcdLocation) == 0 {
-		log.Info("No etcd endpoints specified in etcdv3 API config")
+		log.Warning("No etcd endpoints specified in etcdv3 API config")
 		return nil, errors.New("no etcd endpoints specified")
 	}
 
@@ -302,7 +302,7 @@ func (c *etcdV3Client) Get(ctx context.Context, k model.Key, revision string) (*
 		return nil, cerrors.ErrorDatastoreError{Err: err}
 	}
 	if len(resp.Kvs) == 0 {
-		logCxt.Info("No results returned from etcdv3 client")
+		logCxt.Debug("No results returned from etcdv3 client")
 		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: k}
 	}
 
@@ -331,11 +331,11 @@ func (c *etcdV3Client) List(ctx context.Context, l model.ListInterface, revision
 	if model.IsListOptionsLastSegmentPrefix(l) {
 		// The last segment is a prefix, perform a prefix Get without adding a segment
 		// delimiter.
-		logCxt.Info("Performing a name-prefix query")
+		logCxt.Debug("Performing a name-prefix query")
 		ops = append(ops, clientv3.WithPrefix())
 	} else if l.KeyFromDefaultPath(key) == nil {
 		// The etcdKey not a fully qualified etcdKey - it must be a prefix.
-		logCxt.Info("Performing a parent-prefix query")
+		logCxt.Debug("Performing a parent-prefix query")
 		if !strings.HasSuffix(key, "/") {
 			key += "/"
 		}
@@ -377,21 +377,7 @@ func (c *etcdV3Client) List(ctx context.Context, l model.ListInterface, revision
 // EnsureInitialized makes sure that the etcd data is initialized for use by
 // Calico.
 func (c *etcdV3Client) EnsureInitialized() error {
-	// Make sure the Ready flag is initialized in the datastore
-	kv := &model.KVPair{
-		Key:   model.ReadyFlagKey{},
-		Value: true,
-	}
-
 	//TODO - still need to worry about ready flag.
-	if _, err := c.Create(context.Background(), kv); err != nil {
-		if _, ok := err.(cerrors.ErrorResourceAlreadyExists); !ok {
-			log.WithError(err).Warn("Failed to set ready flag")
-			return err
-		}
-	}
-
-	log.Info("Ready flag is already set")
 	return nil
 }
 

--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversion
+
+const (
+	NamespaceLabelPrefix       = "pcns."
+	NamespaceProfileNamePrefix = "kns."
+	K8sNetworkPolicyNamePrefix = "knp.default."
+)

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -351,12 +351,12 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Performing a Get on the Profile and ensure no error in the Calico API", func() {
-			_, err := c.Get(ctx, model.ResourceKey{Name: fmt.Sprintf("k8s_ns.%s", ns.ObjectMeta.Name), Kind: capiv2.KindProfile}, "")
+			_, err := c.Get(ctx, model.ResourceKey{Name: fmt.Sprintf("kns.%s", ns.ObjectMeta.Name), Kind: capiv2.KindProfile}, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("Checking the correct entries are in our cache", func() {
-			expectedName := "k8s_ns.test-syncer-namespace-default-deny"
+			expectedName := "kns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 		})
@@ -367,7 +367,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Checking the correct entries are no longer in our cache", func() {
-			expectedName := "k8s_ns.test-syncer-namespace-default-deny"
+			expectedName := "kns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 		})
@@ -407,13 +407,13 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 
 		// Perform a Get and ensure no error in the Calico API.
 		By("getting a Profile", func() {
-			_, err := c.Get(ctx, model.ResourceKey{Name: fmt.Sprintf("k8s_ns.%s", ns.ObjectMeta.Name), Kind: capiv2.KindProfile}, "")
+			_, err := c.Get(ctx, model.ResourceKey{Name: fmt.Sprintf("kns.%s", ns.ObjectMeta.Name), Kind: capiv2.KindProfile}, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Expect corresponding Profile updates over the syncer for this Namespace.
 		By("Checking the correct entries are in our cache", func() {
-			expectedName := "k8s_ns.test-syncer-namespace-no-default-deny"
+			expectedName := "kns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 		})
@@ -424,7 +424,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Checking the correct entries are in no longer in our cache", func() {
-			expectedName := "k8s_ns.test-syncer-namespace-no-default-deny"
+			expectedName := "kns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 		})
@@ -483,7 +483,11 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Perform a Get and ensure no error in the Calico API.
-		_, err = c.Get(ctx, model.ResourceKey{Name: fmt.Sprintf("knp.default.default.%s", np.ObjectMeta.Name), Kind: capiv2.KindNetworkPolicy}, "")
+		_, err = c.Get(ctx, model.ResourceKey{
+			Name:      fmt.Sprintf("knp.default.%s", np.ObjectMeta.Name),
+			Namespace: "default",
+			Kind:      capiv2.KindNetworkPolicy,
+		}, "")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -68,35 +68,35 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				expectedCacheSize += 5
 				syncTester.ExpectCacheSize(expectedCacheSize)
 				syncTester.ExpectData(model.KVPair{
-					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "k8s_ns.default"}},
+					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "kns.default"}},
 					Value: &model.ProfileRules{
 						InboundRules:  []model.Rule{{Action: "allow"}},
 						OutboundRules: []model.Rule{{Action: "allow"}},
 					},
 				})
 				syncTester.ExpectData(model.KVPair{
-					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "k8s_ns.kube-public"}},
+					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "kns.kube-public"}},
 					Value: &model.ProfileRules{
 						InboundRules:  []model.Rule{{Action: "allow"}},
 						OutboundRules: []model.Rule{{Action: "allow"}},
 					},
 				})
 				syncTester.ExpectData(model.KVPair{
-					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "k8s_ns.kube-system"}},
+					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "kns.kube-system"}},
 					Value: &model.ProfileRules{
 						InboundRules:  []model.Rule{{Action: "allow"}},
 						OutboundRules: []model.Rule{{Action: "allow"}},
 					},
 				})
 				syncTester.ExpectData(model.KVPair{
-					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "k8s_ns.namespace-1"}},
+					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "kns.namespace-1"}},
 					Value: &model.ProfileRules{
 						InboundRules:  []model.Rule{{Action: "allow"}},
 						OutboundRules: []model.Rule{{Action: "allow"}},
 					},
 				})
 				syncTester.ExpectData(model.KVPair{
-					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "k8s_ns.namespace-2"}},
+					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "kns.namespace-2"}},
 					Value: &model.ProfileRules{
 						InboundRules:  []model.Rule{{Action: "allow"}},
 						OutboundRules: []model.Rule{{Action: "allow"}},

--- a/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor.go
@@ -43,5 +43,5 @@ func convertGlobalNetworkPolicyV2ToV1Value(val interface{}) (interface{}, error)
 	if !ok {
 		return nil, errors.New("Value is not a valid GlobalNetworkPolicy resource value")
 	}
-	return convertPolicyV2ToV1Spec(v2res.Spec)
+	return convertPolicyV2ToV1Spec(v2res.Spec, "")
 }

--- a/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor_test.go
@@ -94,21 +94,17 @@ var _ = Describe("Test the GlobalNetworkPolicy update processor", func() {
 				Code: &incode,
 			},
 			Source: apiv2.EntityRule{
-				Tag:         "tag1",
 				Nets:        []string{"10.100.10.1"},
 				Selector:    "calico/k8s_ns == selector1",
 				Ports:       []numorstring.Port{port80},
-				NotTag:      "nottag1",
 				NotNets:     []string{"192.168.40.1"},
 				NotSelector: "has(label1)",
 				NotPorts:    []numorstring.Port{port443},
 			},
 			Destination: apiv2.EntityRule{
-				Tag:         "tag2",
 				Nets:        []string{"10.100.1.1"},
 				Selector:    "calico/k8s_ns == selector2",
 				Ports:       []numorstring.Port{port443},
-				NotTag:      "nottag2",
 				NotNets:     []string{"192.168.80.1"},
 				NotSelector: "has(label2)",
 				NotPorts:    []numorstring.Port{port80},
@@ -135,21 +131,17 @@ var _ = Describe("Test the GlobalNetworkPolicy update processor", func() {
 				Code: &encode,
 			},
 			Source: apiv2.EntityRule{
-				Tag:         "tag2",
 				Nets:        []string{"10.100.1.1"},
 				Selector:    "calico/k8s_ns == selector2",
 				Ports:       []numorstring.Port{port443},
-				NotTag:      "nottag2",
 				NotNets:     []string{"192.168.80.1"},
 				NotSelector: "has(label2)",
 				NotPorts:    []numorstring.Port{port80},
 			},
 			Destination: apiv2.EntityRule{
-				Tag:         "tag1",
 				Nets:        []string{"10.100.10.1"},
 				Selector:    "calico/k8s_ns == selector1",
 				Ports:       []numorstring.Port{port80},
-				NotTag:      "nottag1",
 				NotNets:     []string{"192.168.40.1"},
 				NotSelector: "has(label1)",
 				NotPorts:    []numorstring.Port{port443},
@@ -173,8 +165,8 @@ var _ = Describe("Test the GlobalNetworkPolicy update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		v1irule := updateprocessors.RuleAPIV2ToBackend(irule)
-		v1erule := updateprocessors.RuleAPIV2ToBackend(erule)
+		v1irule := updateprocessors.RuleAPIV2ToBackend(irule, "")
+		v1erule := updateprocessors.RuleAPIV2ToBackend(erule, "")
 		Expect(kvps).To(Equal([]*model.KVPair{
 			{
 				Key: v1GlobalNetworkPolicyKey2,

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
+func mustParseCIDR(cidr string) *cnet.IPNet {
+	ipn := cnet.MustParseCIDR(cidr)
+	return &ipn
+}
+
 var _ = Describe("Test the NetworkPolicy update processor", func() {
 	name1 := "name1"
 	name2 := "name2"
@@ -53,6 +58,8 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 
 		By("converting a NetworkPolicy with minimum configuration")
 		res := apiv2.NewNetworkPolicy()
+		res.Name = name1
+		res.Namespace = ns1
 		res.Spec.PreDNAT = true
 		res.Spec.ApplyOnForward = true
 
@@ -66,6 +73,7 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 		Expect(kvps[0]).To(Equal(&model.KVPair{
 			Key: v1NetworkPolicyKey1,
 			Value: &model.Policy{
+				Selector:       "projectcalico.org/namespace == 'namespace1'",
 				PreDNAT:        true,
 				ApplyOnForward: true,
 			},
@@ -98,21 +106,17 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 				Code: &incode,
 			},
 			Source: apiv2.EntityRule{
-				Tag:         "tag1",
 				Nets:        []string{"10.100.10.1"},
-				Selector:    "calico/k8s_ns == selector1",
+				Selector:    "mylabel = value1",
 				Ports:       []numorstring.Port{port80},
-				NotTag:      "nottag1",
 				NotNets:     []string{"192.168.40.1"},
 				NotSelector: "has(label1)",
 				NotPorts:    []numorstring.Port{port443},
 			},
 			Destination: apiv2.EntityRule{
-				Tag:         "tag2",
 				Nets:        []string{"10.100.1.1"},
-				Selector:    "calico/k8s_ns == selector2",
+				Selector:    "",
 				Ports:       []numorstring.Port{port443},
-				NotTag:      "nottag2",
 				NotNets:     []string{"192.168.80.1"},
 				NotSelector: "has(label2)",
 				NotPorts:    []numorstring.Port{port80},
@@ -139,29 +143,27 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 				Code: &encode,
 			},
 			Source: apiv2.EntityRule{
-				Tag:         "tag2",
 				Nets:        []string{"10.100.1.1"},
-				Selector:    "calico/k8s_ns == selector2",
+				Selector:    "kns.namespacelabel1 == 'value1'",
 				Ports:       []numorstring.Port{port443},
-				NotTag:      "nottag2",
 				NotNets:     []string{"192.168.80.1"},
 				NotSelector: "has(label2)",
 				NotPorts:    []numorstring.Port{port80},
 			},
 			Destination: apiv2.EntityRule{
-				Tag:         "tag1",
 				Nets:        []string{"10.100.10.1"},
-				Selector:    "calico/k8s_ns == selector1",
+				Selector:    "kns.namespacelabel2 == 'value2'",
 				Ports:       []numorstring.Port{port80},
-				NotTag:      "nottag1",
 				NotNets:     []string{"192.168.40.1"},
 				NotSelector: "has(label1)",
 				NotPorts:    []numorstring.Port{port443},
 			},
 		}
 		order := float64(101)
-		selector := "calico/k8s_ns == selectme"
+		selector := "mylabel == selectme"
 
+		res.Name = name2
+		res.Namespace = ns2
 		res.Spec.Order = &order
 		res.Spec.IngressRules = []apiv2.Rule{irule}
 		res.Spec.EgressRules = []apiv2.Rule{erule}
@@ -177,24 +179,74 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		v1irule := updateprocessors.RuleAPIV2ToBackend(irule)
-		v1erule := updateprocessors.RuleAPIV2ToBackend(erule)
-		Expect(kvps).To(Equal([]*model.KVPair{
-			{
-				Key: v1NetworkPolicyKey2,
-				Value: &model.Policy{
-					Order:          &order,
-					InboundRules:   []model.Rule{v1irule},
-					OutboundRules:  []model.Rule{v1erule},
-					Selector:       selector,
-					DoNotTrack:     true,
-					PreDNAT:        false,
-					ApplyOnForward: true,
-					Types:          []string{"ingress"},
-				},
-				Revision: "1234",
-			},
-		}))
+		// Correct number of entries returned
+		Expect(kvps).To(HaveLen(1))
+		kvp := kvps[0]
+
+		// Correct Key and Revision
+		Expect(kvp.Key).To(Equal(v1NetworkPolicyKey2))
+		Expect(kvp.Revision).To(Equal("1234"))
+
+		// Correct top level Policy field values
+		value := kvp.Value.(*model.Policy)
+		Expect(value.Order).To(Equal(&order))
+		Expect(value.Selector).To(Equal("(mylabel == selectme) && projectcalico.org/namespace == 'namespace2'"))
+		Expect(value.DoNotTrack).To(BeTrue())
+		Expect(value.PreDNAT).To(BeFalse())
+		Expect(value.ApplyOnForward).To(BeTrue())
+		Expect(value.Types).To(Equal([]string{"ingress"}))
+		Expect(value.InboundRules).To(HaveLen(1))
+		Expect(value.OutboundRules).To(HaveLen(1))
+
+		// Correct inbound rule
+		rulev1 := value.InboundRules[0]
+		Expect(rulev1.Action).To(Equal("allow"))
+		Expect(rulev1.IPVersion).To(Equal(&v4))
+		Expect(rulev1.Protocol).To(Equal(&iproto))
+		Expect(rulev1.ICMPCode).To(Equal(&icode))
+		Expect(rulev1.ICMPType).To(Equal(&itype))
+		Expect(rulev1.NotProtocol).To(Equal(&inproto))
+		Expect(rulev1.NotICMPCode).To(Equal(&incode))
+		Expect(rulev1.NotICMPType).To(Equal(&intype))
+
+		Expect(rulev1.SrcNets).To(Equal([]*cnet.IPNet{mustParseCIDR("10.100.10.1/32")}))
+		Expect(rulev1.SrcSelector).To(Equal("(mylabel = value1) && projectcalico.org/namespace == 'namespace2'"))
+		Expect(rulev1.SrcPorts).To(Equal([]numorstring.Port{port80}))
+		Expect(rulev1.DstNets).To(Equal([]*cnet.IPNet{mustParseCIDR("10.100.1.1/32")}))
+		Expect(rulev1.DstSelector).To(Equal("projectcalico.org/namespace == 'namespace2'"))
+		Expect(rulev1.DstPorts).To(Equal([]numorstring.Port{port443}))
+
+		Expect(rulev1.NotSrcNets).To(Equal([]*cnet.IPNet{mustParseCIDR("192.168.40.1/32")}))
+		Expect(rulev1.NotSrcSelector).To(Equal("has(label1)"))
+		Expect(rulev1.NotSrcPorts).To(Equal([]numorstring.Port{port443}))
+		Expect(rulev1.NotDstNets).To(Equal([]*cnet.IPNet{mustParseCIDR("192.168.80.1/32")}))
+		Expect(rulev1.NotDstSelector).To(Equal("has(label2)"))
+		Expect(rulev1.NotDstPorts).To(Equal([]numorstring.Port{port80}))
+
+		// Correct outbound rule
+		rulev1 = value.OutboundRules[0]
+		Expect(rulev1.IPVersion).To(Equal(&v4))
+		Expect(rulev1.Protocol).To(Equal(&eproto))
+		Expect(rulev1.ICMPCode).To(Equal(&ecode))
+		Expect(rulev1.ICMPType).To(Equal(&etype))
+		Expect(rulev1.NotProtocol).To(Equal(&enproto))
+		Expect(rulev1.NotICMPCode).To(Equal(&encode))
+		Expect(rulev1.NotICMPType).To(Equal(&entype))
+
+
+		Expect(rulev1.SrcNets).To(Equal([]*cnet.IPNet{mustParseCIDR("10.100.1.1/32")}))
+		Expect(rulev1.SrcSelector).To(Equal("kns.namespacelabel1 == 'value1'"))
+		Expect(rulev1.SrcPorts).To(Equal([]numorstring.Port{port443}))
+		Expect(rulev1.DstNets).To(Equal([]*cnet.IPNet{mustParseCIDR("10.100.10.1/32")}))
+		Expect(rulev1.DstSelector).To(Equal("kns.namespacelabel2 == 'value2'"))
+		Expect(rulev1.DstPorts).To(Equal([]numorstring.Port{port80}))
+
+		Expect(rulev1.NotSrcNets).To(Equal([]*cnet.IPNet{mustParseCIDR("192.168.80.1/32")}))
+		Expect(rulev1.NotSrcSelector).To(Equal("has(label2)"))
+		Expect(rulev1.NotSrcPorts).To(Equal([]numorstring.Port{port80}))
+		Expect(rulev1.NotDstNets).To(Equal([]*cnet.IPNet{mustParseCIDR("192.168.40.1/32")}))
+		Expect(rulev1.NotDstSelector).To(Equal("has(label1)"))
+		Expect(rulev1.NotDstPorts).To(Equal([]numorstring.Port{port443}))
 
 		By("deleting the first network policy")
 

--- a/lib/backend/syncersv1/updateprocessors/profileprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/profileprocessor.go
@@ -104,12 +104,12 @@ func convertProfileV2ToV1Value(val interface{}) (*model.Profile, error) {
 
 	var irules []model.Rule
 	for _, irule := range v2res.Spec.IngressRules {
-		irules = append(irules, RuleAPIV2ToBackend(irule))
+		irules = append(irules, RuleAPIV2ToBackend(irule, ""))
 	}
 
 	var erules []model.Rule
 	for _, erule := range v2res.Spec.EgressRules {
-		erules = append(erules, RuleAPIV2ToBackend(erule))
+		erules = append(erules, RuleAPIV2ToBackend(erule, ""))
 	}
 
 	rules := model.ProfileRules{

--- a/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
@@ -97,21 +97,17 @@ var _ = Describe("Test the Profile update processor", func() {
 				Code: &incode,
 			},
 			Source: apiv2.EntityRule{
-				Tag:         "tag1",
 				Nets:        []string{"10.100.10.1"},
 				Selector:    "calico/k8s_ns == selector1",
 				Ports:       []numorstring.Port{port80},
-				NotTag:      "nottag1",
 				NotNets:     []string{"192.168.40.1"},
 				NotSelector: "has(label1)",
 				NotPorts:    []numorstring.Port{port443},
 			},
 			Destination: apiv2.EntityRule{
-				Tag:         "tag2",
 				Nets:        []string{"10.100.1.1"},
 				Selector:    "calico/k8s_ns == selector2",
 				Ports:       []numorstring.Port{port443},
-				NotTag:      "nottag2",
 				NotNets:     []string{"192.168.80.1"},
 				NotSelector: "has(label2)",
 				NotPorts:    []numorstring.Port{port80},
@@ -138,21 +134,17 @@ var _ = Describe("Test the Profile update processor", func() {
 				Code: &encode,
 			},
 			Source: apiv2.EntityRule{
-				Tag:         "tag2",
 				Nets:        []string{"10.100.1.1"},
 				Selector:    "calico/k8s_ns == selector2",
 				Ports:       []numorstring.Port{port443},
-				NotTag:      "nottag2",
 				NotNets:     []string{"192.168.80.1"},
 				NotSelector: "has(label2)",
 				NotPorts:    []numorstring.Port{port80},
 			},
 			Destination: apiv2.EntityRule{
-				Tag:         "tag1",
 				Nets:        []string{"10.100.10.1"},
 				Selector:    "calico/k8s_ns == selector1",
 				Ports:       []numorstring.Port{port80},
-				NotTag:      "nottag1",
 				NotNets:     []string{"192.168.40.1"},
 				NotSelector: "has(label1)",
 				NotPorts:    []numorstring.Port{port443},
@@ -168,8 +160,8 @@ var _ = Describe("Test the Profile update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		v1irule := updateprocessors.RuleAPIV2ToBackend(irule)
-		v1erule := updateprocessors.RuleAPIV2ToBackend(erule)
+		v1irule := updateprocessors.RuleAPIV2ToBackend(irule, "")
+		v1erule := updateprocessors.RuleAPIV2ToBackend(erule, "")
 		Expect(kvps).To(HaveLen(2))
 		Expect(kvps[0]).To(Equal(&model.KVPair{
 			Key:      model.ProfileLabelsKey{v1ProfileKey2},

--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -15,27 +15,30 @@
 package updateprocessors
 
 import (
+	"fmt"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
-func RulesAPIV2ToBackend(ars []apiv2.Rule) []model.Rule {
+func RulesAPIV2ToBackend(ars []apiv2.Rule, ns string) []model.Rule {
 	if ars == nil {
 		return []model.Rule{}
 	}
 
 	brs := make([]model.Rule, len(ars))
 	for idx, ar := range ars {
-		brs[idx] = RuleAPIV2ToBackend(ar)
+		brs[idx] = RuleAPIV2ToBackend(ar, ns)
 	}
 	return brs
 }
 
 // RuleAPIToBackend converts an API Rule structure to a Backend Rule structure.
-func RuleAPIV2ToBackend(ar apiv2.Rule) model.Rule {
+func RuleAPIV2ToBackend(ar apiv2.Rule, ns string) model.Rule {
 	var icmpCode, icmpType, notICMPCode, notICMPType *int
 	if ar.ICMP != nil {
 		icmpCode = ar.ICMP.Code
@@ -45,6 +48,45 @@ func RuleAPIV2ToBackend(ar apiv2.Rule) model.Rule {
 	if ar.NotICMP != nil {
 		notICMPCode = ar.NotICMP.Code
 		notICMPType = ar.NotICMP.Type
+	}
+
+	// If we have any selector specified, then we may need to add the namespace selector.
+	// We do this if this policy is namespaced AND if the Selector does not have any other
+	// k8s namespace (profile label) selector in it.
+	// TODO this is TEMPORARY CODE:  We currently do a simple regex to search for kns. in the
+	// selector to see if we are performing k8s namespace queries.
+	nsSelector := fmt.Sprintf("%s == '%s'", apiv2.LabelNamespace, ns)
+	if ns != "" && (ar.Source.Selector != "" || ar.Source.NotSelector != "") {
+		logCxt := log.WithFields(log.Fields{
+			"Namespace":   ns,
+			"Selector":    ar.Source.Selector,
+			"NotSelector": ar.Source.NotSelector,
+		})
+		logCxt.Debug("Maybe update source Selector to include namespace")
+		if !strings.Contains(ar.Source.Selector, "kns.") {
+			logCxt.Debug("Updating source selector")
+			if ar.Source.Selector == "" {
+				ar.Source.Selector = nsSelector
+			} else {
+				ar.Source.Selector = fmt.Sprintf("(%s) && %s", ar.Source.Selector, nsSelector)
+			}
+		}
+	}
+	if ns != "" && (ar.Destination.Selector != "" || ar.Destination.NotSelector != "") {
+		logCxt := log.WithFields(log.Fields{
+			"Namespace":   ns,
+			"Selector":    ar.Destination.Selector,
+			"NotSelector": ar.Destination.NotSelector,
+		})
+		logCxt.Debug("Maybe update Destination Selector to include namespace")
+		if !strings.Contains(ar.Destination.Selector, "kns.") {
+			logCxt.Debug("Updating Destination selector")
+			if ar.Destination.Selector == "" {
+				ar.Destination.Selector = nsSelector
+			} else {
+				ar.Destination.Selector = fmt.Sprintf("(%s) && %s", ar.Destination.Selector, nsSelector)
+			}
+		}
 	}
 
 	return model.Rule{
@@ -57,20 +99,16 @@ func RuleAPIV2ToBackend(ar apiv2.Rule) model.Rule {
 		NotICMPCode: notICMPCode,
 		NotICMPType: notICMPType,
 
-		SrcTag:      ar.Source.Tag,
 		SrcNets:     convertStringsToNets(ar.Source.Nets),
 		SrcSelector: ar.Source.Selector,
 		SrcPorts:    ar.Source.Ports,
-		DstTag:      ar.Destination.Tag,
 		DstNets:     normalizeIPNets(ar.Destination.Nets),
 		DstSelector: ar.Destination.Selector,
 		DstPorts:    ar.Destination.Ports,
 
-		NotSrcTag:      ar.Source.NotTag,
 		NotSrcNets:     convertStringsToNets(ar.Source.NotNets),
 		NotSrcSelector: ar.Source.NotSelector,
 		NotSrcPorts:    ar.Source.NotPorts,
-		NotDstTag:      ar.Destination.NotTag,
 		NotDstNets:     normalizeIPNets(ar.Destination.NotNets),
 		NotDstSelector: ar.Destination.NotSelector,
 		NotDstPorts:    ar.Destination.NotPorts,

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -115,19 +115,18 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 	}
 
 	v1value := &model.WorkloadEndpoint{
-		State:            "active",
-		Name:             v2res.Spec.InterfaceName,
-		ActiveInstanceID: v2res.Spec.ContainerID,
-		Mac:              cmac,
-		ProfileIDs:       v2res.Spec.Profiles,
-		IPv4Nets:         ipv4Nets,
-		IPv6Nets:         ipv6Nets,
-		IPv4NAT:          ipv4NAT,
-		IPv6NAT:          ipv6NAT,
-		Labels:           v2res.GetLabels(),
-		IPv4Gateway:      ipv4Gateway,
-		IPv6Gateway:      ipv6Gateway,
-		Ports:            ports,
+		State:       "active",
+		Name:        v2res.Spec.InterfaceName,
+		Mac:         cmac,
+		ProfileIDs:  v2res.Spec.Profiles,
+		IPv4Nets:    ipv4Nets,
+		IPv6Nets:    ipv6Nets,
+		IPv4NAT:     ipv4NAT,
+		IPv6NAT:     ipv6NAT,
+		Labels:      v2res.GetLabels(),
+		IPv4Gateway: ipv4Gateway,
+		IPv6Gateway: ipv6Gateway,
+		Ports:       ports,
 	}
 
 	return v1value, nil

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
@@ -75,6 +75,15 @@ var _ = Describe("Test the WorkloadEndpoint update processor", func() {
 
 		By("converting a WorkloadEndpoint with minimum configuration")
 		res := apiv2.NewWorkloadEndpoint()
+		res.Namespace = ns1
+		res.Labels = map[string]string{
+			"projectcalico.org/namespace":    ns1,
+			"projectcalico.org/orchestrator": oid1,
+		}
+		res.Spec.Node = hn1
+		res.Spec.Orchestrator = oid1
+		res.Spec.Workload = wid1
+		res.Spec.Endpoint = eid1
 		res.Spec.InterfaceName = iface1
 
 		kvps, err := up.Process(&model.KVPair{
@@ -90,13 +99,26 @@ var _ = Describe("Test the WorkloadEndpoint update processor", func() {
 				State: "active",
 				Name:  iface1,
 				Ports: []model.EndpointPort{},
+				Labels: map[string]string{
+					"projectcalico.org/namespace":    ns1,
+					"projectcalico.org/orchestrator": oid1,
+				},
 			},
 			Revision: "abcde",
 		}))
 
 		By("adding another WorkloadEndpoint with a full configuration")
 		res = apiv2.NewWorkloadEndpoint()
-		res.Labels = map[string]string{"testLabel": "label"}
+		res.Namespace = ns2
+		res.Labels = map[string]string{
+			"testLabel":                      "label",
+			"projectcalico.org/namespace":    ns2,
+			"projectcalico.org/orchestrator": oid2,
+		}
+		res.Spec.Node = hn2
+		res.Spec.Orchestrator = oid2
+		res.Spec.Workload = wid2
+		res.Spec.Endpoint = eid2
 		res.Spec.InterfaceName = iface2
 		res.Spec.ContainerID = "container2"
 		res.Spec.MAC = "01:23:45:67:89:ab"
@@ -134,18 +156,21 @@ var _ = Describe("Test the WorkloadEndpoint update processor", func() {
 			{
 				Key: v1WorkloadEndpointKey2,
 				Value: &model.WorkloadEndpoint{
-					State:            "active",
-					Name:             iface2,
-					ActiveInstanceID: "container2",
-					Mac:              &mac2,
-					ProfileIDs:       []string{"testProfile"},
-					IPv4Nets:         []cnet.IPNet{expectedIPv4Net},
-					IPv4NAT:          []model.IPNAT{expectedIPv4NAT},
-					Labels:           map[string]string{"testLabel": "label"},
-					IPv4Gateway:      expectedIPv4Gateway,
-					IPv6Gateway:      expectedIPv6Gateway,
+					State:      "active",
+					Name:       iface2,
+					Mac:        &mac2,
+					ProfileIDs: []string{"testProfile"},
+					IPv4Nets:   []cnet.IPNet{expectedIPv4Net},
+					IPv4NAT:    []model.IPNAT{expectedIPv4NAT},
+					Labels: map[string]string{
+						"testLabel":                      "label",
+						"projectcalico.org/namespace":    ns2,
+						"projectcalico.org/orchestrator": oid2,
+					},
+					IPv4Gateway: expectedIPv4Gateway,
+					IPv6Gateway: expectedIPv6Gateway,
 					Ports: []model.EndpointPort{
-						model.EndpointPort{
+						{
 							Name:     "portname",
 							Protocol: numorstring.ProtocolFromInt(uint8(30)),
 							Port:     uint16(8080),

--- a/lib/clientv2/workloadendpoint.go
+++ b/lib/clientv2/workloadendpoint.go
@@ -46,6 +46,7 @@ func (r workloadEndpoints) Create(ctx context.Context, res *apiv2.WorkloadEndpoi
 	if err := r.validate(res); err != nil {
 		return nil, err
 	}
+	r.updateLabelsForStorage(res)
 	out, err := r.client.resources.Create(ctx, opts, apiv2.KindWorkloadEndpoint, res)
 	if out != nil {
 		return out.(*apiv2.WorkloadEndpoint), err
@@ -59,6 +60,7 @@ func (r workloadEndpoints) Update(ctx context.Context, res *apiv2.WorkloadEndpoi
 	if err := r.validate(res); err != nil {
 		return nil, err
 	}
+	r.updateLabelsForStorage(res)
 	out, err := r.client.resources.Update(ctx, opts, apiv2.KindWorkloadEndpoint, res)
 	if out != nil {
 		return out.(*apiv2.WorkloadEndpoint), err
@@ -129,4 +131,15 @@ func (r workloadEndpoints) validate(res *apiv2.WorkloadEndpoint) error {
 		}
 	}
 	return nil
+}
+
+// updateLabelsForStorage updates the set of labels that we persist.  It adds/overrides
+// the Namespace and Orchestrator labels which must be set to the correct values and are
+// not user configurable.
+func (r workloadEndpoints) updateLabelsForStorage(res *apiv2.WorkloadEndpoint) {
+	if res.Labels == nil {
+		res.Labels = make(map[string]string, 2)
+	}
+	res.Labels[apiv2.LabelNamespace] = res.Namespace
+	res.Labels[apiv2.LabelOrchestrator] = res.Spec.Orchestrator
 }

--- a/lib/clientv2/workloadendpoint_e2e_test.go
+++ b/lib/clientv2/workloadendpoint_e2e_test.go
@@ -124,6 +124,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1_1)
+			Expect(res1.Labels[apiv2.LabelOrchestrator]).To(Equal(res1.Spec.Orchestrator))
+			Expect(res1.Labels[apiv2.LabelNamespace]).To(Equal(res1.Namespace))
 
 			// Track the version of the original data for name1.
 			rv1_1 := res1.ResourceVersion
@@ -141,6 +143,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1_1)
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+			Expect(res.Labels[apiv2.LabelOrchestrator]).To(Equal(res.Spec.Orchestrator))
+			Expect(res.Labels[apiv2.LabelNamespace]).To(Equal(res.Namespace))
 
 			By("Getting WorkloadEndpoint (name2) before it is created")
 			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
@@ -152,6 +156,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
 			testutils.ExpectResource(&outList.Items[0], apiv2.KindWorkloadEndpoint, namespace1, name1, spec1_1)
+			Expect(outList.Items[0].Labels[apiv2.LabelOrchestrator]).To(Equal(outList.Items[0].Spec.Orchestrator))
+			Expect(outList.Items[0].Labels[apiv2.LabelNamespace]).To(Equal(outList.Items[0].Namespace))
 
 			By("Creating a new WorkloadEndpoint with name2/spec2_1")
 			res2, outError := c.WorkloadEndpoints().Create(ctx, &apiv2.WorkloadEndpoint{
@@ -185,6 +191,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			res1, outError = c.WorkloadEndpoints().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(res1, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1_2)
+			Expect(res1.Labels[apiv2.LabelOrchestrator]).To(Equal(res1.Spec.Orchestrator))
+			Expect(res1.Labels[apiv2.LabelNamespace]).To(Equal(res1.Namespace))
 
 			// Track the version of the updated name1 data.
 			rv1_2 := res1.ResourceVersion
@@ -237,6 +245,8 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			dres, outError := c.WorkloadEndpoints().Delete(ctx, namespace1, name1, options.DeleteOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			testutils.ExpectResource(dres, apiv2.KindWorkloadEndpoint, namespace1, name1, spec1_2)
+			Expect(dres.Labels[apiv2.LabelOrchestrator]).To(Equal(dres.Spec.Orchestrator))
+			Expect(dres.Labels[apiv2.LabelNamespace]).To(Equal(dres.Namespace))
 
 			By("Updating WorkloadEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.WorkloadEndpoints().Update(ctx, res2, options.SetOptions{TTL: 2 * time.Second})

--- a/lib/testutils/rules.go
+++ b/lib/testutils/rules.go
@@ -57,7 +57,6 @@ var InRule1 = apiv2.Rule{
 	Protocol:  &strProtocol1,
 	ICMP:      &icmp1,
 	Source: apiv2.EntityRule{
-		Tag:      "tag1",
 		Nets:     []string{cidr1},
 		Selector: "label1 == 'value1'",
 		Ports: []numorstring.Port{
@@ -74,7 +73,6 @@ var InRule2 = apiv2.Rule{
 	Protocol:  &numProtocol1,
 	ICMP:      &icmp1,
 	Source: apiv2.EntityRule{
-		Tag:      "tag2",
 		Nets:     []string{cidrv61},
 		Selector: "has(label2)",
 	},
@@ -86,7 +84,6 @@ var EgressRule1 = apiv2.Rule{
 	Protocol:  &numProtocol1,
 	ICMP:      &icmp1,
 	Source: apiv2.EntityRule{
-		Tag:      "tag3",
 		Nets:     []string{cidr2},
 		Selector: "all()",
 	},
@@ -98,7 +95,6 @@ var EgressRule2 = apiv2.Rule{
 	Protocol:  &strProtocol2,
 	ICMP:      &icmp1,
 	Source: apiv2.EntityRule{
-		Tag:      "tag4",
 		Nets:     []string{cidrv62},
 		Selector: "label2 == '1234'",
 	},


### PR DESCRIPTION
Bug fixes:

-  Wasn't handling namespace selection correctly (was only in KDD code, but is now non-KDD only)
-  Policy name from k8s policy should not have the namespace in it anymore
-  Added orchestrator label so that k8s-backed policy only applies to k8s WEPs.

Also:
-  Some name prefix changes
