### PR TITLE
Support for ServiceAccount in policy

### DIFF
--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -15,6 +15,8 @@
 package apiconfig
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
@@ -26,6 +28,7 @@ const (
 	EtcdV3              DatastoreType = "etcdv3"
 	Kubernetes          DatastoreType = "kubernetes"
 	KindCalicoAPIConfig               = "CalicoAPIConfig"
+	AlphaFeatureSA                    = "serviceaccounts"
 )
 
 // CalicoAPIConfig contains the connection information for a Calico CalicoAPIConfig resource
@@ -44,6 +47,8 @@ type CalicoAPIConfigSpec struct {
 	EtcdConfig
 	// Inline the k8s config fields.
 	KubeConfig
+	// Alpha Feature set: comma separated list of alpha features that are enabled.
+	AlphaFeatures string `json:"alphafeatures" envconfig:"ALPHA_FEATURES" default:""`
 }
 
 type EtcdConfig struct {
@@ -75,4 +80,18 @@ func NewCalicoAPIConfig() *CalicoAPIConfig {
 			APIVersion: apiv3.GroupVersionCurrent,
 		},
 	}
+}
+
+// IsAlphaFeatureSet checks if the comma separated features have the
+// name set in it.
+func IsAlphaFeatureSet(features, name string) bool {
+
+	fs := strings.Split(features, ",")
+	for _, f := range fs {
+		if f == name {
+			return true
+		}
+	}
+
+	return false
 }

--- a/lib/apis/v3/constants.go
+++ b/lib/apis/v3/constants.go
@@ -32,6 +32,10 @@ const (
 	// and may be used for label matches by Policy selectors.
 	LabelNamespace = "projectcalico.org/namespace"
 
+	// Label used to denote the ServiceAccount.  This is added to the workload endpoints by Calico
+	// and may be used for label matches by Policy selectors.
+	LabelServiceAccount = "projectcalico.org/serviceaccount"
+
 	// Label used to denote the Orchestrator.  This is added to the workload endpoints by an
 	// orchestrator.
 	LabelOrchestrator = "projectcalico.org/orchestrator"

--- a/lib/apis/v3/policy.go
+++ b/lib/apis/v3/policy.go
@@ -129,6 +129,21 @@ type EntityRule struct {
 	// Since only some protocols have ports, if any ports are specified it requires the
 	// Protocol match in the Rule to be set to "TCP" or "UDP".
 	NotPorts []numorstring.Port `json:"notPorts,omitempty" validate:"omitempty,dive"`
+
+	// ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+	// terminates at) a pod running as a matching service account.
+	ServiceAccounts *ServiceAccountMatch `json:"serviceAccounts,omitempty" validate:"omitempty"`
+}
+
+type ServiceAccountMatch struct {
+	// Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+	// at) a pod running as a service account whose name is in the list.
+	Names []string `json:"names,omitempty" validate:"omitempty"`
+
+	// Selector is an optional field that restricts the rule to only apply to traffic that originates from
+	// (or terminates at) a pod running as a service account that matches the given label selector.
+	// If both Names and Selector are specified then they are AND'ed.
+	Selector string `json:"selector,omitempty" validate:"omitempty"`
 }
 
 type Action string

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -32,7 +32,7 @@ func NewClient(config apiconfig.CalicoAPIConfig) (c bapi.Client, err error) {
 	case apiconfig.EtcdV3:
 		c, err = etcdv3.NewEtcdV3Client(&config.Spec.EtcdConfig)
 	case apiconfig.Kubernetes:
-		c, err = k8s.NewKubeClient(&config.Spec.KubeConfig)
+		c, err = k8s.NewKubeClient(&config.Spec)
 	default:
 		err = errors.New(fmt.Sprintf("Unknown datastore type: %v",
 			config.Spec.DatastoreType))

--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -15,7 +15,9 @@
 package conversion
 
 const (
-	NamespaceLabelPrefix       = "pcns."
-	NamespaceProfileNamePrefix = "kns."
-	K8sNetworkPolicyNamePrefix = "knp.default."
+	NamespaceLabelPrefix            = "pcns."
+	NamespaceProfileNamePrefix      = "kns."
+	K8sNetworkPolicyNamePrefix      = "knp.default."
+	ServiceAccountLabelPrefix       = "pcsa."
+	ServiceAccountProfileNamePrefix = "ksa."
 )

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -25,6 +25,7 @@ import (
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/names"
@@ -47,6 +48,8 @@ const (
 
 //TODO: make this private and expose a public conversion interface instead
 type Converter struct {
+	// AlphaSA set to true if the alpha feature for serviceaccounts is enabled.
+	AlphaSA bool
 }
 
 // VethNameForWorkload returns a deterministic veth name
@@ -98,7 +101,7 @@ func (c Converter) NamespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, erro
 			Kind: apiv3.KindProfile,
 		},
 		Value:    profile,
-		Revision: ns.ResourceVersion,
+		Revision: c.JoinProfileRevisions(ns.ResourceVersion, ""),
 	}
 	return &kvp, nil
 }
@@ -146,8 +149,18 @@ func (c Converter) HasIPAddress(pod *kapiv1.Pod) bool {
 // PodToWorkloadEndpoint requires a Pods Name and Node Name to be populated. It will
 // fail to convert from a Pod to WorkloadEndpoint otherwise.
 func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error) {
-	// Pull out the profile and workload ID based on pod name and Namespace.
-	profile := NamespaceProfileNamePrefix + pod.Namespace
+
+	// Get all the profiles that apply
+	var profiles []string
+
+	// Pull out the Namespace based profile off the pod name and Namespace.
+	profiles = append(profiles, NamespaceProfileNamePrefix+pod.Namespace)
+
+	// Pull out the Serviceaccount based profile off the pod SA and namespace
+	if c.AlphaSA && pod.Spec.ServiceAccountName != "" {
+		profiles = append(profiles, serviceAccountNameToProfileName(pod.Spec.ServiceAccountName, pod.Namespace))
+	}
+
 	wepids := names.WorkloadEndpointIdentifiers{
 		Node:         pod.Spec.NodeName,
 		Orchestrator: apiv3.OrchestratorKubernetes,
@@ -183,6 +196,10 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 	}
 	labels[apiv3.LabelNamespace] = pod.Namespace
 	labels[apiv3.LabelOrchestrator] = apiv3.OrchestratorKubernetes
+
+	if c.AlphaSA && pod.Spec.ServiceAccountName != "" {
+		labels[apiv3.LabelServiceAccount] = pod.Spec.ServiceAccountName
+	}
 
 	// Map any named ports through.
 	var endpointPorts []apiv3.EndpointPort
@@ -228,7 +245,7 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 		Pod:           pod.Name,
 		Endpoint:      "eth0",
 		InterfaceName: interfaceName,
-		Profiles:      []string{profile},
+		Profiles:      profiles,
 		IPNetworks:    ipNets,
 		Ports:         endpointPorts,
 	}
@@ -557,5 +574,106 @@ func (c Converter) SplitNetworkPolicyRevision(rev string) (crdNPRev string, k8sN
 
 	crdNPRev = revs[0]
 	k8sNPRev = revs[1]
+	return
+}
+
+// serviceAccountNameToProfileName creates a profile name that is a join
+// of 'ksa.' + namespace + "." + serviceaccount name.
+func serviceAccountNameToProfileName(sa, namespace string) string {
+	// Need to incorporate the namespace into the name of the sa based profile
+	// to make them globally unique
+	if namespace == "" {
+		namespace = "default"
+	}
+	return ServiceAccountProfileNamePrefix + namespace + "." + sa
+}
+
+// ServiceAccountToProfile converts a ServiceAccount to a Calico Profile.  The Profile stores
+// labels from the ServiceAccount which are inherited by the WorkloadEndpoints within
+// the Profile.
+func (c Converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KVPair, error) {
+	// Generate the labels to apply to the profile, using a special prefix
+	// to indicate that these are the labels from the parent Kubernetes ServiceAccount.
+	labels := map[string]string{}
+	for k, v := range sa.ObjectMeta.Labels {
+		labels[ServiceAccountLabelPrefix+k] = v
+	}
+
+	name := serviceAccountNameToProfileName(sa.Name, sa.Namespace)
+	profile := apiv3.NewProfile()
+	profile.ObjectMeta = metav1.ObjectMeta{
+		Name:              name,
+		CreationTimestamp: sa.CreationTimestamp,
+		UID:               sa.UID,
+	}
+	profile.Spec = apiv3.ProfileSpec{
+		LabelsToApply: labels,
+	}
+
+	// Embed the profile in a KVPair.
+	kvp := model.KVPair{
+		Key: model.ResourceKey{
+			Name: name,
+			Kind: apiv3.KindProfile,
+		},
+		Value:    profile,
+		Revision: c.JoinProfileRevisions("", sa.ResourceVersion),
+	}
+	return &kvp, nil
+}
+
+// ProfileNameToServiceAccount extracts the ServiceAccount name from the given Profile name.
+func (c Converter) ProfileNameToServiceAccount(profileName string) (ns, sa string, err error) {
+
+	// Profile objects backed by ServiceAccounts have form "ksa.<namespace>.<sa_name>"
+	if !strings.HasPrefix(profileName, ServiceAccountProfileNamePrefix) {
+		// This is not backed by a Kubernetes ServiceAccount.
+		err = fmt.Errorf("Profile %s not backed by a ServiceAccount", profileName)
+		return
+	}
+
+	names := strings.SplitN(profileName, ".", 3)
+	if len(names) != 3 {
+		err = fmt.Errorf("Profile %s is not formatted correctly", profileName)
+		return
+	}
+
+	ns = names[1]
+	sa = names[2]
+	return
+}
+
+// JoinProfileRevisions constructs the revision from the individual namespace and serviceaccount
+// revisions.
+// This is conditional on the feature flag for serviceaccount set or not.
+func (c Converter) JoinProfileRevisions(nsRev, saRev string) string {
+	if c.AlphaSA == false {
+		return nsRev
+	}
+
+	return nsRev + "/" + saRev
+}
+
+// SplitProfileRevision extracts the namespace and serviceaccount revisions from the combined
+// revision returned on the KDD service account based profile.
+// This is conditional on the feature flag for serviceaccount set or not.
+func (c Converter) SplitProfileRevision(rev string) (nsRev string, saRev string, err error) {
+	if rev == "" {
+		return
+	}
+
+	if c.AlphaSA == false {
+		nsRev = rev
+		return
+	}
+
+	revs := strings.Split(rev, "/")
+	if len(revs) != 2 {
+		err = fmt.Errorf("ResourceVersion is not valid: %s", rev)
+		return
+	}
+
+	nsRev = revs[0]
+	saRev = revs[1]
 	return
 }

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -25,7 +25,6 @@ import (
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/names"

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -272,7 +272,8 @@ func (c cb) GetSyncerValuePresentFunc(key model.Key) func() interface{} {
 
 func CreateClientAndSyncer(cfg apiconfig.KubeConfig) (*KubeClient, *cb, api.Syncer) {
 	// First create the client.
-	c, err := NewKubeClient(&cfg)
+	caCfg := apiconfig.CalicoAPIConfigSpec{KubeConfig: cfg}
+	c, err := NewKubeClient(&caCfg)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
@@ -31,9 +32,11 @@ import (
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
 
-func NewWorkloadEndpointClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewWorkloadEndpointClient(c *kubernetes.Clientset, a string) K8sResourceClient {
+	alphaSA := apiconfig.IsAlphaFeatureSet(a, apiconfig.AlphaFeatureSA)
 	return &WorkloadEndpointClient{
 		clientSet: c,
+		converter: conversion.Converter{AlphaSA: alphaSA},
 	}
 }
 

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -128,12 +128,13 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		})
 	}
 
-	// Make sure there are no "namespace" labels on the wep
+	// Make sure there are no "namespace" or "serviceaccount" labels on the wep
 	// we pass to felix. This prevents a wep from pretending it is
 	// in another namespace.
 	labels := map[string]string{}
 	for k, v := range v3res.GetLabels() {
-		if !strings.HasPrefix(k, conversion.NamespaceLabelPrefix) {
+		if !strings.HasPrefix(k, conversion.NamespaceLabelPrefix) &&
+			!strings.HasPrefix(k, conversion.ServiceAccountLabelPrefix) {
 			labels[k] = v
 		}
 	}

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"

--- a/lib/clientv3/client.go
+++ b/lib/clientv3/client.go
@@ -33,7 +33,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/set"
-	"github.com/satori/go.uuid"
 )
 
 // client implements the client.Interface.

--- a/lib/clientv3/globalnetworkpolicy.go
+++ b/lib/clientv3/globalnetworkpolicy.go
@@ -16,8 +16,10 @@ package clientv3
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
@@ -48,6 +50,11 @@ func (r globalNetworkPolicies) Create(ctx context.Context, res *apiv3.GlobalNetw
 		return nil, err
 	}
 
+	// Check if it is permitted to create the network policy with the specific alpha feature support.
+	if err := r.validateAlphaFeatures(res); err != nil {
+		return nil, err
+	}
+
 	// Properly prefix the name
 	res.GetObjectMeta().SetName(convertPolicyNameForStorage(res.GetObjectMeta().GetName()))
 	out, err := r.client.resources.Create(ctx, opts, apiv3.KindGlobalNetworkPolicy, res)
@@ -68,6 +75,11 @@ func (r globalNetworkPolicies) Update(ctx context.Context, res *apiv3.GlobalNetw
 	defaultPolicyTypesField(res.Spec.Ingress, res.Spec.Egress, &res.Spec.Types)
 
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	// Check if it is permitted to create the network policy with the specific alpha feature support.
+	if err := r.validateAlphaFeatures(res); err != nil {
 		return nil, err
 	}
 
@@ -138,6 +150,17 @@ func (r globalNetworkPolicies) Watch(ctx context.Context, opts options.ListOptio
 	}
 
 	return r.client.resources.Watch(ctx, opts, apiv3.KindGlobalNetworkPolicy, &policyConverter{})
+}
+
+func (r globalNetworkPolicies) validateAlphaFeatures(res *apiv3.GlobalNetworkPolicy) error {
+	if apiconfig.IsAlphaFeatureSet(r.client.config.Spec.AlphaFeatures, apiconfig.AlphaFeatureSA) == false {
+		err := validator.ValidateNoServiceAccountRules(res.Spec.Ingress, res.Spec.Egress)
+		if err != nil {
+			return fmt.Errorf("Global NP %s: %s", res.GetObjectMeta().GetName(), err.Error())
+		}
+	}
+
+	return nil
 }
 
 func defaultPolicyTypesField(ingressRules, egressRules []apiv3.Rule, types *[]apiv3.PolicyType) {

--- a/lib/clientv3/workloadendpoint.go
+++ b/lib/clientv3/workloadendpoint.go
@@ -141,8 +141,8 @@ func (r workloadEndpoints) assignOrValidateName(res *apiv3.WorkloadEndpoint) err
 }
 
 // updateLabelsForStorage updates the set of labels that we persist.  It adds/overrides
-// the Namespace and Orchestrator labels which must be set to the correct values and are
-// not user configurable.
+// the Namespace, Orchestrator and if needed the Service account labels which must be
+// set to the correct values and are not user configurable.
 func (r workloadEndpoints) updateLabelsForStorage(res *apiv3.WorkloadEndpoint) {
 	if res.Labels == nil {
 		res.Labels = make(map[string]string, 2)

--- a/lib/converter/rule.go
+++ b/lib/converter/rule.go
@@ -143,6 +143,7 @@ func ruleBackendToAPI(br model.Rule) api.Rule {
 			Type: br.NotICMPType,
 		}
 	}
+
 	return api.Rule{
 		Action:      ruleActionBackendToAPI(br.Action),
 		IPVersion:   br.IPVersion,

--- a/lib/testutils/resources.go
+++ b/lib/testutils/resources.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	yaml "gopkg.in/yaml.v2"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -26,7 +28,6 @@ import (
 
 	"fmt"
 
-	"github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/watch"

--- a/lib/upgrade/etcd/conversionv1v3/names.go
+++ b/lib/upgrade/etcd/conversionv1v3/names.go
@@ -15,14 +15,14 @@
 package conversionv1v3
 
 import (
-	"strings"
 	"regexp"
+	"strings"
 )
 
 var (
-	nonNameChar = regexp.MustCompile("[^-.a-z0-9]+")
-	nonNameNoDotChar = regexp.MustCompile("[^-a-z0-9]+")
-	dotDashSeq = regexp.MustCompile("[.-]*[.][.-]*")
+	nonNameChar               = regexp.MustCompile("[^-.a-z0-9]+")
+	nonNameNoDotChar          = regexp.MustCompile("[^-a-z0-9]+")
+	dotDashSeq                = regexp.MustCompile("[.-]*[.][.-]*")
 	trailingLeadingDotsDashes = regexp.MustCompile("^[.-]*(.*?)[.-]*$")
 )
 
@@ -35,7 +35,7 @@ var (
 // -  Remove leading and trailing dashes and dots
 func convertName(v1Name string) string {
 	name := strings.ToLower(v1Name)
-	name = strings.Replace(name,"/", ".", -1)
+	name = strings.Replace(name, "/", ".", -1)
 	name = nonNameChar.ReplaceAllString(name, "-")
 	name = dotDashSeq.ReplaceAllString(name, ".")
 

--- a/lib/validator/v1/validator.go
+++ b/lib/validator/v1/validator.go
@@ -31,7 +31,6 @@ import (
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"gopkg.in/go-playground/validator.v8"
 )
 
 var validate *validator.Validate

--- a/lib/validator/v3/alphafeaturecheck.go
+++ b/lib/validator/v3/alphafeaturecheck.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"errors"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+)
+
+// ValidateNoServiceAccountRules checks if the set of rules have the
+// serviceAccount match set and if yes then it returns an error.
+func ValidateNoServiceAccountRules(ingress, egress []apiv3.Rule) error {
+	for _, rule := range ingress {
+		if rule.Source.ServiceAccounts != nil ||
+			rule.Destination.ServiceAccounts != nil {
+			return errors.New("alpha feature Service Account Match used")
+		}
+	}
+
+	for _, rule := range egress {
+		if rule.Source.ServiceAccounts != nil ||
+			rule.Destination.ServiceAccounts != nil {
+			return errors.New("alpha feature Service Account Match used")
+		}
+	}
+
+	return nil
+}

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/go-playground/validator.v8"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 


### PR DESCRIPTION
## Description
New feature to support service accounts match in GNP and NP policy.
Service accounts are a basic unit off which security policies are based off. It will be useful for calico policy to support rules that enable users to use them as selectors.
- Implemented using profiles. Profiles now watch both namespaces and service accounts.
- Support is behind a new env variable ALPHA_FEATURE ("serviceaccounts")
- Limited to KDD for now.

Testing:
- Written a few unit tests and have also tested GNP/NP with service account matches.

## Todos
- [ ] Tests
- [ ] Documentation
- [x ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
