### PR TITLE
Fix NetworkPolicy watcher:

### DIFF
--- a/lib/backend/k8s/resources/watcher.go
+++ b/lib/backend/k8s/resources/watcher.go
@@ -80,9 +80,9 @@ func (crw *k8sWatcherConverter) HasTerminated() bool {
 // Loop to process the events stream from the underlying k8s Watcher and convert them to
 // backend KVPs.
 func (crw *k8sWatcherConverter) processK8sEvents() {
-	crw.logCxt.Info("Watcher process started")
+	crw.logCxt.Info("Kubernetes watcher/converter started")
 	defer func() {
-		crw.logCxt.Info("Watcher process terminated")
+		crw.logCxt.Info("Kubernetes watcher/converter stopped, closing result channel")
 		crw.Stop()
 		close(crw.resultChan)
 		atomic.AddUint32(&crw.terminated, 1)

--- a/lib/backend/watchersyncer/watchercache.go
+++ b/lib/backend/watchersyncer/watchercache.go
@@ -85,6 +85,7 @@ func (wc *watcherCache) run() {
 			// If the channel is closed then resync/recreate the watch.
 			wc.logger.Info("Watch channel closed by remote - recreate watcher")
 			wc.resyncAndCreateWatcher()
+			continue
 		}
 
 		// Handle the specific event type.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- In watcher cache, restart loop after a channel closure rather than trying to process the zero-valued event.
- In networkPolicyWatcher,
  - only try to cast the value if it is non-nil so that error events are passed through
  - fix the scoping of variables to avoid leaking values from one loop to the next
- Improve logs in the watcher; avoid using the work "process", which was confusing.

Fixes #669 

## Todos
- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
