### PR TITLE
Handle no-op events in KDD watcher 

### DIFF
--- a/lib/backend/k8s/resources/watcher.go
+++ b/lib/backend/k8s/resources/watcher.go
@@ -106,6 +106,10 @@ func (crw *k8sWatcherConverter) processK8sEvents() {
 			} else {
 				// We have a valid event, so convert it.
 				e = crw.convertEvent(event)
+				if e == nil {
+					crw.logCxt.Debug("Event converted to a no-op")
+					continue
+				}
 			}
 
 			select {
@@ -148,7 +152,6 @@ func (crw *k8sWatcherConverter) convertEvent(kevent kwatch.Event) *api.WatchEven
 			}
 		}
 		if kvp == nil {
-			crw.logCxt.Debug("Event converted to a no-op")
 			return nil
 		}
 	}


### PR DESCRIPTION
## Description
Recently added code to filter out host-networked pods by converting the pod event to a no-op.  Looks like this wasn't handled all the way up the stack.

