### PR TITLE
Fixed issues with not all API functions being consistent

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c0e7407ccf235e89513f6a3e4f2a01bd3ceca847ff3a50378b3e97bc84d16c30
-updated: 2017-10-18T11:59:01.494957752-07:00
+hash: ee2ca161587aa178e381cfb3b0f304b2c6dd68e5bfead27a347a9f203c33af39
+updated: 2017-11-16T16:07:52.422843395-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -18,7 +18,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
-  version: f1d7dd87da3e8feab4aaf675b8e29c6a5ed5f58b
+  version: bb66589f8cf18960c7f3d56b1b83753caeed9c7a
   subpackages:
   - auth/authpb
   - client
@@ -142,7 +142,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: c893efa28eb45626cdaa76c9f653b62488858837
+  version: 1eecca0ba8e6f5ea5a431ce21d3aee2af0b4c90b
   subpackages:
   - format
   - internal/assertion
@@ -254,7 +254,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  version: 9d8544a6b2c7df9cff240fcf92d7b2f59bc13416
   subpackages:
   - internal
   - internal/app_identity
@@ -290,7 +290,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 6c6dac0277229b9e9578c5ca3f74a4345d35cdc2
+  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -415,7 +415,7 @@ imports:
   - util/integer
   - util/jsonpath
 - name: k8s.io/code-generator
-  version: 0c5165a97e055df28cca8bbcb8b7c8ae1019b3f1
+  version: 6db2ee6aa9ab51230d6e0d970b398274a88e81b0
 - name: k8s.io/gengo
   version: 70ad626ed2d7a483d89d2c4c56364d60b48ee8fc
 - name: k8s.io/kube-openapi

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/projectcalico/libcalico-go
 import:
 - package: github.com/coreos/etcd
-  version: ^3.2.7
+  version: 3.2.7
   subpackages:
   - client
   - clientv3

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -124,6 +124,9 @@ func (c *etcdV3Client) Create(ctx context.Context, d *model.KVPair) (*model.KVPa
 		return existing, cerrors.ErrorResourceAlreadyExists{Identifier: d.Key}
 	}
 
+	v, err := model.ParseValue(d.Key, []byte(value))
+	cerrors.PanicIfErrored(err, "Unexpected error parsing stored datastore entry: %v", value)
+	d.Value = v
 	d.Revision = strconv.FormatInt(txnResp.Header.Revision, 10)
 
 	return d, nil
@@ -182,6 +185,9 @@ func (c *etcdV3Client) Update(ctx context.Context, d *model.KVPair) (*model.KVPa
 		return existing, cerrors.ErrorResourceUpdateConflict{Identifier: d.Key}
 	}
 
+	v, err := model.ParseValue(d.Key, []byte(value))
+	cerrors.PanicIfErrored(err, "Unexpected error parsing stored datastore entry: %v", value)
+	d.Value = v
 	d.Revision = strconv.FormatInt(txnResp.Header.Revision, 10)
 
 	return d, nil
@@ -207,6 +213,9 @@ func (c *etcdV3Client) Apply(d *model.KVPair) (*model.KVPair, error) {
 		return nil, cerrors.ErrorDatastoreError{Err: err}
 	}
 
+	v, err := model.ParseValue(d.Key, []byte(value))
+	cerrors.PanicIfErrored(err, "Unexpected error parsing stored datastore entry: %v", value)
+	d.Value = v
 	d.Revision = strconv.FormatInt(resp.Header.Revision, 10)
 
 	return d, nil

--- a/lib/clientv3/common_test.go
+++ b/lib/clientv3/common_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("Common resource tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+	Describe("Common resource tests", func() {
+		It("Should return the data that was stored in the datastore, even if it was changed", func() {
+			ctx := context.Background()
+			name1 := "ippool-1"
+			spec1 := apiv3.IPPoolSpec{
+				CIDR:     "1.2.3.0/24",
+				IPIPMode: apiv3.IPIPModeAlways,
+			}
+			c, err := clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			be.Clean()
+
+			By("Creating a new IPPool with name1/spec1 and expecting CreationTimestamp nanoseconds to be stripped off")
+			now := time.Now()
+			res1, outError := c.IPPools().Create(ctx, &apiv3.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, CreationTimestamp: metav1.Time{now}},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			testutils.ExpectResource(res1, apiv3.KindIPPool, testutils.ExpectNoNamespace, name1, spec1)
+			// Make sure that the timestamp is the same except for the inclusion of nanoseconds
+			timestamp := res1.GetObjectMeta().GetCreationTimestamp()
+			Expect(timestamp.Day()).To(Equal(now.Day()))
+			Expect(timestamp.Hour()).To(Equal(now.Hour()))
+			Expect(timestamp.Minute()).To(Equal(now.Minute()))
+			Expect(timestamp.Month()).To(Equal(now.Month()))
+			Expect(timestamp.Nanosecond()).To(Equal(0))
+			Expect(timestamp.Second()).To(Equal(now.Second()))
+			Expect(timestamp.Year()).To(Equal(now.Year()))
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Deleting IPPool (name1) with the new resource version")
+			dres, outError := c.IPPools().Delete(ctx, name1, options.DeleteOptions{ResourceVersion: rv1_1})
+			Expect(outError).NotTo(HaveOccurred())
+			// The pool will first be disabled, so tweak the Disabled field before doing the comparison.
+			spec1.Disabled = true
+			testutils.ExpectResource(dres, apiv3.KindIPPool, testutils.ExpectNoNamespace, name1, spec1)
+		})
+	})
+})

--- a/lib/clientv3/globalnetworkpolicy.go
+++ b/lib/clientv3/globalnetworkpolicy.go
@@ -111,6 +111,11 @@ func (r globalNetworkPolicies) Get(ctx context.Context, name string, opts option
 // List returns the list of GlobalNetworkPolicy objects that match the supplied options.
 func (r globalNetworkPolicies) List(ctx context.Context, opts options.ListOptions) (*apiv3.GlobalNetworkPolicyList, error) {
 	res := &apiv3.GlobalNetworkPolicyList{}
+	// Add the name prefix if name is provided
+	if opts.Name != "" {
+		opts.Name = convertPolicyNameForStorage(opts.Name)
+	}
+
 	if err := r.client.resources.List(ctx, opts, apiv3.KindGlobalNetworkPolicy, apiv3.KindGlobalNetworkPolicyList, res); err != nil {
 		return nil, err
 	}
@@ -127,6 +132,11 @@ func (r globalNetworkPolicies) List(ctx context.Context, opts options.ListOption
 // Watch returns a watch.Interface that watches the globalNetworkPolicies that match the
 // supplied options.
 func (r globalNetworkPolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	// Add the name prefix if name is provided
+	if opts.Name != "" {
+		opts.Name = convertPolicyNameForStorage(opts.Name)
+	}
+
 	return r.client.resources.Watch(ctx, opts, apiv3.KindGlobalNetworkPolicy)
 }
 

--- a/lib/clientv3/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv3/globalnetworkpolicy_e2e_test.go
@@ -405,7 +405,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			// Only etcdv3 supports watching a specific instance of a resource.
 			if config.Spec.DatastoreType == apiconfig.EtcdV3 {
 				By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
-				w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{Name: "default." + name1, ResourceVersion: rev0})
+				w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
 				Expect(err).NotTo(HaveOccurred())
 				testWatcher2_1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
 				defer testWatcher2_1.Stop()

--- a/lib/clientv3/networkpolicy.go
+++ b/lib/clientv3/networkpolicy.go
@@ -110,6 +110,11 @@ func (r networkPolicies) Get(ctx context.Context, namespace, name string, opts o
 // List returns the list of NetworkPolicy objects that match the supplied options.
 func (r networkPolicies) List(ctx context.Context, opts options.ListOptions) (*apiv3.NetworkPolicyList, error) {
 	res := &apiv3.NetworkPolicyList{}
+	// Add the name prefix if name is provided
+	if opts.Name != "" {
+		opts.Name = convertPolicyNameForStorage(opts.Name)
+	}
+
 	if err := r.client.resources.List(ctx, opts, apiv3.KindNetworkPolicy, apiv3.KindNetworkPolicyList, res); err != nil {
 		return nil, err
 	}
@@ -126,5 +131,10 @@ func (r networkPolicies) List(ctx context.Context, opts options.ListOptions) (*a
 // Watch returns a watch.Interface that watches the NetworkPolicies that match the
 // supplied options.
 func (r networkPolicies) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	// Add the name prefix if name is provided
+	if opts.Name != "" {
+		opts.Name = convertPolicyNameForStorage(opts.Name)
+	}
+
 	return r.client.resources.Watch(ctx, opts, apiv3.KindNetworkPolicy)
 }

--- a/lib/clientv3/networkpolicy_e2e_test.go
+++ b/lib/clientv3/networkpolicy_e2e_test.go
@@ -429,7 +429,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			// Only etcdv3 supports watching a specific instance of a resource.
 			if config.Spec.DatastoreType == apiconfig.EtcdV3 {
 				By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
-				w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{Namespace: namespace1, Name: "default." + name1, ResourceVersion: rev0})
+				w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{Namespace: namespace1, Name: name1, ResourceVersion: rev0})
 				Expect(err).NotTo(HaveOccurred())
 				testWatcher2_1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
 				defer testWatcher2_1.Stop()


### PR DESCRIPTION
## Description
Fixes some consistency errors with the API and cases where it could be used:
1. Return values from `Create`, `Apply`, `Update` requests will mirror the exact information that was stored, not just the information that was passed in.
2. `List` and `Watch` functions will handle name prefixing properly for policies so that the return values from `Create` or `Update` requests can be used in those functions.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
