### PR TITLE
Fix WEP and watcher bug.

### DIFF
--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -129,6 +129,12 @@ func (c *WorkloadEndpointClient) Get(ctx context.Context, key model.Key, revisio
 	if err != nil {
 		return nil, err
 	}
+	if wepID.Pod == "" {
+		return nil, cerrors.ErrorResourceDoesNotExist{
+			Identifier: key,
+			Err: errors.New("malformed WorkloadEndpoint name - unable to determine Pod name"),
+		}
+	}
 
 	pod, err := c.clientSet.CoreV1().Pods(k.Namespace).Get(wepID.Pod, metav1.GetOptions{ResourceVersion: revision})
 	if err != nil {

--- a/lib/clientv3/resources.go
+++ b/lib/clientv3/resources.go
@@ -347,7 +347,11 @@ func (w *watcher) run() {
 
 	for {
 		select {
-		case event := <-w.backend.ResultChan():
+		case event, ok := <-w.backend.ResultChan():
+			if !ok {
+				log.Debug("Watcher results channel closed by remote")
+				return
+			}
 			e := w.convertEvent(event)
 			select {
 			case w.results <- e:


### PR DESCRIPTION
## Description
-  Fix KDD WEP name handling for Get:  Ensure WEP name is correctly formatted and includes the Pod.
-  Handle clientv3 watch channel closure by terminating the watch when the results channel is closed.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```