### PR TITLE
Added logic to remove prefixes from watcher output

### DIFF
--- a/lib/clientv3/bgpconfig.go
+++ b/lib/clientv3/bgpconfig.go
@@ -110,7 +110,7 @@ func (r bgpConfigurations) List(ctx context.Context, opts options.ListOptions) (
 // Watch returns a watch.Interface that watches the BGPConfiguration that
 // match the supplied options.
 func (r bgpConfigurations) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindBGPConfiguration)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindBGPConfiguration, nil)
 }
 
 func (r bgpConfigurations) ValidateDefaultOnlyFields(res *apiv3.BGPConfiguration) error {

--- a/lib/clientv3/bgppeer.go
+++ b/lib/clientv3/bgppeer.go
@@ -97,5 +97,5 @@ func (r bgpPeers) List(ctx context.Context, opts options.ListOptions) (*apiv3.BG
 // Watch returns a watch.Interface that watches the BGPPeers that match the
 // supplied options.
 func (r bgpPeers) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindBGPPeer)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindBGPPeer, nil)
 }

--- a/lib/clientv3/clusterinfo.go
+++ b/lib/clientv3/clusterinfo.go
@@ -104,5 +104,5 @@ func (r clusterInformation) List(ctx context.Context, opts options.ListOptions) 
 // Watch returns a watch.Interface that watches the ClusterInformation that
 // match the supplied options.
 func (r clusterInformation) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindClusterInformation)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindClusterInformation, nil)
 }

--- a/lib/clientv3/felixconfig.go
+++ b/lib/clientv3/felixconfig.go
@@ -100,5 +100,5 @@ func (r felixConfigurations) List(ctx context.Context, opts options.ListOptions)
 // Watch returns a watch.Interface that watches the FelixConfiguration that
 // match the supplied options.
 func (r felixConfigurations) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindFelixConfiguration)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindFelixConfiguration, nil)
 }

--- a/lib/clientv3/globalnetworkpolicy.go
+++ b/lib/clientv3/globalnetworkpolicy.go
@@ -137,7 +137,7 @@ func (r globalNetworkPolicies) Watch(ctx context.Context, opts options.ListOptio
 		opts.Name = convertPolicyNameForStorage(opts.Name)
 	}
 
-	return r.client.resources.Watch(ctx, opts, apiv3.KindGlobalNetworkPolicy)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindGlobalNetworkPolicy, &policyConverter{})
 }
 
 func defaultPolicyTypesField(ingressRules, egressRules []apiv3.Rule, types *[]apiv3.PolicyType) {
@@ -176,4 +176,11 @@ func convertPolicyNameFromStorage(name string) string {
 	}
 	parts := strings.SplitN(name, ".", 2)
 	return parts[len(parts)-1]
+}
+
+type policyConverter struct{}
+
+func (pc *policyConverter) Convert(r resource) resource {
+	r.GetObjectMeta().SetName(convertPolicyNameFromStorage(r.GetObjectMeta().GetName()))
+	return r
 }

--- a/lib/clientv3/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv3/globalnetworkpolicy_e2e_test.go
@@ -322,8 +322,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			Expect(err).NotTo(HaveOccurred())
 
 			rev1 := outRes1.ResourceVersion
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes1.GetObjectMeta().SetName("default." + name1)
 
 			By("Configuring a GlobalNetworkPolicy name2/spec2 and storing the response")
 			outRes2, err := c.GlobalNetworkPolicies().Create(
@@ -334,8 +332,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				},
 				options.SetOptions{},
 			)
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes2.GetObjectMeta().SetName("default." + name2)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
 			w, err := c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
@@ -367,8 +363,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
-			// Update the name to reflect the name that would be passed in from calicoctl
-			outRes2.GetObjectMeta().SetName(name2)
 			outRes3, err := c.GlobalNetworkPolicies().Update(
 				ctx,
 				&apiv3.GlobalNetworkPolicy{
@@ -378,9 +372,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				options.SetOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes2.GetObjectMeta().SetName("default." + name2)
-			outRes3.GetObjectMeta().SetName("default." + name2)
 			testWatcher2.ExpectEvents(apiv3.KindGlobalNetworkPolicy, []watch.Event{
 				{
 					Type:   watch.Added,
@@ -444,8 +435,6 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				},
 				options.SetOptions{},
 			)
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes1.GetObjectMeta().SetName("default." + name1)
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.GlobalNetworkPolicies().Watch(ctx, options.ListOptions{})

--- a/lib/clientv3/hostendpoint.go
+++ b/lib/clientv3/hostendpoint.go
@@ -97,5 +97,5 @@ func (r hostEndpoints) List(ctx context.Context, opts options.ListOptions) (*api
 // Watch returns a watch.Interface that watches the HostEndpoints that match the
 // supplied options.
 func (r hostEndpoints) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindHostEndpoint)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindHostEndpoint, nil)
 }

--- a/lib/clientv3/ippool.go
+++ b/lib/clientv3/ippool.go
@@ -194,7 +194,7 @@ func (r ipPools) List(ctx context.Context, opts options.ListOptions) (*apiv3.IPP
 // Watch returns a watch.Interface that watches the IPPools that match the
 // supplied options.
 func (r ipPools) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindIPPool)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindIPPool, nil)
 }
 
 // validateAndSetDefaults validates IPPool fields and sets default values that are

--- a/lib/clientv3/networkpolicy.go
+++ b/lib/clientv3/networkpolicy.go
@@ -136,5 +136,5 @@ func (r networkPolicies) Watch(ctx context.Context, opts options.ListOptions) (w
 		opts.Name = convertPolicyNameForStorage(opts.Name)
 	}
 
-	return r.client.resources.Watch(ctx, opts, apiv3.KindNetworkPolicy)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindNetworkPolicy, &policyConverter{})
 }

--- a/lib/clientv3/networkpolicy_e2e_test.go
+++ b/lib/clientv3/networkpolicy_e2e_test.go
@@ -346,8 +346,6 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 				options.SetOptions{},
 			)
 			rev1 := outRes1.ResourceVersion
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes1.GetObjectMeta().SetName("default." + name1)
 
 			By("Configuring a NetworkPolicy namespace2/name2/spec2 and storing the response")
 			outRes2, err := c.NetworkPolicies().Create(
@@ -358,8 +356,6 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 				},
 				options.SetOptions{},
 			)
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes2.GetObjectMeta().SetName("default." + name2)
 
 			By("Starting a watcher from revision rev1 - this should skip the first creation")
 			w, err := c.NetworkPolicies().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
@@ -391,8 +387,6 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			defer testWatcher2.Stop()
 
 			By("Modifying res2")
-			// Update the name to reflect the name that would be passed in from calicoctl
-			outRes2.GetObjectMeta().SetName(name2)
 			outRes3, err := c.NetworkPolicies().Update(
 				ctx,
 				&apiv3.NetworkPolicy{
@@ -402,9 +396,6 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 				options.SetOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())
-			// Update the name to reflect the underlying data returned from the watcher
-			outRes2.GetObjectMeta().SetName("default." + name2)
-			outRes3.GetObjectMeta().SetName("default." + name2)
 			testWatcher2.ExpectEvents(apiv3.KindNetworkPolicy, []watch.Event{
 				{
 					Type:   watch.Added,

--- a/lib/clientv3/node.go
+++ b/lib/clientv3/node.go
@@ -208,5 +208,5 @@ func (r nodes) List(ctx context.Context, opts options.ListOptions) (*apiv3.NodeL
 // Watch returns a watch.Interface that watches the Nodes that match the
 // supplied options.
 func (r nodes) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindNode)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindNode, nil)
 }

--- a/lib/clientv3/profile.go
+++ b/lib/clientv3/profile.go
@@ -97,5 +97,5 @@ func (r profiles) List(ctx context.Context, opts options.ListOptions) (*apiv3.Pr
 // Watch returns a watch.Interface that watches the Profiles that match the
 // supplied options.
 func (r profiles) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindProfile)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindProfile, nil)
 }

--- a/lib/clientv3/workloadendpoint.go
+++ b/lib/clientv3/workloadendpoint.go
@@ -104,7 +104,7 @@ func (r workloadEndpoints) List(ctx context.Context, opts options.ListOptions) (
 // Watch returns a watch.Interface that watches the NetworkPolicies that match the
 // supplied options.
 func (r workloadEndpoints) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return r.client.resources.Watch(ctx, opts, apiv3.KindWorkloadEndpoint)
+	return r.client.resources.Watch(ctx, opts, apiv3.KindWorkloadEndpoint, nil)
 }
 
 // assignOrValidateName either assigns the name calculated from the Spec fields, or validates


### PR DESCRIPTION
## Description
Make it so the internal name prefixes on the policy objects are stripped out and consistent with what the user interacts with.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
