### PR TITLE
Treat a zero struct as a watcher failure.

### DIFF
--- a/lib/backend/k8s/resources/customresource.go
+++ b/lib/backend/k8s/resources/customresource.go
@@ -312,7 +312,7 @@ func (c *customK8sResourceClient) Watch(ctx context.Context, list model.ListInte
 		r.GetObjectKind().SetGroupVersionKind(c.k8sResourceTypeMeta.GetObjectKind().GroupVersionKind())
 		return c.convertResourceToKVPair(r)
 	}
-	return newK8sWatcherConverter(ctx, toKVPair, k8sWatch), nil
+	return newK8sWatcherConverter(ctx, resl.Kind+" (custom)", toKVPair, k8sWatch), nil
 }
 
 // EnsureInitialized is a no-op since the CRD should be

--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -63,9 +63,10 @@ func NewNetworkPolicyClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sReso
 
 // Implements the api.Client interface for NetworkPolicys.
 type networkPolicyClient struct {
-	clientSet *kubernetes.Clientset
-	crdClient *customK8sResourceClient
-	converter conversion.Converter
+	resourceName string
+	clientSet    *kubernetes.Clientset
+	crdClient    *customK8sResourceClient
+	converter    conversion.Converter
 }
 
 func (c *networkPolicyClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -256,7 +257,7 @@ func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterfac
 		}
 		return c.converter.K8sNetworkPolicyToCalico(np)
 	}
-	k8sWatch := newK8sWatcherConverter(ctx, converter, k8sRawWatch)
+	k8sWatch := newK8sWatcherConverter(ctx, "NetworkPolicy (namespaced)", converter, k8sRawWatch)
 
 	calicoWatch, err := c.crdClient.Watch(ctx, list, crdRev)
 	if err != nil {

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -174,7 +174,7 @@ func (c *nodeClient) Watch(ctx context.Context, list model.ListInterface, revisi
 		}
 		return K8sNodeToCalico(k8sNode)
 	}
-	return newK8sWatcherConverter(ctx, converter, k8sWatch), nil
+	return newK8sWatcherConverter(ctx, "Node", converter, k8sWatch), nil
 }
 
 // K8sNodeToCalico converts a Kubernetes format node, with Calico annotations, to a Calico Node.

--- a/lib/backend/k8s/resources/profile.go
+++ b/lib/backend/k8s/resources/profile.go
@@ -150,5 +150,5 @@ func (c *profileClient) Watch(ctx context.Context, list model.ListInterface, rev
 		}
 		return c.converter.NamespaceToProfile(k8sNamespace)
 	}
-	return newK8sWatcherConverter(ctx, converter, k8sWatch), nil
+	return newK8sWatcherConverter(ctx, "Profile", converter, k8sWatch), nil
 }

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -192,5 +192,5 @@ func (c *WorkloadEndpointClient) Watch(ctx context.Context, list model.ListInter
 		}
 		return c.converter.PodToWorkloadEndpoint(k8sPod)
 	}
-	return newK8sWatcherConverter(ctx, converter, k8sWatch), nil
+	return newK8sWatcherConverter(ctx, "Pod", converter, k8sWatch), nil
 }

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -233,7 +233,6 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 		Expect(rulev1.NotICMPCode).To(Equal(&encode))
 		Expect(rulev1.NotICMPType).To(Equal(&entype))
 
-
 		Expect(rulev1.SrcNets).To(Equal([]*cnet.IPNet{mustParseCIDR("10.100.1.1/32")}))
 		Expect(rulev1.SrcSelector).To(Equal("kns.namespacelabel1 == 'value1'"))
 		Expect(rulev1.SrcPorts).To(Equal([]numorstring.Port{port443}))


### PR DESCRIPTION
## Description
Treat a k8s event with no type as an error and shut down the watch.  Presumably, the zero struct is generated by the k8s watcher closing its channel.

Fixes #624 (but may be worth a bit more digging to figure out why the watches are timing out).

## Todos
- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
