### PR TITLE
Fix panics in test code and use log formatter to improve the test logs

### DIFF
--- a/lib/backend/k8s/k8s_suite_test.go
+++ b/lib/backend/k8s/k8s_suite_test.go
@@ -19,9 +19,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestModel(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Model Suite")
 }

--- a/lib/backend/k8s/resources/resources_suite_test.go
+++ b/lib/backend/k8s/resources/resources_suite_test.go
@@ -19,9 +19,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestModel(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "K8s resources Suite")
 }

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_suite_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "BGP syncer test suite")
 }

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1_suite_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Felix syncer test suite")
 }

--- a/lib/backend/syncersv1/updateprocessors/updateprocessors_suite_test.go
+++ b/lib/backend/syncersv1/updateprocessors/updateprocessors_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Syncer update processors suite")
 }

--- a/lib/backend/watchersyncer/watchersyncer_suite_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Backend multi-watcher/syncer test suite")
 }

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -72,7 +72,7 @@ var (
 		Revision: "abcdef12345",
 	}
 	notSupported = cerrors.ErrorOperationNotSupported{}
-	genError = errors.New("Generic error")
+	genError     = errors.New("Generic error")
 )
 
 var _ = Describe("Test the backend datstore multi-watch syncer", func() {

--- a/lib/clientv2/client_suite_test.go
+++ b/lib/clientv2/client_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "client Suite")
 }

--- a/lib/clientv2/watch_e2e_test.go
+++ b/lib/clientv2/watch_e2e_test.go
@@ -39,8 +39,8 @@ import (
 var _ = testutils.E2eDatastoreDescribe("Additional watch tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
 	ctx := context.Background()
-	numEvents := 10000
-	numWatchers := 1000
+	numEvents := 5000
+	numWatchers := 100
 
 	Describe("Test prefix deletion of the datastore", func() {
 		It("should receive watch events for each of the deleted keys", func() {

--- a/lib/clientv2/watch_e2e_test.go
+++ b/lib/clientv2/watch_e2e_test.go
@@ -156,6 +156,7 @@ var _ = testutils.E2eDatastoreDescribe("Additional watch tests", testutils.Datas
 				wg.Add(1)
 				go func(w watch.Interface) {
 					log.Info("Running test event consumer")
+					defer GinkgoRecover()
 					defer wg.Done()
 					for e := range w.ResultChan() {
 						if e.Type == watch.Deleted {

--- a/lib/health/health_suite_test.go
+++ b/lib/health/health_suite_test.go
@@ -23,11 +23,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-func init() {
-	testutils.HookLogrusForGinkgo()
-}
-
 func TestSet(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Health Suite")
 }

--- a/lib/logutils/logutils_suite_test.go
+++ b/lib/logutils/logutils_suite_test.go
@@ -15,25 +15,18 @@
 package logutils_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
-
 	"github.com/onsi/ginkgo/reporters"
-	"github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-func init() {
-	testutils.HookLogrusForGinkgo()
-	logrus.AddHook(&logutils.ContextHook{})
-	logrus.SetFormatter(&logutils.Formatter{})
-}
-
 func TestLogutils(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("junit.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Logutils Suite", []Reporter{junitReporter})

--- a/lib/set/set_suite_test.go
+++ b/lib/set/set_suite_test.go
@@ -25,11 +25,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-func init() {
-	testutils.HookLogrusForGinkgo()
-}
-
 func TestSet(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("junit.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Set Suite", []Reporter{junitReporter})

--- a/lib/testutils/ginkgolog.go
+++ b/lib/testutils/ginkgolog.go
@@ -16,9 +16,13 @@ package testutils
 import (
 	"github.com/onsi/ginkgo"
 	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/logutils"
 )
 
 func HookLogrusForGinkgo() {
+	logrus.AddHook(logutils.ContextHook{})
+	logrus.SetFormatter(&logutils.Formatter{})
 	logrus.SetOutput(ginkgo.GinkgoWriter)
 	logrus.SetLevel(logrus.DebugLevel)
 }

--- a/lib/validator/validator_suite_test.go
+++ b/lib/validator/validator_suite_test.go
@@ -23,11 +23,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-func init() {
-	testutils.HookLogrusForGinkgo()
-}
-
 func TestValidator(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Validator Suite")
 }


### PR DESCRIPTION
Fixes in this PR are:
-  Use GinkgoRecover in a test groutine - so we get better diags
-  Fix up the syncer tester code to handle the fact that we didn't get the correct number of events (this was causing a panic in a test).  This PR does not fix up the flake that caused that situation in the first place, but at least we'll get better diags now.
-  Update the logging across a slew of our test suites.
-  Reduce the size of the watcher test as we were running out of memory now that I'd beefed up the logs.

There are a few places where I moved the call to `testutils.HookLogrusForGinkgo()` out of an `init()` into the test suite main function - this is basically to ensure someone doesn't copy and paste this into a test suite that is in a non-test package.