### PR TITLE
Fix up parsing of rules with no selector

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -76,8 +76,10 @@ func RuleAPIV2ToBackend(ar apiv2.Rule, ns string) model.Rule {
 	}
 
 	srcSelector := ar.Source.Selector
-	if sourceNSSelector != "" {
+	if sourceNSSelector != "" && (ar.Source.Selector != "" || ar.Source.NotSelector != "" || ar.Source.NamespaceSelector != "") {
 		// We need to namespace the rule's selector when converting to a v1 object.
+		// This occurs when a Selector, NotSelector, or NamespaceSelector is provided and either this is a
+		// namespaced NetworkPolicy object, or a NamespaceSelector was defined.
 		logCxt := log.WithFields(log.Fields{
 			"Namespace":         ns,
 			"Selector":          ar.Source.Selector,
@@ -93,8 +95,10 @@ func RuleAPIV2ToBackend(ar apiv2.Rule, ns string) model.Rule {
 	}
 
 	dstSelector := ar.Destination.Selector
-	if destNSSelector != "" {
+	if destNSSelector != "" && (ar.Destination.Selector != "" || ar.Destination.NotSelector != "" || ar.Destination.NamespaceSelector != "") {
 		// We need to namespace the rule's selector when converting to a v1 object.
+		// This occurs when a Selector, NotSelector, or NamespaceSelector is provided and either this is a
+		// namespaced NetworkPolicy object, or a NamespaceSelector was defined.
 		logCxt := log.WithFields(log.Fields{
 			"Namespace":         ns,
 			"Selector":          ar.Destination.Selector,

--- a/lib/backend/syncersv1/updateprocessors/rules_test.go
+++ b/lib/backend/syncersv1/updateprocessors/rules_test.go
@@ -212,6 +212,42 @@ var _ = Describe("Test the Rules Conversion Functions", func() {
 		})
 	})
 
+	It("should parse a rule with ports but no selectors", func() {
+		tcp := numorstring.ProtocolFromString("tcp")
+		port80 := numorstring.SinglePort(uint16(80))
+
+		r := apiv2.Rule{
+			Action:   apiv2.Allow,
+			Protocol: &tcp,
+			Source: apiv2.EntityRule{
+				Ports: []numorstring.Port{port80},
+			},
+			Destination: apiv2.EntityRule{
+				Ports: []numorstring.Port{port80},
+			},
+		}
+
+		// Process the rule and get the corresponding v1 representation.
+		rulev1 := updateprocessors.RuleAPIV2ToBackend(r, "")
+
+		By("generating an empty source selector", func() {
+			Expect(rulev1.SrcSelector).To(Equal(""))
+		})
+
+		By("generating the correct ingress ports", func() {
+			Expect(rulev1.SrcPorts).To(Equal([]numorstring.Port{port80}))
+		})
+
+		By("generating an empty destination selector", func() {
+			Expect(rulev1.DstSelector).To(Equal(""))
+		})
+
+		By("generating the correct egress ports", func() {
+			Expect(rulev1.DstPorts).To(Equal([]numorstring.Port{port80}))
+		})
+
+	})
+
 	It("should parse a rule with both a selector and namespace selector", func() {
 		r := apiv2.Rule{
 			Action: apiv2.Allow,
@@ -234,7 +270,7 @@ var _ = Describe("Test the Rules Conversion Functions", func() {
 		})
 
 		By("generating the correct destination selector", func() {
-			Expect(rulev1.SrcSelector).To(Equal(expected))
+			Expect(rulev1.DstSelector).To(Equal(expected))
 		})
 	})
 
@@ -263,5 +299,4 @@ var _ = Describe("Test the Rules Conversion Functions", func() {
 			Expect(rulev1.SrcSelector).To(Equal(e))
 		})
 	})
-
 })


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This fixes a(nother) bug in the namespace selector logic.

We were always namespacing the rules, even if no selectors were provided.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
