### PR TITLE
Check bgp peer scope kdd

### DIFF
--- a/lib/api/node.go
+++ b/lib/api/node.go
@@ -65,6 +65,17 @@ type NodeSpec struct {
 	// BGP configuration for this node.  If this omitted, the Calico node
 	// will be run in policy-only mode.
 	BGP *NodeBGPSpec `json:"bgp,omitempty" validate:"omitempty"`
+
+	// OrchRefs for this node.
+	OrchRefs []OrchRef `json:"orchRefs,omitempty" validate:"omitempty"`
+}
+
+// OrchRef is used to correlate a Calico node to its corresponding representation in a given orchestrator
+type OrchRef struct {
+	// NodeName represents the name for this node according to the orchestrator.
+	NodeName string `json:"nodeName,omitempty" validate:"omitempty"`
+	// Orchestrator represents the orchestrator using this node.
+	Orchestrator string `json:"orchestrator"`
 }
 
 // NodeSpec contains the specification for a Calico Node resource.

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -486,6 +486,10 @@ func (c *ModelAdaptor) getNodeSubcomponents(nk model.NodeKey, nv *model.Node) er
 		return err
 	}
 
+	if component, err := c.client.Get(model.OrchRefKey{Hostname: nk.Hostname}); err == nil {
+		nv.OrchRefs = component.Value.([]model.OrchRef)
+	}
+
 	return nil
 }
 
@@ -646,6 +650,12 @@ func toNodeComponents(d *model.KVPair) (primary *model.KVPair, optional []*model
 			},
 		})
 	}
+	if len(n.OrchRefs) > 0 {
+		optional = append(optional, &model.KVPair{
+			Key:   model.OrchRefKey{Hostname: nk.Hostname},
+			Value: n.OrchRefs,
+		})
+	}
 
 	return primary, optional
 }
@@ -691,6 +701,11 @@ func toNodeDeleteComponents(d *model.KVPair) (primary *model.KVPair, optional []
 			Key: model.NodeBGPConfigKey{
 				Nodename: nk.Hostname,
 				Name:     "network_v6",
+			},
+		},
+		&model.KVPair{
+			Key: model.OrchRefKey{
+				Hostname: nk.Hostname,
 			},
 		},
 	}

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -117,6 +117,11 @@ var _ = Describe("Test Pod conversion", func() {
 		expectedLabels := map[string]string{"labelA": "valueA", "labelB": "valueB", "calico/k8s_ns": "default"}
 		Expect(wep.Value.(*model.WorkloadEndpoint).Labels).To(Equal(expectedLabels))
 
+		// Assert the interface name is fixed.  The calculation of this name should be consistent
+		// between releases otherwise there will be issues upgrading a node with networked Pods.
+		// If this fails, fix the code not this expect!
+		Expect(wep.Value.(*model.WorkloadEndpoint).Name).To(Equal("cali7f94ce7c295"))
+
 		// Assert ResourceVersion is present.
 		Expect(wep.Revision.(string)).To(Equal("1234"))
 	})
@@ -147,7 +152,7 @@ var _ = Describe("Test Pod conversion", func() {
 	It("should parse a Pod with no labels", func() {
 		pod := k8sapi.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "podA",
+				Name:      "podB",
 				Namespace: "default",
 			},
 			Spec: k8sapi.PodSpec{
@@ -162,7 +167,7 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert key fields.
-		Expect(wep.Key.(model.WorkloadEndpointKey).WorkloadID).To(Equal("default.podA"))
+		Expect(wep.Key.(model.WorkloadEndpointKey).WorkloadID).To(Equal("default.podB"))
 		Expect(wep.Key.(model.WorkloadEndpointKey).Hostname).To(Equal("nodeA"))
 		Expect(wep.Key.(model.WorkloadEndpointKey).EndpointID).To(Equal("eth0"))
 		Expect(wep.Key.(model.WorkloadEndpointKey).OrchestratorID).To(Equal("k8s"))
@@ -172,6 +177,11 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(len(wep.Value.(*model.WorkloadEndpoint).IPv4Nets)).To(Equal(1))
 		Expect(wep.Value.(*model.WorkloadEndpoint).State).To(Equal("active"))
 		Expect(wep.Value.(*model.WorkloadEndpoint).Labels).To(Equal(map[string]string{"calico/k8s_ns": "default"}))
+
+		// Assert the interface name is fixed.  The calculation of this name should be consistent
+		// between releases otherwise there will be issues upgrading a node with networked Pods.
+		// If this fails, fix the code not this expect!
+		Expect(wep.Value.(*model.WorkloadEndpoint).Name).To(Equal("cali92cf1f5e9f6"))
 	})
 
 	It("should Parse a Pod with no NodeName", func() {

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -307,8 +307,6 @@ func (c *KubeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
 func (c *KubeClient) Create(d *model.KVPair) (*model.KVPair, error) {
 	log.Debugf("Performing 'Create' for %+v", d)
 	switch d.Key.(type) {
-	case model.PolicyKey:
-		return c.gnpClient.Create(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Create(d)
 	case model.IPPoolKey:
@@ -337,8 +335,6 @@ func (c *KubeClient) Create(d *model.KVPair) (*model.KVPair, error) {
 func (c *KubeClient) Update(d *model.KVPair) (*model.KVPair, error) {
 	log.Debugf("Performing 'Update' for %+v", d)
 	switch d.Key.(type) {
-	case model.PolicyKey:
-		return c.gnpClient.Update(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Update(d)
 	case model.IPPoolKey:
@@ -369,8 +365,6 @@ func (c *KubeClient) Apply(d *model.KVPair) (*model.KVPair, error) {
 	switch d.Key.(type) {
 	case model.WorkloadEndpointKey:
 		return c.applyWorkloadEndpoint(d)
-	case model.PolicyKey:
-		return c.gnpClient.Apply(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Apply(d)
 	case model.IPPoolKey:
@@ -400,12 +394,10 @@ func (c *KubeClient) Apply(d *model.KVPair) (*model.KVPair, error) {
 	}
 }
 
-// Delete an entry in the datastore. Returns an error if the entry does not exist.
+// Delete an entry in the datastore. This is a no-op when using the k8s backend.
 func (c *KubeClient) Delete(d *model.KVPair) error {
 	log.Debugf("Performing 'Delete' for %+v", d)
 	switch d.Key.(type) {
-	case model.PolicyKey:
-		return c.gnpClient.Delete(d)
 	case model.GlobalConfigKey:
 		return c.globalFelixConfigClient.Delete(d)
 	case model.IPPoolKey:

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -594,8 +594,8 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// Make sure we clean up after ourselves.  We allow this to fail because
 		// part of our explicit testing below is to delete the resource.
 		defer func() {
-			c.Delete(kvp1a)
-			c.Delete(kvp2a)
+			c.gnpClient.Delete(kvp1a)
+			c.gnpClient.Delete(kvp2a)
 		}()
 
 		// Check our syncer has the correct GNP entries for the two
@@ -607,7 +607,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Creating a Global Network Policy", func() {
-			_, err := c.Create(kvp1a)
+			_, err := c.gnpClient.Create(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -623,12 +623,12 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Attempting to recreate an existing Global Network Policy", func() {
-			_, err := c.Create(kvp1a)
+			_, err := c.gnpClient.Create(kvp1a)
 			Expect(err).To(HaveOccurred())
 		})
 
 		By("Updating an existing Global Network Policy", func() {
-			_, err := c.Update(kvp1b)
+			_, err := c.gnpClient.Update(kvp1b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -644,7 +644,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Applying a non-existent Global Network Policy", func() {
-			_, err := c.Apply(kvp2a)
+			_, err := c.gnpClient.Apply(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -654,7 +654,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Updating the Global Network Policy created by Apply", func() {
-			_, err := c.Apply(kvp2b)
+			_, err := c.gnpClient.Apply(kvp2b)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -664,7 +664,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleted the Global Network Policy created by Apply", func() {
-			err := c.Delete(kvp2a)
+			err := c.gnpClient.Delete(kvp2a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -676,7 +676,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		// Perform Get operations directly on the main client - this
 		// will fan out requests to the appropriate Policy client
 		// (including the Global Network Policy client).
-		By("Getting a Global Network Policy that does not exist", func() {
+		By("Getting a Global Network Policy that does noe exist", func() {
 			_, err := c.Get(model.PolicyKey{Name: "my-non-existent-test-gnp"})
 			Expect(err).To(HaveOccurred())
 		})
@@ -705,7 +705,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleting an existing Global Network Policy", func() {
-			err := c.Delete(kvp1a)
+			err := c.gnpClient.Delete(kvp1a)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/lib/backend/k8s/resources/globalbgppeer.go
+++ b/lib/backend/k8s/resources/globalbgppeer.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"errors"
 )
 
 const (
@@ -85,6 +86,10 @@ func (c GlobalBGPPeerConverter) ToKVPair(r CustomK8sResource) (*model.KVPair, er
 	// BGP Peer, use the client conversion helper to convert between KV and API.
 	t := r.(*custom.BGPPeer)
 
+	if t.Spec.Scope != scope.Global {
+		return nil, errors.New("global BGPPeer is configured with non-global scope - this is expected during upgrade to v3.x")
+	}
+	
 	peer := api.BGPPeer{
 		Metadata: api.BGPPeerMetadata{
 			PeerIP: t.Spec.PeerIP,

--- a/lib/backend/model/bgp_node.go
+++ b/lib/backend/model/bgp_node.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/projectcalico/libcalico-go/lib/errors"
+)
+
+var (
+	typeBGPNode = reflect.TypeOf(BGPNode{})
+)
+
+type BGPNodeKey struct {
+	Host string
+}
+
+func (key BGPNodeKey) defaultPath() (string, error) {
+	if key.Host == "" {
+		return "", errors.ErrorInsufficientIdentifiers{Name: "host"}
+	}
+
+	k := "/calico/bgp/v1/host/" + key.Host
+	return k, nil
+}
+
+func (key BGPNodeKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
+}
+
+func (key BGPNodeKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
+func (key BGPNodeKey) valueType() reflect.Type {
+	return typeBGPNode
+}
+
+func (key BGPNodeKey) String() string {
+	return fmt.Sprintf("BGPNodeKey(host=%s)", key.Host)
+}
+
+type BGPNode struct {
+}

--- a/lib/backend/model/rule.go
+++ b/lib/backend/model/rule.go
@@ -31,10 +31,13 @@ type Rule struct {
 	Protocol    *numorstring.Protocol `json:"protocol,omitempty" validate:"omitempty"`
 	NotProtocol *numorstring.Protocol `json:"!protocol,omitempty" validate:"omitempty"`
 
-	ICMPType    *int `json:"icmp_type,omitempty" validate:"omitempty,gte=1,lte=255"`
-	ICMPCode    *int `json:"icmp_code,omitempty" validate:"omitempty,gte=1,lte=255"`
-	NotICMPType *int `json:"!icmp_type,omitempty" validate:"omitempty,gte=1,lte=255"`
-	NotICMPCode *int `json:"!icmp_code,omitempty" validate:"omitempty,gte=1,lte=255"`
+	// ICMP validation notes: 0 is a valid (common) ICMP type and code.  Type = 255 is not assigned
+	// to any protocol and the Linux kernel doesn't support matching on it so we validate against
+	// it.
+	ICMPType    *int `json:"icmp_type,omitempty" validate:"omitempty,gte=0,lt=255"`
+	ICMPCode    *int `json:"icmp_code,omitempty" validate:"omitempty,gte=0,lte=255"`
+	NotICMPType *int `json:"!icmp_type,omitempty" validate:"omitempty,gte=0,lt=255"`
+	NotICMPCode *int `json:"!icmp_code,omitempty" validate:"omitempty,gte=0,lte=255"`
 
 	SrcTag      string             `json:"src_tag,omitempty" validate:"omitempty,tag"`
 	SrcNet      *net.IPNet         `json:"src_net,omitempty" validate:"omitempty"`

--- a/lib/backend/model/rule_test.go
+++ b/lib/backend/model/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ var icmpProto = numorstring.ProtocolFromString("icmp")
 var intProto = numorstring.ProtocolFromInt(123)
 var icmpType = 10
 var icmpCode = 6
+var icmpTypeZero = 0
+var icmpCodeZero = 0
 var portRange, _ = numorstring.PortFromRange(10, 20)
 var ports = []numorstring.Port{
 	numorstring.SinglePort(1234),
@@ -59,6 +61,10 @@ var ruleStringTests = []ruleTest{
 		"deny icmp type 10"},
 	{model.Rule{Protocol: &icmpProto, ICMPType: &icmpType, ICMPCode: &icmpCode},
 		"allow icmp type 10 code 6"},
+	{model.Rule{Action: "deny", Protocol: &icmpProto, ICMPType: &icmpTypeZero},
+		"deny icmp type 0"},
+	{model.Rule{Protocol: &icmpProto, ICMPType: &icmpTypeZero, ICMPCode: &icmpCodeZero},
+		"allow icmp type 0 code 0"},
 	// And negations of packet-wide matches.
 	{model.Rule{Action: "allow", NotProtocol: &tcpProto}, "allow !tcp"},
 	{model.Rule{Action: "deny", Protocol: &icmpProto, NotICMPType: &icmpType},

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -189,6 +189,13 @@ func (h *nodes) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, error
 		v.BGPASNumber = an.Spec.BGP.ASNumber
 	}
 
+	for _, orchRef := range an.Spec.OrchRefs {
+		v.OrchRefs = append(v.OrchRefs, model.OrchRef{
+			Orchestrator: orchRef.Orchestrator,
+			NodeName:     orchRef.NodeName,
+		})
+	}
+
 	return &model.KVPair{Key: k, Value: &v}, nil
 }
 
@@ -234,6 +241,13 @@ func (h *nodes) convertKVPairToAPI(d *model.KVPair) (unversioned.Resource, error
 				apiNode.Spec.BGP.IPv6Address = bv.BGPIPv6Addr.Network()
 			}
 		}
+	}
+
+	for _, orchref := range bv.OrchRefs {
+		apiNode.Spec.OrchRefs = append(apiNode.Spec.OrchRefs, api.OrchRef{
+			NodeName:     orchref.NodeName,
+			Orchestrator: orchref.Orchestrator,
+		})
 	}
 
 	return apiNode, nil

--- a/lib/client/node_e2e_test.go
+++ b/lib/client/node_e2e_test.go
@@ -96,9 +96,9 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV2, 
 			_, err = c.Nodes().Update(&api.Node{Metadata: meta1, Spec: spec2})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Apply node2 with spec1.
+			// Applying node2 with spec1.
 			By("Applying node2 with spec1")
-			_, err = c.Nodes().Update(&api.Node{Metadata: meta2, Spec: spec1})
+			_, err = c.Nodes().Apply(&api.Node{Metadata: meta2, Spec: spec1})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get node with meta1.
@@ -166,11 +166,31 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV2, 
 				BGP: &api.NodeBGPSpec{
 					IPv4Address: &cidrv4,
 				},
+				OrchRefs: []api.OrchRef{
+					{
+						Orchestrator: "k8s",
+						NodeName:     "node1",
+					},
+					{
+						Orchestrator: "mesos",
+						NodeName:     "node1",
+					},
+				},
 			},
 			api.NodeSpec{
 				BGP: &api.NodeBGPSpec{
 					IPv6Address: &cidrv6,
 					ASNumber:    &asn,
+				},
+				OrchRefs: []api.OrchRef{
+					{
+						Orchestrator: "k8s",
+						NodeName:     "node2",
+					},
+					{
+						Orchestrator: "mesos",
+						NodeName:     "node2",
+					},
 				},
 			}),
 

--- a/lib/validator/validator_test.go
+++ b/lib/validator/validator_test.go
@@ -69,6 +69,20 @@ func init() {
 		// Empty rule is valid, it means "allow all".
 		Entry("empty rule (m)", model.Rule{}, true),
 
+		// (Backend model) ICMP.
+		Entry("should accept ICMP 0/any (m)", model.Rule{ICMPType: &V0}, true),
+		Entry("should accept ICMP 0/0 (m)", model.Rule{ICMPType: &V0, ICMPCode: &V0}, true),
+		Entry("should accept ICMP 128/0 (m)", model.Rule{ICMPType: &V128, ICMPCode: &V0}, true),
+		Entry("should accept ICMP 254/255 (m)", model.Rule{ICMPType: &V254, ICMPCode: &V255}, true),
+		Entry("should reject ICMP 255/255 (m)", model.Rule{ICMPType: &V255, ICMPCode: &V255}, false),
+		Entry("should reject ICMP 128/256 (m)", model.Rule{ICMPType: &V128, ICMPCode: &V256}, false),
+		Entry("should accept not ICMP 0/any (m)", model.Rule{NotICMPType: &V0}, true),
+		Entry("should accept not ICMP 0/0 (m)", model.Rule{NotICMPType: &V0, NotICMPCode: &V0}, true),
+		Entry("should accept not ICMP 128/0 (m)", model.Rule{NotICMPType: &V128, NotICMPCode: &V0}, true),
+		Entry("should accept not ICMP 254/255 (m)", model.Rule{NotICMPType: &V254, NotICMPCode: &V255}, true),
+		Entry("should reject not ICMP 255/255 (m)", model.Rule{NotICMPType: &V255, NotICMPCode: &V255}, false),
+		Entry("should reject not ICMP 128/256 (m)", model.Rule{NotICMPType: &V128, NotICMPCode: &V256}, false),
+
 		// (Backend model) Actions.
 		Entry("should accept allow action (m)", model.Rule{Action: "allow"}, true),
 		Entry("should accept deny action (m)", model.Rule{Action: "deny"}, true),


### PR DESCRIPTION
## Description
Check whether the scope field in the KDD BGP Peer Spec matches Global before returning as a Global BGPPeer.

Note that this will log a warning log if the scope field is not set.  After migrating config during upgrade, confd will spew out occasional warning logs for any node-specific BGP Peer that is configured - hence the reason the log explicitly mentions upgrade scenario.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```