### PR TITLE
Add serviceaccount match under feature flag.

### DIFF
--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -15,6 +15,8 @@
 package apiconfig
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
@@ -26,6 +28,7 @@ const (
 	EtcdV3              DatastoreType = "etcdv3"
 	Kubernetes          DatastoreType = "kubernetes"
 	KindCalicoAPIConfig               = "CalicoAPIConfig"
+	AlphaFeatureSA                    = "serviceaccounts"
 )
 
 // CalicoAPIConfig contains the connection information for a Calico CalicoAPIConfig resource
@@ -44,6 +47,8 @@ type CalicoAPIConfigSpec struct {
 	EtcdConfig
 	// Inline the k8s config fields.
 	KubeConfig
+	// Alpha Feature set: comma separated list of alpha features that are enabled.
+	AlphaFeatures string `json:"alphafeatures" envconfig:"ALPHA_FEATURES" default:""`
 }
 
 type EtcdConfig struct {
@@ -75,4 +80,18 @@ func NewCalicoAPIConfig() *CalicoAPIConfig {
 			APIVersion: apiv3.GroupVersionCurrent,
 		},
 	}
+}
+
+// IsAlphaFeatureSet checks if the comma separated features have the
+// name set in it.
+func IsAlphaFeatureSet(features, name string) bool {
+
+	fs := strings.Split(features, ",")
+	for _, f := range fs {
+		if f == name {
+			return true
+		}
+	}
+
+	return false
 }

--- a/lib/apis/v3/constants.go
+++ b/lib/apis/v3/constants.go
@@ -32,6 +32,10 @@ const (
 	// and may be used for label matches by Policy selectors.
 	LabelNamespace = "projectcalico.org/namespace"
 
+	// Label used to denote the ServiceAccount.  This is added to the workload endpoints by Calico
+	// and may be used for label matches by Policy selectors.
+	LabelServiceAccount = "projectcalico.org/serviceaccount"
+
 	// Label used to denote the Orchestrator.  This is added to the workload endpoints by an
 	// orchestrator.
 	LabelOrchestrator = "projectcalico.org/orchestrator"

--- a/lib/apis/v3/policy.go
+++ b/lib/apis/v3/policy.go
@@ -129,6 +129,21 @@ type EntityRule struct {
 	// Since only some protocols have ports, if any ports are specified it requires the
 	// Protocol match in the Rule to be set to "TCP" or "UDP".
 	NotPorts []numorstring.Port `json:"notPorts,omitempty" validate:"omitempty,dive"`
+
+	// ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+	// terminates at) a pod running as a matching service account.
+	ServiceAccounts *ServiceAccountMatch `json:"serviceAccounts,omitempty" validate:"omitempty"`
+}
+
+type ServiceAccountMatch struct {
+	// Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+	// at) a pod running as a service account whose name is in the list.
+	Names []string `json:"names,omitempty" validate:"omitempty"`
+
+	// Selector is an optional field that restricts the rule to only apply to traffic that originates from
+	// (or terminates at) a pod running as a service account that matches the given label selector.
+	// If both Names and Selector are specified then they are AND'ed.
+	Selector string `json:"selector,omitempty" validate:"omitempty"`
 }
 
 type Action string

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -32,7 +32,7 @@ func NewClient(config apiconfig.CalicoAPIConfig) (c bapi.Client, err error) {
 	case apiconfig.EtcdV3:
 		c, err = etcdv3.NewEtcdV3Client(&config.Spec.EtcdConfig)
 	case apiconfig.Kubernetes:
-		c, err = k8s.NewKubeClient(&config.Spec.KubeConfig)
+		c, err = k8s.NewKubeClient(&config.Spec)
 	default:
 		err = errors.New(fmt.Sprintf("Unknown datastore type: %v",
 			config.Spec.DatastoreType))

--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -15,7 +15,9 @@
 package conversion
 
 const (
-	NamespaceLabelPrefix       = "pcns."
-	NamespaceProfileNamePrefix = "kns."
-	K8sNetworkPolicyNamePrefix = "knp.default."
+	NamespaceLabelPrefix            = "pcns."
+	NamespaceProfileNamePrefix      = "kns."
+	K8sNetworkPolicyNamePrefix      = "knp.default."
+	ServiceAccountLabelPrefix       = "pcsa."
+	ServiceAccountProfileNamePrefix = "ksa."
 )

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -272,7 +272,8 @@ func (c cb) GetSyncerValuePresentFunc(key model.Key) func() interface{} {
 
 func CreateClientAndSyncer(cfg apiconfig.KubeConfig) (*KubeClient, *cb, api.Syncer) {
 	// First create the client.
-	c, err := NewKubeClient(&cfg)
+	caCfg := apiconfig.CalicoAPIConfigSpec{KubeConfig: cfg}
+	c, err := NewKubeClient(&caCfg)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
@@ -31,9 +32,11 @@ import (
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
 
-func NewWorkloadEndpointClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewWorkloadEndpointClient(c *kubernetes.Clientset, a string) K8sResourceClient {
+	alphaSA := apiconfig.IsAlphaFeatureSet(a, apiconfig.AlphaFeatureSA)
 	return &WorkloadEndpointClient{
 		clientSet: c,
+		converter: conversion.Converter{AlphaSA: alphaSA},
 	}
 }
 

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -128,12 +128,13 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		})
 	}
 
-	// Make sure there are no "namespace" labels on the wep
+	// Make sure there are no "namespace" or "serviceaccount" labels on the wep
 	// we pass to felix. This prevents a wep from pretending it is
 	// in another namespace.
 	labels := map[string]string{}
 	for k, v := range v3res.GetLabels() {
-		if !strings.HasPrefix(k, conversion.NamespaceLabelPrefix) {
+		if !strings.HasPrefix(k, conversion.NamespaceLabelPrefix) &&
+			!strings.HasPrefix(k, conversion.ServiceAccountLabelPrefix) {
 			labels[k] = v
 		}
 	}

--- a/lib/clientv3/globalnetworkpolicy.go
+++ b/lib/clientv3/globalnetworkpolicy.go
@@ -16,8 +16,10 @@ package clientv3
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
@@ -48,6 +50,11 @@ func (r globalNetworkPolicies) Create(ctx context.Context, res *apiv3.GlobalNetw
 		return nil, err
 	}
 
+	// Check if it is permitted to create the network policy with the specific alpha feature support.
+	if err := r.validateAlphaFeatures(res); err != nil {
+		return nil, err
+	}
+
 	// Properly prefix the name
 	res.GetObjectMeta().SetName(convertPolicyNameForStorage(res.GetObjectMeta().GetName()))
 	out, err := r.client.resources.Create(ctx, opts, apiv3.KindGlobalNetworkPolicy, res)
@@ -68,6 +75,11 @@ func (r globalNetworkPolicies) Update(ctx context.Context, res *apiv3.GlobalNetw
 	defaultPolicyTypesField(res.Spec.Ingress, res.Spec.Egress, &res.Spec.Types)
 
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	// Check if it is permitted to create the network policy with the specific alpha feature support.
+	if err := r.validateAlphaFeatures(res); err != nil {
 		return nil, err
 	}
 
@@ -138,6 +150,17 @@ func (r globalNetworkPolicies) Watch(ctx context.Context, opts options.ListOptio
 	}
 
 	return r.client.resources.Watch(ctx, opts, apiv3.KindGlobalNetworkPolicy, &policyConverter{})
+}
+
+func (r globalNetworkPolicies) validateAlphaFeatures(res *apiv3.GlobalNetworkPolicy) error {
+	if apiconfig.IsAlphaFeatureSet(r.client.config.Spec.AlphaFeatures, apiconfig.AlphaFeatureSA) == false {
+		err := validator.ValidateNoServiceAccountRules(res.Spec.Ingress, res.Spec.Egress)
+		if err != nil {
+			return fmt.Errorf("Global NP %s: %s", res.GetObjectMeta().GetName(), err.Error())
+		}
+	}
+
+	return nil
 }
 
 func defaultPolicyTypesField(ingressRules, egressRules []apiv3.Rule, types *[]apiv3.PolicyType) {

--- a/lib/validator/v3/alphafeaturecheck.go
+++ b/lib/validator/v3/alphafeaturecheck.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"errors"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+)
+
+// ValidateNoServiceAccountRules checks if the set of rules have the
+// serviceAccount match set and if yes then it returns an error.
+func ValidateNoServiceAccountRules(ingress, egress []apiv3.Rule) error {
+	for _, rule := range ingress {
+		if rule.Source.ServiceAccounts != nil ||
+			rule.Destination.ServiceAccounts != nil {
+			return errors.New("alpha feature Service Account Match used")
+		}
+	}
+
+	for _, rule := range egress {
+		if rule.Source.ServiceAccounts != nil ||
+			rule.Destination.ServiceAccounts != nil {
+			return errors.New("alpha feature Service Account Match used")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
Add support for service account matches and also add a feature flag. SA match will be under feature flag.
This is related to PR https://github.com/projectcalico/libcalico-go/pull/693

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
