### PR TITLE
Redfine when a Pod is a valid Calico Workload Endpoint

### DIFF
--- a/lib/backend/k8s/resources/watcher.go
+++ b/lib/backend/k8s/resources/watcher.go
@@ -132,7 +132,7 @@ func (crw *k8sWatcherConverter) convertEvent(kevent kwatch.Event) *api.WatchEven
 			}
 		}
 		if kvp == nil {
-			crw.logCxt.Info("Event converted to a no-op")
+			crw.logCxt.Debug("Event converted to a no-op")
 			return nil
 		}
 	}


### PR DESCRIPTION
Update List/Watch to return KDD WEP that have a Node assigned and are not Host networked.  This removes the requirement of an IP address being assigned.

Fixes https://github.com/projectcalico/libcalico-go/issues/637