### PR TITLE
Include TypeMeta in resource returned/converted by NetworkPolicy CRD Client

### DIFF
--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -51,8 +51,13 @@ func NewNetworkPolicyClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sReso
 		resource:        NetworkPolicyResourceName,
 		description:     "Calico Network Policies",
 		k8sResourceType: reflect.TypeOf(apiv2.NetworkPolicy{}),
-		k8sListType:     reflect.TypeOf(apiv2.NetworkPolicyList{}),
-		namespaced:      true,
+		k8sResourceTypeMeta: metav1.TypeMeta{
+			Kind:       apiv2.KindNetworkPolicy,
+			APIVersion: apiv2.GroupVersionCurrent,
+		},
+		k8sListType:  reflect.TypeOf(apiv2.NetworkPolicyList{}),
+		resourceKind: apiv2.KindNetworkPolicy,
+		namespaced:   true,
 	}
 	return &networkPolicyClient{
 		clientSet: c,

--- a/lib/clientv2/networkpolicy_e2e_test.go
+++ b/lib/clientv2/networkpolicy_e2e_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/watch"
 )
 
-var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
+var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
 	ctx := context.Background()
 	order1 := 99.999


### PR DESCRIPTION

## Description
The NetworkPolicy client wasn't passing some parameters that the CustomResourceClient requires to include TypeMeta. Pass them in and enable E2E tests that catch this bug.


## Todos
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
