### PR TITLE
Add HostEndpoints support for kubernetes datastore

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -198,6 +198,12 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 	kubeClient.registerResourceClient(
 		reflect.TypeOf(model.ResourceKey{}),
 		reflect.TypeOf(model.ResourceListOptions{}),
+		apiv3.KindHostEndpoint,
+		resources.NewHostEndpointClient(cs, crdClientV1),
+	)
+	kubeClient.registerResourceClient(
+		reflect.TypeOf(model.ResourceKey{}),
+		reflect.TypeOf(model.ResourceListOptions{}),
 		apiv3.KindWorkloadEndpoint,
 		resources.NewWorkloadEndpointClient(cs, ca.AlphaFeatures),
 	)
@@ -272,6 +278,7 @@ func (c *KubeClient) Clean() error {
 		apiv3.KindGlobalNetworkPolicy,
 		apiv3.KindGlobalNetworkSet,
 		apiv3.KindIPPool,
+		apiv3.KindHostEndpoint,
 	}
 	ctx := context.Background()
 	for _, k := range kinds {
@@ -339,6 +346,8 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 				&apiv3.GlobalNetworkPolicyList{},
 				&apiv3.NetworkPolicy{},
 				&apiv3.NetworkPolicyList{},
+				&apiv3.HostEndpoint{},
+				&apiv3.HostEndpointList{},
 			)
 			return nil
 		})

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -699,6 +699,157 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 	})
 
+	It("should handle a CRUD of Host Endpoint", func() {
+		kvp1Name := "my-test-hep1"
+		kvp1a := &model.KVPair{
+			Key: model.ResourceKey{Name: kvp1Name, Kind: apiv3.KindHostEndpoint},
+			Value: &apiv3.HostEndpoint{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv3.KindHostEndpoint,
+					APIVersion: apiv3.GroupVersionCurrent,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: kvp1Name,
+				},
+				Spec: apiv3.HostEndpointSpec{
+					Node:          "my-test-node1",
+					InterfaceName: "eth0",
+				},
+			},
+		}
+
+		kvp1b := &model.KVPair{
+			Key: model.ResourceKey{Name: kvp1Name, Kind: apiv3.KindHostEndpoint},
+			Value: &apiv3.HostEndpoint{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv3.KindHostEndpoint,
+					APIVersion: apiv3.GroupVersionCurrent,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: kvp1Name,
+				},
+				Spec: apiv3.HostEndpointSpec{
+					Node:          "my-test-node1",
+					InterfaceName: "eth1",
+				},
+			},
+		}
+
+		kvp2Name := "my-test-hep2"
+		kvp2a := &model.KVPair{
+			Key: model.ResourceKey{Name: kvp2Name, Kind: apiv3.KindHostEndpoint},
+			Value: &apiv3.HostEndpoint{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv3.KindHostEndpoint,
+					APIVersion: apiv3.GroupVersionCurrent,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: kvp2Name,
+				},
+				Spec: apiv3.HostEndpointSpec{
+					Node:          "my-test-node2",
+					InterfaceName: "eth0",
+				},
+			},
+		}
+
+		kvp2b := &model.KVPair{
+			Key: model.ResourceKey{Name: kvp2Name, Kind: apiv3.KindHostEndpoint},
+			Value: &apiv3.HostEndpoint{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv3.KindHostEndpoint,
+					APIVersion: apiv3.GroupVersionCurrent,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: kvp2Name,
+				},
+				Spec: apiv3.HostEndpointSpec{
+					Node:          "my-test-node2",
+					InterfaceName: "eth1",
+				},
+			},
+		}
+
+		var kvpRes *model.KVPair
+		var err error
+
+		// Make sure we clean up after ourselves.  We allow this to fail because
+		// part of our explicit testing below is to delete the resource.
+		defer func() {
+			c.Delete(ctx, kvp1a.Key, "")
+			c.Delete(ctx, kvp2a.Key, "")
+		}()
+
+		By("Creating a Host Endpoint", func() {
+			kvpRes, err = c.Create(ctx, kvp1a)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Attempting to recreate an existing Host Endpoint", func() {
+			_, err := c.Create(ctx, kvp1a)
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Updating an existing Host Endpoint", func() {
+			kvp1b.Revision = kvpRes.Revision
+			_, err := c.Update(ctx, kvp1b)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Create a non-existent Host Endpoint", func() {
+			kvpRes, err = c.Create(ctx, kvp2a)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Updating the Host Endpoint created by Create", func() {
+			kvp2b.Revision = kvpRes.Revision
+			_, err := c.Update(ctx, kvp2b)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Getting a missing Host Endpoint", func() {
+			_, err := c.Get(ctx, model.ResourceKey{Name: "my-non-existent-test-hep", Kind: apiv3.KindHostEndpoint}, "")
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("Listing a missing Host Endpoint", func() {
+			kvps, err := c.List(ctx, model.ResourceListOptions{Name: "my-non-existent-test-hep", Kind: apiv3.KindHostEndpoint}, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps.KVPairs).To(HaveLen(0))
+		})
+
+		By("Listing an explicit Host Endpoint", func() {
+			kvps, err := c.List(ctx, model.ResourceListOptions{Name: kvp1Name, Kind: apiv3.KindHostEndpoint}, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps.KVPairs).To(HaveLen(1))
+			Expect(kvps.KVPairs[0].Key).To(Equal(kvp1b.Key))
+			Expect(kvps.KVPairs[0].Value.(*apiv3.HostEndpoint).ObjectMeta.Name).To(Equal(kvp1b.Value.(*apiv3.HostEndpoint).ObjectMeta.Name))
+			Expect(kvps.KVPairs[0].Value.(*apiv3.HostEndpoint).Spec).To(Equal(kvp1b.Value.(*apiv3.HostEndpoint).Spec))
+		})
+
+		By("Listing all Host Endpoints", func() {
+			kvps, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindHostEndpoint}, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kvps.KVPairs).To(HaveLen(2))
+			keys := []model.Key{}
+			vals := []interface{}{}
+			for _, k := range kvps.KVPairs {
+				keys = append(keys, k.Key)
+				vals = append(vals, k.Value.(*apiv3.HostEndpoint).Spec)
+			}
+			Expect(keys).To(ContainElement(kvp1b.Key))
+			Expect(keys).To(ContainElement(kvp2b.Key))
+			Expect(vals).To(ContainElement(kvp1b.Value.(*apiv3.HostEndpoint).Spec))
+			Expect(vals).To(ContainElement(kvp2b.Value.(*apiv3.HostEndpoint).Spec))
+
+		})
+
+		By("Deleting an existing Host Endpoint", func() {
+			_, err := c.Delete(ctx, kvp1a.Key, "")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	It("should handle a CRUD of BGP Peer", func() {
 		kvp1a := &model.KVPair{
 			Key: model.ResourceKey{

--- a/lib/backend/k8s/resources/hostendpoint.go
+++ b/lib/backend/k8s/resources/hostendpoint.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"reflect"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	HostEndpointResourceName = "HostEndpoints"
+	HostEndpointCRDName      = "hostendpoints.crd.projectcalico.org"
+)
+
+func NewHostEndpointClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	return &customK8sResourceClient{
+		clientSet:       c,
+		restClient:      r,
+		name:            HostEndpointCRDName,
+		resource:        HostEndpointResourceName,
+		description:     "Calico HostEndpoints",
+		k8sResourceType: reflect.TypeOf(apiv3.HostEndpoint{}),
+		k8sResourceTypeMeta: metav1.TypeMeta{
+			Kind:       apiv3.KindHostEndpoint,
+			APIVersion: apiv3.GroupVersionCurrent,
+		},
+		k8sListType:  reflect.TypeOf(apiv3.HostEndpointList{}),
+		resourceKind: apiv3.KindHostEndpoint,
+	}
+}

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -233,69 +233,67 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				Revision: gns.ResourceVersion,
 			})
 
-			if config.Spec.DatastoreType != apiconfig.Kubernetes {
-				By("Creating a HostEndpoint")
-				hep, err := c.HostEndpoints().Create(
-					ctx,
-					&apiv3.HostEndpoint{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "hosta.eth0-a",
-							Labels: map[string]string{
-								"label1": "value1",
-							},
-						},
-						Spec: apiv3.HostEndpointSpec{
-							Node:          "127.0.0.1",
-							InterfaceName: "eth0",
-							ExpectedIPs:   []string{"1.2.3.4", "aa:bb::cc:dd"},
-							Profiles:      []string{"profile1", "profile2"},
-							Ports: []apiv3.EndpointPort{
-								{
-									Name:     "port1",
-									Protocol: numorstring.ProtocolFromString("TCP"),
-									Port:     1234,
-								},
-								{
-									Name:     "port2",
-									Protocol: numorstring.ProtocolFromString("UDP"),
-									Port:     1010,
-								},
-							},
-						},
-					},
-					options.SetOptions{},
-				)
-
-				Expect(err).NotTo(HaveOccurred())
-				// The host endpoint will add as single entry ( +1 )
-				expectedCacheSize += 1
-				syncTester.ExpectCacheSize(expectedCacheSize)
-				syncTester.ExpectData(model.KVPair{
-					Key: model.HostEndpointKey{Hostname: "127.0.0.1", EndpointID: "hosta.eth0-a"},
-					Value: &model.HostEndpoint{
-						Name:              "eth0",
-						ExpectedIPv4Addrs: []net.IP{net.MustParseIP("1.2.3.4")},
-						ExpectedIPv6Addrs: []net.IP{net.MustParseIP("aa:bb::cc:dd")},
+			By("Creating a HostEndpoint")
+			hep, err := c.HostEndpoints().Create(
+				ctx,
+				&apiv3.HostEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hosta.eth0-a",
 						Labels: map[string]string{
 							"label1": "value1",
 						},
-						ProfileIDs: []string{"profile1", "profile2"},
-						Ports: []model.EndpointPort{
+					},
+					Spec: apiv3.HostEndpointSpec{
+						Node:          "127.0.0.1",
+						InterfaceName: "eth0",
+						ExpectedIPs:   []string{"1.2.3.4", "aa:bb::cc:dd"},
+						Profiles:      []string{"profile1", "profile2"},
+						Ports: []apiv3.EndpointPort{
 							{
 								Name:     "port1",
-								Protocol: numorstring.ProtocolFromStringV1("TCP"),
+								Protocol: numorstring.ProtocolFromString("TCP"),
 								Port:     1234,
 							},
 							{
 								Name:     "port2",
-								Protocol: numorstring.ProtocolFromStringV1("UDP"),
+								Protocol: numorstring.ProtocolFromString("UDP"),
 								Port:     1010,
 							},
 						},
 					},
-					Revision: hep.ResourceVersion,
-				})
-			}
+				},
+				options.SetOptions{},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			// The host endpoint will add as single entry ( +1 )
+			expectedCacheSize += 1
+			syncTester.ExpectCacheSize(expectedCacheSize)
+			syncTester.ExpectData(model.KVPair{
+				Key: model.HostEndpointKey{Hostname: "127.0.0.1", EndpointID: "hosta.eth0-a"},
+				Value: &model.HostEndpoint{
+					Name:              "eth0",
+					ExpectedIPv4Addrs: []net.IP{net.MustParseIP("1.2.3.4")},
+					ExpectedIPv6Addrs: []net.IP{net.MustParseIP("aa:bb::cc:dd")},
+					Labels: map[string]string{
+						"label1": "value1",
+					},
+					ProfileIDs: []string{"profile1", "profile2"},
+					Ports: []model.EndpointPort{
+						{
+							Name:     "port1",
+							Protocol: numorstring.ProtocolFromStringV1("TCP"),
+							Port:     1234,
+						},
+						{
+							Name:     "port2",
+							Protocol: numorstring.ProtocolFromStringV1("UDP"),
+							Port:     1010,
+						},
+					},
+				},
+				Revision: hep.ResourceVersion,
+			})
 
 			By("Starting a new syncer and verifying that all current entries are returned before sync status")
 			// We need to create a new syncTester and syncer.

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
@@ -66,15 +66,10 @@ func New(client api.Client, callbacks api.SyncerCallbacks, datastoreType apiconf
 			ListInterface:   model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy},
 			UpdateProcessor: updateprocessors.NewNetworkPolicyUpdateProcessor(),
 		},
-	}
-
-	if datastoreType != apiconfig.Kubernetes {
-		resourceTypes = append(resourceTypes,
-			watchersyncer.ResourceType{
-				ListInterface:   model.ResourceListOptions{Kind: apiv3.KindHostEndpoint},
-				UpdateProcessor: updateprocessors.NewHostEndpointUpdateProcessor(),
-			},
-		)
+		{
+			ListInterface:   model.ResourceListOptions{Kind: apiv3.KindHostEndpoint},
+			UpdateProcessor: updateprocessors.NewHostEndpointUpdateProcessor(),
+		},
 	}
 
 	return watchersyncer.New(

--- a/test/crds.yaml
+++ b/test/crds.yaml
@@ -70,6 +70,19 @@ items:
       kind: GlobalNetworkPolicy
       plural: globalnetworkpolicies
       singular: globalnetworkpolicy
+- apiVersion: apiextensions.k8s.io/v1beta1
+  description: Calico Host Endpoints
+  kind: CustomResourceDefinition
+  metadata:
+    name: hostendpoints.crd.projectcalico.org
+  spec:
+    scope: Cluster
+    group: crd.projectcalico.org
+    version: v1
+    names:
+      kind: HostEndpoint
+      plural: hostendpoints
+      singular: hostendpoint
 # V2 only CRDs.
 - apiVersion: apiextensions.k8s.io/v1beta1
   description: Calico Felix Configuration


### PR DESCRIPTION
## HostEndpoints for kubernetes datasource (CRD)
Currently, kubernetes datastore doesn't allow to create HostEndpoints. It is impossible to filter kubernetes services external traffic without Host Endpoints.

Autotests: based on tests for BGP Peer.

Manual testing:
 - calicoctl allow me to create, list and delete Host Endpoints.
 - felix 3.0.0-alpha1 (with same patch on top of libcalico-go v2.0.0-alpha1) correctly apply GlobalNetworkPolicies with preDNAT: true, applyOnForward: true.

Issues:
- https://github.com/projectcalico/calico/issues/1379

## Todos
- [ ] Documentation
- [ ] Release note

## Release Note
```release-note
Added Kubernetes API datastore support for configuring Host Endpoints
```