### PR TITLE
Fix error message when the minimum port of a range is invalid

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -416,10 +416,10 @@ func validatePort(v *validator.Validate, structLevel *validator.StructLevel) {
 		}
 	} else if p.MinPort < 1 {
 		structLevel.ReportError(reflect.ValueOf(p.MinPort),
-			"Port", "", reason("port range invalid, port number must be between 0 and 65536"))
+			"Port", "", reason("port range invalid, port number must be between 1 and 65535"))
 	} else if p.MaxPort < 1 {
 		structLevel.ReportError(reflect.ValueOf(p.MaxPort),
-			"Port", "", reason("port range invalid, port number must be between 0 and 65536"))
+			"Port", "", reason("port range invalid, port number must be between 1 and 65535"))
 	}
 }
 

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -414,7 +414,10 @@ func validatePort(v *validator.Validate, structLevel *validator.StructLevel) {
 			structLevel.ReportError(reflect.ValueOf(p.PortName),
 				"Port", "", reason("named port invalid, if name is specified, min and max should be 0"))
 		}
-	} else if p.MinPort < 1 || p.MaxPort < 1 {
+	} else if p.MinPort < 1 {
+		structLevel.ReportError(reflect.ValueOf(p.MinPort),
+			"Port", "", reason("port range invalid, port number must be between 0 and 65536"))
+	} else if p.MaxPort < 1 {
 		structLevel.ReportError(reflect.ValueOf(p.MaxPort),
 			"Port", "", reason("port range invalid, port number must be between 0 and 65536"))
 	}

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -68,6 +68,26 @@ func init() {
 	// Max name length
 	maxNameLength := 253
 
+	// Perform validation on error messages from validator
+	DescribeTable("Validator errors",
+		func(input interface{}, e string) {
+			err := v3.Validate(input)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal(e))
+		},
+		Entry("should reject Rule with invalid port (name + number)",
+			api.Rule{
+				Action:   "Allow",
+				Protocol: protocolFromString("TCP"),
+				Destination: api.EntityRule{
+					NotPorts: []numorstring.Port{{
+						MinPort: 0,
+						MaxPort: 456,
+					}},
+				},
+			}, "error with field Port = '0' (port range invalid, port number must be between 1 and 65535)"),
+	)
+
 	// Perform basic validation of different fields and structures to test simple valid/invalid
 	// scenarios.  This does not test precise error strings - but does cover a lot of the validation
 	// code paths.


### PR DESCRIPTION
For example, prior to this change, for YAML

apiVersion: projectcalico.org/v3
kind: NetworkPolicy
metadata:
  name: policy2
spec:
  Egress:
  - action: Deny
    destination: {}
    protocol: TCP
    source:
      ports:
      - 0:65535
  Ingress:
  - action: Allow
    destination: {}
    protocol: UDP
    source: {}
  order: 100000
  selector: ''

calicoctl says:

Failed to execute command: error with field Port = '65535' (port range invalid, port number must be between 0 and 65536)
