### PR TITLE
Conversion of Bgppeer from v1 to v3

### DIFF
--- a/lib/upgrade/etcd/conversionv1v3/bgppeer.go
+++ b/lib/upgrade/etcd/conversionv1v3/bgppeer.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversionv1v3
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
+	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/scope"
+)
+
+// BGPPeer implements the Converter interface.
+type BGPPeer struct{}
+
+// APIV1ToBackendV1 converts v1 BGPPeer API to v1 BGPPeer KVPair.
+func (bp BGPPeer) APIV1ToBackendV1(rIn unversioned.Resource) (*model.KVPair, error) {
+	ap, ok := rIn.(apiv1.BGPPeer)
+	if !ok {
+		return nil, fmt.Errorf("Conversion to BGPPeer is not possible with %v", rIn)
+	}
+
+	if len(ap.Metadata.PeerIP.IP) == 0 {
+		return nil, fmt.Errorf("no PeerIP is set, invalid BGPPeer: %v", rIn)
+	}
+
+	k, err := bp.convertMetadataToKey(ap.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	d := model.KVPair{
+		Key: k,
+		Value: &model.BGPPeer{
+			PeerIP: ap.Metadata.PeerIP,
+			ASNum:  ap.Spec.ASNumber,
+		},
+	}
+
+	log.WithFields(log.Fields{
+		"APIV1":  rIn,
+		"KVPair": d,
+	}).Debug("Converted BGPPeer")
+
+	return &d, nil
+}
+
+func (_ BGPPeer) convertMetadataToKey(bpm apiv1.BGPPeerMetadata) (model.Key, error) {
+	if bpm.Scope == scope.Global {
+		if bpm.Node != "" {
+			return nil, fmt.Errorf("With Global scope having a Node is invalid: %v", bpm)
+		}
+		return model.GlobalBGPPeerKey{
+			PeerIP: bpm.PeerIP,
+		}, nil
+	} else if bpm.Scope == scope.Node {
+		if bpm.Node == "" {
+			return nil, fmt.Errorf("With Node scope a Node must be defined: %v", bpm)
+		}
+		return model.NodeBGPPeerKey{
+			PeerIP:   bpm.PeerIP,
+			Nodename: bpm.Node,
+		}, nil
+	} else {
+		return nil, errors.ErrorInsufficientIdentifiers{
+			Name: "scope",
+		}
+	}
+}
+
+// BackendV1ToAPIV3 converts v1 BGPPeer KVPair to v3 API.
+func (bp BGPPeer) BackendV1ToAPIV3(kvp *model.KVPair) (Resource, error) {
+	peer, ok := kvp.Value.(*model.BGPPeer)
+	if !ok {
+		return nil, fmt.Errorf("value is not a valid BGPPeer resource Value: %v", kvp.Value)
+	}
+
+	r := &apiv3.BGPPeer{
+		Spec: apiv3.BGPPeerSpec{
+			PeerIP:   peer.PeerIP.String(),
+			ASNumber: peer.ASNum,
+		},
+	}
+
+	switch kvp.Key.(type) {
+	case model.GlobalBGPPeerKey:
+		r.ObjectMeta = v1.ObjectMeta{Name: convertIpToName(peer.PeerIP.IP)}
+	case model.NodeBGPPeerKey:
+		nk := kvp.Key.(model.NodeBGPPeerKey)
+		n := convertName(nk.Nodename)
+		r.Spec.Node = n
+		r.ObjectMeta = v1.ObjectMeta{Name: n + "." + convertIpToName(peer.PeerIP.IP)}
+	default:
+		return nil, fmt.Errorf("Invalid key for BGPPeer: %v", kvp.Key)
+	}
+
+	log.WithFields(log.Fields{
+		"KVPair": *kvp,
+		"APIV3":  r,
+	}).Debug("Converted BGPPeer")
+	return r, nil
+}

--- a/lib/upgrade/etcd/conversionv1v3/bgppeer_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/bgppeer_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversionv1v3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
+	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/scope"
+)
+
+var bgpPeerTable = []struct {
+	description string
+	v1API       unversioned.Resource
+	v1KVP       *model.KVPair
+	v3API       apiv3.BGPPeer
+}{
+	{
+		description: "global scoped BGPPeer",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope:  scope.Global,
+				PeerIP: *net.ParseIP("10.0.0.1"),
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+		v1KVP: &model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: *net.ParseIP("10.0.0.1"),
+			},
+			Value: &model.BGPPeer{
+				PeerIP: *net.ParseIP("10.0.0.1"),
+				ASNum:  255,
+			},
+		},
+		v3API: apiv3.BGPPeer{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "10-0-0-1",
+			},
+			Spec: apiv3.BGPPeerSpec{
+				PeerIP:   "10.0.0.1",
+				ASNumber: 255,
+			},
+		},
+	},
+	{
+		description: "global scoped ipv6 BGPPeer",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope:  scope.Global,
+				PeerIP: *net.ParseIP("Aa:bb::"),
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+		v1KVP: &model.KVPair{
+			Key: model.GlobalBGPPeerKey{
+				PeerIP: *net.ParseIP("Aa:bb::"),
+			},
+			Value: &model.BGPPeer{
+				PeerIP: *net.ParseIP("Aa:bb::"),
+				ASNum:  255,
+			},
+		},
+		v3API: apiv3.BGPPeer{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "00aa-00bb-0000-0000-0000-0000-0000-0000",
+			},
+			Spec: apiv3.BGPPeerSpec{
+				PeerIP:   "aa:bb::",
+				ASNumber: 255,
+			},
+		},
+	},
+	{
+		description: "node scoped BGPPeer",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope:  scope.Node,
+				Node:   "namedNode",
+				PeerIP: *net.ParseIP("10.0.0.1"),
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+		v1KVP: &model.KVPair{
+			Key: model.NodeBGPPeerKey{
+				Nodename: "namedNode",
+				PeerIP:   *net.ParseIP("10.0.0.1"),
+			},
+			Value: &model.BGPPeer{
+				PeerIP: *net.ParseIP("10.0.0.1"),
+				ASNum:  255,
+			},
+		},
+		v3API: apiv3.BGPPeer{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "namednode.10-0-0-1",
+			},
+			Spec: apiv3.BGPPeerSpec{
+				PeerIP:   "10.0.0.1",
+				Node:     "namednode",
+				ASNumber: 255,
+			},
+		},
+	},
+	{
+		description: "node scoped BGPPeer with ipv6",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope:  scope.Node,
+				Node:   "namedNode",
+				PeerIP: *net.ParseIP("Aa:bb::"),
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+		v1KVP: &model.KVPair{
+			Key: model.NodeBGPPeerKey{
+				Nodename: "namedNode",
+				PeerIP:   *net.ParseIP("Aa:bb::"),
+			},
+			Value: &model.BGPPeer{
+				PeerIP: *net.ParseIP("Aa:bb::"),
+				ASNum:  255,
+			},
+		},
+		v3API: apiv3.BGPPeer{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "namednode.00aa-00bb-0000-0000-0000-0000-0000-0000",
+			},
+			Spec: apiv3.BGPPeerSpec{
+				PeerIP:   "aa:bb::",
+				Node:     "namednode",
+				ASNumber: 255,
+			},
+		},
+	},
+}
+
+func TestCanConvertV1ToV3BGPPeer(t *testing.T) {
+	for _, entry := range bgpPeerTable {
+		t.Run(entry.description, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			p := BGPPeer{}
+
+			// Test and assert v1 API to v1 backend logic.
+			v1KVPResult, err := p.APIV1ToBackendV1(entry.v1API)
+			Expect(err).NotTo(HaveOccurred(), entry.description)
+			md := entry.v1API.(apiv1.BGPPeer).Metadata
+			if md.Scope == "global" {
+				Expect(v1KVPResult.Key.(model.GlobalBGPPeerKey).PeerIP).To(Equal(entry.v1KVP.Key.(model.GlobalBGPPeerKey).PeerIP))
+			} else {
+				Expect(v1KVPResult.Key.(model.NodeBGPPeerKey).PeerIP).To(Equal(entry.v1KVP.Key.(model.NodeBGPPeerKey).PeerIP))
+			}
+			Expect(v1KVPResult.Value.(*model.BGPPeer)).To(Equal(entry.v1KVP.Value))
+
+			// Test and assert v1 backend to v3 API logic.
+			v3APIResult, err := p.BackendV1ToAPIV3(entry.v1KVP)
+			Expect(err).NotTo(HaveOccurred(), entry.description)
+			Expect(v3APIResult.(*apiv3.BGPPeer).Name).To(Equal(entry.v3API.Name), entry.description)
+			Expect(v3APIResult.(*apiv3.BGPPeer).Spec).To(Equal(entry.v3API.Spec), entry.description)
+		})
+	}
+}
+
+var bgpPeerFailTable = []struct {
+	description string
+	v1API       unversioned.Resource
+}{
+	{
+		description: "missing PeerIP",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope: scope.Global,
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+	},
+	{
+		description: "scope set global with node specified",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope:  scope.Global,
+				Node:   "namedNode",
+				PeerIP: *net.ParseIP("10.0.0.1"),
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+	},
+	{
+		description: "scope set node with NO node specified",
+		v1API: apiv1.BGPPeer{
+			Metadata: apiv1.BGPPeerMetadata{
+				Scope:  scope.Node,
+				PeerIP: *net.ParseIP("10.0.0.1"),
+			},
+			Spec: apiv1.BGPPeerSpec{
+				ASNumber: 255,
+			},
+		},
+	},
+}
+
+func TestFailConvertV1ToV3BGPPeer(t *testing.T) {
+	for _, entry := range bgpPeerFailTable {
+		t.Run(entry.description, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			p := BGPPeer{}
+
+			// Test and assert v1 API to v1 backend logic.
+			_, err := p.APIV1ToBackendV1(entry.v1API)
+			Expect(err).To(HaveOccurred(), entry.description)
+		})
+	}
+}
+
+func TestBGPConvertWithInvalidResource(t *testing.T) {
+	t.Run("APIV1ToBackendV1 with the wrong resource produces an error",
+		func(t *testing.T) {
+			RegisterTestingT(t)
+			resource := apiv1.IPPool{
+				Metadata: apiv1.IPPoolMetadata{},
+				Spec:     apiv1.IPPoolSpec{},
+			}
+
+			p := BGPPeer{}
+			_, err := p.APIV1ToBackendV1(resource)
+
+			Expect(err).To(HaveOccurred())
+		})
+	t.Run("BackendV1ToAPIV3 with wrong resource produces an error",
+		func(t *testing.T) {
+			RegisterTestingT(t)
+			resource := &model.KVPair{
+				Key:   model.IPPoolKey{},
+				Value: &model.IPPool{},
+			}
+
+			p := BGPPeer{}
+			_, err := p.BackendV1ToAPIV3(resource)
+
+			Expect(err).To(HaveOccurred())
+		})
+}

--- a/lib/upgrade/etcd/conversionv1v3/ippool.go
+++ b/lib/upgrade/etcd/conversionv1v3/ippool.go
@@ -68,7 +68,7 @@ func (_ IPPool) APIV1ToBackendV1(rIn unversioned.Resource) (*model.KVPair, error
 func (_ IPPool) BackendV1ToAPIV3(kvp *model.KVPair) (Resource, error) {
 	pool, ok := kvp.Value.(*model.IPPool)
 	if !ok {
-		return nil, fmt.Errorf("value is not a valid BGPPeer resource key")
+		return nil, fmt.Errorf("value is not a valid IPPool resource Value")
 	}
 
 	return &apiv3.IPPool{

--- a/lib/upgrade/etcd/conversionv1v3/names_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/names_test.go
@@ -15,6 +15,7 @@
 package conversionv1v3
 
 import (
+	"net"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -84,6 +85,24 @@ func TestCanConvertV1ToV3NameNoDots(t *testing.T) {
 		t.Run(entry.v1Name, func(t *testing.T) {
 			RegisterTestingT(t)
 			Expect(convertNameNoDots(entry.v1Name)).To(Equal(entry.v3Name), entry.v1Name)
+		})
+	}
+}
+
+var ipToNameTable = []struct {
+	ip   net.IP
+	name string
+}{
+	{net.ParseIP("192.168.0.1"), "192-168-0-1"},
+	{net.ParseIP("Aa:bb::"), "00aa-00bb-0000-0000-0000-0000-0000-0000"},
+	{net.ParseIP("0Aa:bb::50"), "00aa-00bb-0000-0000-0000-0000-0000-0050"},
+}
+
+func TestCanConvertIpToName(t *testing.T) {
+	for _, entry := range ipToNameTable {
+		t.Run(entry.ip.String(), func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(convertIpToName(entry.ip)).To(Equal(entry.name), entry.ip.String())
 		})
 	}
 }


### PR DESCRIPTION
- [ ] I'm not sure on the conversion of IP to name.
  - Do IPv4 addresses need any expansion/padding?
  - Are any addresses stored that won't be the length of IPv4 or IPv6? If so then currently it would be turned into a hex string (with no punctuation).
- [ ] Is the name conversion the proper one? I think so, we would want to preserve any `.` in the node names I believe, is that also ok for the name of the BGPPeer also?

```release-note
None required
```
