### PR TITLE
Combine CRD+K8s NP resource versions in the Calico NP resource version

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -535,3 +535,27 @@ func (c Converter) ProfileNameToNamespace(profileName string) (string, error) {
 
 	return strings.TrimPrefix(profileName, NamespaceProfileNamePrefix), nil
 }
+
+// JoinNetworkPolicyRevisions constructs the revision from the individual CRD and K8s NetworkPolicy
+// revisions.
+func (c Converter) JoinNetworkPolicyRevisions(crdNPRev, k8sNPRev string) string {
+	return crdNPRev + "/" + k8sNPRev
+}
+
+// SplitNetworkPolicyRevision extracts the CRD and K8s NetworkPolicy revisions from the combined
+// revision returned on the KDD NetworkPolicy client.
+func (c Converter) SplitNetworkPolicyRevision(rev string) (crdNPRev string, k8sNPRev string, err error) {
+	if rev == "" {
+		return
+	}
+
+	revs := strings.Split(rev, "/")
+	if len(revs) != 2 {
+		err = fmt.Errorf("ResourceVersion is not valid: %s", rev)
+		return
+	}
+
+	crdNPRev = revs[0]
+	k8sNPRev = revs[1]
+	return
+}

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -1629,4 +1629,49 @@ var _ = Describe("Test Namespace conversion", func() {
 			Expect(Egress[0]).To(Equal(apiv2.Rule{Action: apiv2.Allow}))
 		})
 	})
+
+	It("should handle NetworkPolicy resource versions", func() {
+		By("converting crd and k8s versions to the correct combined version")
+		rev := c.JoinNetworkPolicyRevisions("1234", "5678")
+		Expect(rev).To(Equal("1234/5678"))
+
+		rev = c.JoinNetworkPolicyRevisions("", "5678")
+		Expect(rev).To(Equal("/5678"))
+
+		rev = c.JoinNetworkPolicyRevisions("1234", "")
+		Expect(rev).To(Equal("1234/"))
+
+		By("extracting crd and k8s versions from the combined version")
+		crdRev, k8sRev, err := c.SplitNetworkPolicyRevision("")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crdRev).To(Equal(""))
+		Expect(k8sRev).To(Equal(""))
+
+		crdRev, k8sRev, err = c.SplitNetworkPolicyRevision("/")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crdRev).To(Equal(""))
+		Expect(k8sRev).To(Equal(""))
+
+		crdRev, k8sRev, err = c.SplitNetworkPolicyRevision("1234/5678")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crdRev).To(Equal("1234"))
+		Expect(k8sRev).To(Equal("5678"))
+
+		crdRev, k8sRev, err = c.SplitNetworkPolicyRevision("/5678")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crdRev).To(Equal(""))
+		Expect(k8sRev).To(Equal("5678"))
+
+		crdRev, k8sRev, err = c.SplitNetworkPolicyRevision("1234/")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crdRev).To(Equal("1234"))
+		Expect(k8sRev).To(Equal(""))
+
+		By("failing to convert an invalid combined version")
+		_, _, err = c.SplitNetworkPolicyRevision("1234")
+		Expect(err).To(HaveOccurred())
+
+		_, _, err = c.SplitNetworkPolicyRevision("1234/5678/1313")
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/lib/clientv2/node.go
+++ b/lib/clientv2/node.go
@@ -17,13 +17,14 @@ package clientv2
 import (
 	"context"
 
+	"fmt"
+
 	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
+	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/names"
+	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/watch"
-	"github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/projectcalico/libcalico-go/lib/errors"
-	"fmt"
 )
 
 // NodeInterface has methods to work with Node resources.
@@ -78,7 +79,7 @@ func (r nodes) Delete(ctx context.Context, name string, opts options.DeleteOptio
 	// Get all weps belonging to the node
 	weps, err := r.client.WorkloadEndpoints().List(ctx, options.ListOptions{
 		Prefix: true,
-		Name: pname,
+		Name:   pname,
 	})
 	if err != nil {
 		return nil, err

--- a/lib/clientv2/node_e2e_test.go
+++ b/lib/clientv2/node_e2e_test.go
@@ -15,8 +15,8 @@
 package clientv2_test
 
 import (
-	"time"
 	"net"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -25,17 +25,18 @@ import (
 
 	"context"
 
+	"fmt"
+
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv2 "github.com/projectcalico/libcalico-go/lib/apis/v2"
 	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/clientv2"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 	"github.com/projectcalico/libcalico-go/lib/watch"
-	cnet "github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/projectcalico/libcalico-go/lib/ipam"
-	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"fmt"
 )
 
 var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
@@ -74,7 +75,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 			},
 		},
 	}
-	Describe("nodes", func () {
+	Describe("nodes", func() {
 		It("should clean up weps, IPAM allocations, etc. when deleted", func() {
 			c, err := clientv2.New(config)
 			Expect(err).NotTo(HaveOccurred())
@@ -107,7 +108,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 
 			affBlock := cnet.IPNet{
 				IPNet: net.IPNet{
-					IP: net.IP{192, 168, 0, 0},
+					IP:   net.IP{192, 168, 0, 0},
 					Mask: net.IPMask{255, 255, 255, 0},
 				},
 			}
@@ -116,7 +117,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 
 			handle := "myhandle"
 			err = c.IPAM().AssignIP(ctx, ipam.AssignIPArgs{
-				IP: cnet.IP{wepIp},
+				IP:       cnet.IP{wepIp},
 				Hostname: name1,
 				HandleID: &handle,
 			})
@@ -124,19 +125,19 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 
 			wep := apiv2.WorkloadEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:             "node--1-k8s-mypod-mywep",
+					Name:      "node--1-k8s-mypod-mywep",
 					Namespace: "default",
 				},
 				Spec: apiv2.WorkloadEndpointSpec{
 					InterfaceName: "eth0",
-					Pod: "mypod",
-					Endpoint: "mywep",
+					Pod:           "mypod",
+					Endpoint:      "mywep",
 					IPNetworks: []string{
 						swepIp,
 					},
-					Node: name1,
-					Orchestrator:     "k8s",
-					Workload:         "default.fakepod",
+					Node:         name1,
+					Orchestrator: "k8s",
+					Workload:     "default.fakepod",
 				},
 			}
 			_, err = c.WorkloadEndpoints().Create(ctx, &wep, options.SetOptions{})


### PR DESCRIPTION
## Description

This PR updates the KDD NetworkPolicy client to use a ResourceVersion for the NP resources that is a combination of the CRD backed NP and the k8s native NP.  

The primary use case is for the WatcherSyncer code, but I've plumbed this through to all of the CRUD operations.