### PR TITLE
re-watch rather than re-sync

### DIFF
--- a/lib/apis/v2/networkpolicy_test.go
+++ b/lib/apis/v2/networkpolicy_test.go
@@ -17,10 +17,11 @@ package v2_test
 import (
 	. "github.com/projectcalico/libcalico-go/lib/apis/v2"
 
+	"reflect"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectcalico/libcalico-go/lib/set"
-	"reflect"
 )
 
 var (

--- a/lib/apis/v2/zz_generated.deepcopy.go
+++ b/lib/apis/v2/zz_generated.deepcopy.go
@@ -19,10 +19,11 @@
 package v2
 
 import (
+	reflect "reflect"
+
 	numorstring "github.com/projectcalico/libcalico-go/lib/numorstring"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	reflect "reflect"
 )
 
 func init() {

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -58,7 +58,7 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 	// If the WEP has no IPNetworks assigned then filter out since we can't yet render the rules.
 	if len(v2res.Spec.IPNetworks) == 0 {
 		log.WithFields(log.Fields{
-			"name": v2res.Name,
+			"name":      v2res.Name,
 			"namespace": v2res.Namespace,
 		}).Debug("Filtering out WEP with no IPNetworks")
 		return nil, nil

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Test the WorkloadEndpoint update processor", func() {
 					"projectcalico.org/namespace":    ns1,
 					"projectcalico.org/orchestrator": oid1,
 				},
-				IPv4Nets:   []cnet.IPNet{expectedIPv4Net},
+				IPv4Nets: []cnet.IPNet{expectedIPv4Net},
 			},
 			Revision: "abcde",
 		}))

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -71,6 +71,7 @@ var (
 	emptyList = &model.KVPairList{
 		Revision: "abcdef12345",
 	}
+	notSupported = cerrors.ErrorOperationNotSupported{}
 	genError = errors.New("Generic error")
 )
 
@@ -112,16 +113,16 @@ var _ = Describe("Test the backend datstore multi-watch syncer", func() {
 		//
 		// For resource 1, the client responses should be:
 		// - list succeeds
-		// - watch fails (watch interval)
+		// - watch fails gen error (immediate retry)
 		// - list fails (list interval)
 		// - list succeeds
 		// - watch succeeds ...
 		//
 		// For resource 2, the client responses should be:
 		// - list succeeds
-		// - watch fails (watch interval)
+		// - watch fails with not supported (watch interval)
 		// - list succeeds
-		// - watch fails (watch interval)
+		// - watch fails with not supported (watch interval)
 		// - list succeeds
 		// - watch succeeds ...
 		//
@@ -138,9 +139,9 @@ var _ = Describe("Test the backend datstore multi-watch syncer", func() {
 		rs.clientListResponse(r1, emptyList)
 		rs.clientWatchResponse(r1, nil)
 		rs.clientListResponse(r2, emptyList)
-		rs.clientWatchResponse(r2, genError)
+		rs.clientWatchResponse(r2, notSupported)
 		rs.clientListResponse(r2, emptyList)
-		rs.clientWatchResponse(r2, genError)
+		rs.clientWatchResponse(r2, notSupported)
 		rs.clientListResponse(r2, emptyList)
 		rs.clientWatchResponse(r2, nil)
 		By("Expecting the time for all events to be handled is within a sensible window")
@@ -159,7 +160,7 @@ var _ = Describe("Test the backend datstore multi-watch syncer", func() {
 
 		// Sim. for resource 3.  We send in these client responses:
 		// - list succeeds
-		// - watch fails (watch interval)
+		// - watch fails with not supported (watch interval)
 		// - list fails (list interval)
 		// - list succeeds
 		// - watch succeeds ... total 6s
@@ -169,7 +170,7 @@ var _ = Describe("Test the backend datstore multi-watch syncer", func() {
 		maxDuration = 130 * expectedDuration / 100
 		rs.clientListResponse(r3, emptyList)
 		rs.ExpectStatusUpdate(api.InSync)
-		rs.clientWatchResponse(r3, genError)
+		rs.clientWatchResponse(r3, notSupported)
 		rs.clientListResponse(r3, genError)
 		rs.clientListResponse(r3, emptyList)
 		rs.clientWatchResponse(r3, nil)

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -157,11 +157,12 @@ func UpdateErrorIdentifier(err error, id interface{}) error {
 
 // Error indicating the watcher has been terminated.
 type ErrorWatchTerminated struct {
-	Err error
+	Err            error
+	ClosedByRemote bool
 }
 
 func (e ErrorWatchTerminated) Error() string {
-	return fmt.Sprintf("watch terminated: %s", e.Err)
+	return fmt.Sprintf("watch terminated (closedByRemote:%v): %s", e.ClosedByRemote, e.Err)
 }
 
 // Error indicating the datastore has failed to parse an entry.


### PR DESCRIPTION
## Description
If the reason for the watch failure was closure by the remote end, retry watching before doing a full resync.

-  In the KDD watcher code, if the channel was closed by the remote, flag that in the error
-  In the watchersyncer, keep track of the "last seen" revision
-  In the watchersyncer, if the channel was closed by the remote, start watching from the last seen revision.

I have also added a 30min timeout for the CRDs - the default if not specified is 1 minute.  In the code review comments I point to a couple of places in the k8s code the show this timeout behavior.

I have not added additional handling of different error types - I think that would require significant testing overhead that is not going to be possible within the timeframe. 