### PR TITLE
Update log.Fatal -> log.Panic

### DIFF
--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -193,7 +193,7 @@ func (syn *etcdSyncer) readSnapshotsFromEtcd(
 				if syn.OneShot {
 					// One-shot mode is used to grab a snapshot and then
 					// stop.  We don't want to go into a retry loop.
-					log.Fatal("Failed to read snapshot from etcd: ", err)
+					log.Panic("Failed to read snapshot from etcd: ", err)
 				}
 				log.Warning("Error getting snapshot, retrying...", err)
 				time.Sleep(1 * time.Second)
@@ -392,7 +392,7 @@ func (syn *etcdSyncer) pollClusterID(interval time.Duration) {
 				log.WithFields(log.Fields{
 					"oldID": lastSeenClusterID,
 					"newID": resp.ClusterID,
-				}).Fatal("etcd cluster ID changed; must exit.")
+				}).Panic("etcd cluster ID changed; must exit.")
 			}
 		}
 		// Jitter by 10% of interval.

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -126,7 +126,7 @@ func (key ResourceKey) defaultPath() (string, error) {
 func (key ResourceKey) defaultDeletePath() (string, error) {
 	ri, ok := resourceInfoByKind[strings.ToLower(key.Kind)]
 	if !ok {
-		log.Fatal("Unexpected resource kind: " + key.Kind)
+		log.Panic("Unexpected resource kind: " + key.Kind)
 	}
 	if namespace.IsNamespaced(key.Kind) {
 		return fmt.Sprintf("/calico/resources/v3/projectcalico.org/%s/%s/%s", ri.plural, key.Namespace, key.Name), nil
@@ -141,7 +141,7 @@ func (key ResourceKey) defaultDeleteParentPaths() ([]string, error) {
 func (key ResourceKey) valueType() reflect.Type {
 	ri, ok := resourceInfoByKind[strings.ToLower(key.Kind)]
 	if !ok {
-		log.Fatal("Unexpected resource kind: " + key.Kind)
+		log.Panic("Unexpected resource kind: " + key.Kind)
 	}
 	return ri.typeOf
 }
@@ -176,7 +176,7 @@ func (options ResourceListOptions) IsLastSegmentIsPrefix() bool {
 func (options ResourceListOptions) KeyFromDefaultPath(path string) Key {
 	ri, ok := resourceInfoByKind[strings.ToLower(options.Kind)]
 	if !ok {
-		log.Fatal("Unexpected resource kind: " + options.Kind)
+		log.Panic("Unexpected resource kind: " + options.Kind)
 	}
 
 	if namespace.IsNamespaced(options.Kind) {
@@ -239,7 +239,7 @@ func (options ResourceListOptions) KeyFromDefaultPath(path string) Key {
 func (options ResourceListOptions) defaultPathRoot() string {
 	ri, ok := resourceInfoByKind[strings.ToLower(options.Kind)]
 	if !ok {
-		log.Fatal("Unexpected resource kind: " + options.Kind)
+		log.Panic("Unexpected resource kind: " + options.Kind)
 	}
 
 	k := "/calico/resources/v3/projectcalico.org/" + ri.plural

--- a/lib/backend/syncersv1/updateprocessors/bgpconfigprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/bgpconfigprocessor.go
@@ -57,7 +57,7 @@ var logLevelToBirdLogLevel = func(value interface{}) interface{} {
 var nodeMeshToString = func(value interface{}) interface{} {
 	enabled := value.(bool)
 	d, err := json.Marshal(nodeToNodeMesh{Enabled: enabled})
-	cerrors.FatalIfErrored(err)
+	cerrors.PanicIfErrored(err, "Unexpected error trying to marshal nodeToNodeMesh structure")
 	return string(d)
 }
 

--- a/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc.go
+++ b/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc.go
@@ -130,14 +130,14 @@ func (c *conflictResolvingCache) Process(kvp *model.KVPair) ([]*model.KVPair, er
 		// Get the old key, we know this succeeds because we had to get the default path to put it
 		// in the cache.
 		oldV1Key, err := model.KeyToDefaultPath(existing.Key)
-		cerrors.FatalIfErrored(err)
+		cerrors.PanicIfErrored(err, "Unable to convert key to path (for key that has already been converted): name=%s, key=%v", name, existing.Key)
 
 		// If the key has changed, first handle this as a delete.  This may result in a
 		// delete response that we need to include.
 		if oldV1Key != v1Key {
 			logCxt.WithField("Old key", oldV1Key).Info("key modified, handle delete first")
 			response, err = c.delete(name)
-			cerrors.FatalIfErrored(err)
+			cerrors.PanicIfErrored(err, "Key entry is not in cache, but should be: name=%s", name)
 		}
 	}
 
@@ -188,7 +188,7 @@ func (c *conflictResolvingCache) delete(name string) ([]*model.KVPair, error) {
 	// Calculate the key for that resource.  This should succeed because we already called
 	// this to get the entry in the cache.
 	v1Key, err := model.KeyToDefaultPath(kvp.Key)
-	cerrors.FatalIfErrored(err)
+	cerrors.PanicIfErrored(err, "Unable to convert key to path (for key that has already been converted): key=%v", kvp.Key)
 
 	// Get the current set of names that map to this key and use this to determine what
 	// updates to send.

--- a/lib/backend/watchersyncer/watchercache.go
+++ b/lib/backend/watchersyncer/watchercache.go
@@ -115,7 +115,7 @@ func (wc *watcherCache) run() {
 			}
 		default:
 			// Unknown event type - not much we can do other than log.
-			wc.logger.WithField("EventType", event.Type).Fatal("Unknown event type received from the datastore")
+			wc.logger.WithField("EventType", event.Type).Panic("Unknown event type received from the datastore")
 		}
 	}
 }

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -998,7 +998,7 @@ func (fw *listWatchSource) list() (*model.KVPairList, error) {
 		log.WithField("Name", fw.name).Info("Returning results from List invocation")
 		return r, nil
 	default:
-		log.WithField("Result", r).Fatal("Unexpected result on list result channel")
+		log.WithField("Result", r).Panic("Unexpected result on list result channel")
 		return nil, nil
 	}
 }
@@ -1015,7 +1015,7 @@ func (fw *listWatchSource) watch() (api.WatchInterface, error) {
 		// results channel.
 		select {
 		case r := <-fw.results:
-			log.Fatalf("Test harness for %s expects results chan to be empty during watch creation: %v", fw.name, r)
+			log.Panicf("Test harness for %s expects results chan to be empty during watch creation: %v", fw.name, r)
 		default:
 		}
 
@@ -1073,7 +1073,7 @@ func (w *watcher) ResultChan() <-chan api.WatchEvent {
 
 func (w *watcher) HasTerminated() bool {
 	// Never invoked by the syncer code, so no need to return anything sensible.
-	log.WithField("Name", w.name).Fatalf("HasTerminated called on watcher - not expected")
+	log.WithField("Name", w.name).Panicf("HasTerminated called on watcher - not expected")
 	return false
 }
 

--- a/lib/clientv3/client.go
+++ b/lib/clientv3/client.go
@@ -85,7 +85,7 @@ func (c client) NetworkPolicies() NetworkPolicyInterface {
 
 // Policies returns an interface for managing policy resources.
 func (c client) GlobalNetworkPolicies() GlobalNetworkPolicyInterface {
-	return globalnetworkpolicies{client: c}
+	return globalNetworkPolicies{client: c}
 }
 
 // IPPools returns an interface for managing IP pool resources.

--- a/lib/clientv3/globalnetworkpolicy.go
+++ b/lib/clientv3/globalnetworkpolicy.go
@@ -33,14 +33,14 @@ type GlobalNetworkPolicyInterface interface {
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
 }
 
-// globalnetworkpolicies implements GlobalNetworkPolicyInterface
-type globalnetworkpolicies struct {
+// globalNetworkPolicies implements GlobalNetworkPolicyInterface
+type globalNetworkPolicies struct {
 	client client
 }
 
 // Create takes the representation of a GlobalNetworkPolicy and creates it.  Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
-func (r globalnetworkpolicies) Create(ctx context.Context, res *apiv3.GlobalNetworkPolicy, opts options.SetOptions) (*apiv3.GlobalNetworkPolicy, error) {
+func (r globalNetworkPolicies) Create(ctx context.Context, res *apiv3.GlobalNetworkPolicy, opts options.SetOptions) (*apiv3.GlobalNetworkPolicy, error) {
 	defaultPolicyTypesField(res.Spec.Ingress, res.Spec.Egress, &res.Spec.Types)
 
 	// Properly prefix the name
@@ -59,7 +59,7 @@ func (r globalnetworkpolicies) Create(ctx context.Context, res *apiv3.GlobalNetw
 
 // Update takes the representation of a GlobalNetworkPolicy and updates it. Returns the stored
 // representation of the GlobalNetworkPolicy, and an error, if there is any.
-func (r globalnetworkpolicies) Update(ctx context.Context, res *apiv3.GlobalNetworkPolicy, opts options.SetOptions) (*apiv3.GlobalNetworkPolicy, error) {
+func (r globalNetworkPolicies) Update(ctx context.Context, res *apiv3.GlobalNetworkPolicy, opts options.SetOptions) (*apiv3.GlobalNetworkPolicy, error) {
 	defaultPolicyTypesField(res.Spec.Ingress, res.Spec.Egress, &res.Spec.Types)
 
 	// Properly prefix the name
@@ -77,7 +77,7 @@ func (r globalnetworkpolicies) Update(ctx context.Context, res *apiv3.GlobalNetw
 }
 
 // Delete takes name of the GlobalNetworkPolicy and deletes it. Returns an error if one occurs.
-func (r globalnetworkpolicies) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.GlobalNetworkPolicy, error) {
+func (r globalNetworkPolicies) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.GlobalNetworkPolicy, error) {
 	out, err := r.client.resources.Delete(ctx, opts, apiv3.KindGlobalNetworkPolicy, noNamespace, convertPolicyNameForStorage(name))
 	if out != nil {
 		// Remove the prefix out of the returned policy name.
@@ -89,7 +89,7 @@ func (r globalnetworkpolicies) Delete(ctx context.Context, name string, opts opt
 
 // Get takes name of the GlobalNetworkPolicy, and returns the corresponding GlobalNetworkPolicy object,
 // and an error if there is any.
-func (r globalnetworkpolicies) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.GlobalNetworkPolicy, error) {
+func (r globalNetworkPolicies) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.GlobalNetworkPolicy, error) {
 	out, err := r.client.resources.Get(ctx, opts, apiv3.KindGlobalNetworkPolicy, noNamespace, convertPolicyNameForStorage(name))
 	if out != nil {
 		// Remove the prefix out of the returned policy name.
@@ -100,7 +100,7 @@ func (r globalnetworkpolicies) Get(ctx context.Context, name string, opts option
 }
 
 // List returns the list of GlobalNetworkPolicy objects that match the supplied options.
-func (r globalnetworkpolicies) List(ctx context.Context, opts options.ListOptions) (*apiv3.GlobalNetworkPolicyList, error) {
+func (r globalNetworkPolicies) List(ctx context.Context, opts options.ListOptions) (*apiv3.GlobalNetworkPolicyList, error) {
 	res := &apiv3.GlobalNetworkPolicyList{}
 	if err := r.client.resources.List(ctx, opts, apiv3.KindGlobalNetworkPolicy, apiv3.KindGlobalNetworkPolicyList, res); err != nil {
 		return nil, err
@@ -115,9 +115,9 @@ func (r globalnetworkpolicies) List(ctx context.Context, opts options.ListOption
 	return res, nil
 }
 
-// Watch returns a watch.Interface that watches the globalnetworkpolicies that match the
+// Watch returns a watch.Interface that watches the globalNetworkPolicies that match the
 // supplied options.
-func (r globalnetworkpolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+func (r globalNetworkPolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
 	return r.client.resources.Watch(ctx, opts, apiv3.KindGlobalNetworkPolicy)
 }
 

--- a/lib/errors/panic.go
+++ b/lib/errors/panic.go
@@ -16,9 +16,9 @@ package errors
 
 import log "github.com/sirupsen/logrus"
 
-// FatalIfErrored logs and panics if the supplied error is non-nil.
-func FatalIfErrored(err error) {
+// PanicIfErrored logs and panics if the supplied error is non-nil.
+func PanicIfErrored(err error, msgformat string, args ...interface{}) {
 	if err != nil {
-		log.WithError(err).Fatal("Unexpected code error requiring restart")
+		log.WithError(err).Panicf(msgformat, args...)
 	}
 }

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -787,13 +787,13 @@ func (c ipamClient) decrementHandle(ctx context.Context, handleID string, blockC
 	for i := 0; i < ipamEtcdRetries; i++ {
 		obj, err := c.client.Get(ctx, model.IPAMHandleKey{HandleID: handleID}, "")
 		if err != nil {
-			log.Fatalf("Can't decrement block because it doesn't exist")
+			log.WithField("handleID", handleID).WithError(err).Panic("Can't decrement block because it doesn't exist")
 		}
 		handle := allocationHandle{obj.Value.(*model.IPAMHandle)}
 
 		_, err = handle.decrementBlock(blockCIDR, num)
 		if err != nil {
-			log.Fatalf("Can't decrement block - too few allocated")
+			log.WithField("handleID", handleID).WithError(err).Panic("Can't decrement block - too few allocated")
 		}
 
 		// Update / Delete as appropriate.  Since we have been manipulating the
@@ -904,7 +904,7 @@ func decideHostname(host string) string {
 	} else {
 		hostname, err = os.Hostname()
 		if err != nil {
-			log.Fatalf("Failed to acquire hostname")
+			log.Panicf("Failed to acquire hostname")
 		}
 	}
 	log.Debugf("Using hostname=%s", hostname)

--- a/lib/ipam/ipam_block.go
+++ b/lib/ipam/ipam_block.go
@@ -406,7 +406,7 @@ func ipToOrdinal(ip cnet.IP, b allocationBlock) int {
 	ord := big.NewInt(0).Sub(ip_int, base_int).Int64()
 	if ord < 0 || ord >= blockSize {
 		// IP address not in the given block.
-		log.Fatalf("IP %s not in block %s", ip, b.CIDR)
+		log.Panicf("IP %s not in block %s", ip, b.CIDR)
 	}
 	return int(ord)
 }

--- a/lib/testutils/syncertester.go
+++ b/lib/testutils/syncertester.go
@@ -77,13 +77,13 @@ func (st *SyncerTester) OnStatusUpdated(status api.SyncStatus) {
 		// None of the concrete syncers that we are testing expect should have the same
 		// status update repeated, nor should the status decrease.  Log and panic.
 		if status == current {
-			log.WithField("Status", status).Fatal("Duplicate identical status updates from syncer")
+			log.WithField("Status", status).Panic("Duplicate identical status updates from syncer")
 		}
 		if status < current {
 			log.WithFields(log.Fields{
 				"NewStatus": status,
 				"OldStatus": st.status,
-			}).Fatal("Decrementing status updates from syncer")
+			}).Panic("Decrementing status updates from syncer")
 		}
 	}
 

--- a/lib/validator/common.go
+++ b/lib/validator/common.go
@@ -75,7 +75,7 @@ func ValidateMetadataIDsAssigned(rm unversioned.ResourceMetadata) error {
 			return errors.ErrorInsufficientIdentifiers{Name: "name"}
 		}
 	default:
-		log.Fatal(fmt.Errorf("Unexpected resource metadata: %s", metadata))
+		log.Panic(fmt.Errorf("Unexpected resource metadata: %s", metadata))
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Update calls to log.Fatal to be log.Panic instead.

From @fasaxc:

 A `log.Fatal` doesn’t give a stack trace and it can’t be caught by the test machinery so it gives poor diags in the field and, if it happens in your test case, then the ginkgo process does an Exit(1), swallowing the logs that it had buffered.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note


```release-note
None required
```