### PR TITLE
Annotate natOutgoing used to be nat-outgoing in v1 api

### DIFF
--- a/lib/apis/v2/ippool.go
+++ b/lib/apis/v2/ippool.go
@@ -42,7 +42,7 @@ type IPPoolSpec struct {
 	IPIPMode IPIPMode `json:"ipipMode,omitempty" validate:"omitempty,ipipmode"`
 	// When nat-outgoing is true, packets sent from Calico networked containers in
 	// this pool to destinations outside of this pool will be masqueraded.
-	NATOutgoing bool `json:"natOutgoing,omitempty"`
+	NATOutgoing bool `json:"natOutgoing,omitempty" confignamev1:"nat-outgoing"`
 	// When disabled is true, Calico IPAM will not assign addresses from this pool.
 	Disabled bool `json:"disabled,omitempty"`
 }


### PR DESCRIPTION
## Description
Annotate natOutgoing used to be nat-outgoing in v1 api.

## Todos
- [ ] Tests -- I'm going to assume that upgrades, when they're supported, will test this.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
