### PR TITLE
Specify APIVersion for HostEndpointList

### DIFF
--- a/lib/apis/v2/hostendpoint.go
+++ b/lib/apis/v2/hostendpoint.go
@@ -94,7 +94,8 @@ func NewHostEndpoint() *HostEndpoint {
 func NewHostEndpointList() *HostEndpointList {
 	return &HostEndpointList{
 		TypeMeta: metav1.TypeMeta{
-			Kind: KindHostEndpointList,
+			Kind:       KindHostEndpointList,
+			APIVersion: GroupVersionCurrent,
 		},
 	}
 }


### PR DESCRIPTION
## Description
Guessed fix for this problem...

`calicoctl get hostEndpoint -o yaml` gives
```
 apiVersion: projectcalico.org/v2
 items: []
 kind: HostEndpointList
 metadata:
   resourceVersion: "23"
```
If that same YAML is then given to `calicoctl delete -f`, it says `Unknown resource type (HostEndpointList) and/or version (projectcalico.org/v2)`

Whereas a similar process for any other type of resource gives (reasonably) `No resources in file`.