### PR TITLE
Revert calculation of veth name in kdd

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -51,11 +51,11 @@ type Converter struct {
 
 // VethNameForWorkload returns a deterministic veth name
 // for the given Kubernetes workload (WEP) name and namespace.
-func VethNameForWorkload(namespace, name string) string {
+func VethNameForWorkload(namespace, podname string) string {
 	// A SHA1 is always 20 bytes long, and so is sufficient for generating the
 	// veth name and mac addr.
 	h := sha1.New()
-	h.Write([]byte(fmt.Sprintf("%s/%s", namespace, name)))
+	h.Write([]byte(fmt.Sprintf("%s.%s", namespace, podname)))
 	return fmt.Sprintf("cali%s", hex.EncodeToString(h.Sum(nil))[:11])
 }
 
@@ -173,7 +173,7 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 
 	// Generate the interface name based on workload.  This must match
 	// the host-side veth configured by the CNI plugin.
-	interfaceName := VethNameForWorkload(pod.Namespace, wepName)
+	interfaceName := VethNameForWorkload(pod.Namespace, pod.Name)
 
 	// Build the labels map.  Start with the pod labels, and append two additional labels for
 	// namespace and orchestrator matches.

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -163,6 +163,11 @@ var _ = Describe("Test Pod conversion", func() {
 			// Unknown protocol port is ignored.
 		))
 
+		// Assert the interface name is fixed.  The calculation of this name should be consistent
+		// between releases otherwise there will be issues upgrading a node with networked Pods.
+		// If this fails, fix the code not this expect!
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.InterfaceName).To(Equal("cali7f94ce7c295"))
+
 		// Assert ResourceVersion is present.
 		Expect(wep.Revision).To(Equal("1234"))
 	})
@@ -170,7 +175,7 @@ var _ = Describe("Test Pod conversion", func() {
 	It("should not parse a Pod without an IP to a WorkloadEndpoint", func() {
 		pod := kapiv1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "podA",
+				Name:      "podB",
 				Namespace: "default",
 				Annotations: map[string]string{
 					"arbitrary": "annotation",
@@ -193,7 +198,7 @@ var _ = Describe("Test Pod conversion", func() {
 	It("should parse a Pod with no labels", func() {
 		pod := kapiv1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "podA",
+				Name:      "podB",
 				Namespace: "default",
 			},
 			Spec: kapiv1.PodSpec{
@@ -208,11 +213,11 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields.
-		Expect(wep.Key.(model.ResourceKey).Name).To(Equal("nodeA-k8s-podA-eth0"))
+		Expect(wep.Key.(model.ResourceKey).Name).To(Equal("nodeA-k8s-podB-eth0"))
 		Expect(wep.Key.(model.ResourceKey).Namespace).To(Equal("default"))
 		Expect(wep.Key.(model.ResourceKey).Kind).To(Equal(apiv3.KindWorkloadEndpoint))
 		// Assert value fields.
-		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.Pod).To(Equal("podA"))
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.Pod).To(Equal("podB"))
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.Node).To(Equal("nodeA"))
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.Endpoint).To(Equal("eth0"))
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.Orchestrator).To(Equal("k8s"))
@@ -221,6 +226,11 @@ var _ = Describe("Test Pod conversion", func() {
 			"projectcalico.org/namespace":    "default",
 			"projectcalico.org/orchestrator": "k8s",
 		}))
+
+		// Assert the interface name is fixed.  The calculation of this name should be consistent
+		// between releases otherwise there will be issues upgrading a node with networked Pods.
+		// If this fails, fix the code not this expect!
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.InterfaceName).To(Equal("cali92cf1f5e9f6"))
 	})
 
 	It("should not parse a Pod with no NodeName", func() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The calculation of the veth name has changed - this reverts that change.

IIUC without that change, upgrading the calico/node on a node that has Calico networked Pods - those pods will not be networked correctly after upgrade because Felix view of the interface name will differ from the interface name that was actually created.

Also added #677 to test against the release-1.7 branch.  Don't need to commit that one unless we think we should - I just added as a sanity check for this PR.

## Todos
- [ ] cni
- [ ] felix


```release-note
None required
```
