### PR TITLE
Make name normalization a public method

### DIFF
--- a/lib/upgrade/etcd/conversionv1v3/bgppeer.go
+++ b/lib/upgrade/etcd/conversionv1v3/bgppeer.go
@@ -105,7 +105,10 @@ func (bp BGPPeer) BackendV1ToAPIV3(kvp *model.KVPair) (Resource, error) {
 		r.ObjectMeta = v1.ObjectMeta{Name: convertIpToName(peer.PeerIP.IP)}
 	case model.NodeBGPPeerKey:
 		nk := kvp.Key.(model.NodeBGPPeerKey)
-		n := convertName(nk.Nodename)
+
+		// Node names are normalized but we don't add any qualifying hashes (so we just use
+		// the normalizeName function to convert).
+		n := ConvertNodeName(nk.Nodename)
 		r.Spec.Node = n
 		r.ObjectMeta = v1.ObjectMeta{Name: n + "." + convertIpToName(peer.PeerIP.IP)}
 	default:

--- a/lib/upgrade/etcd/conversionv1v3/hostendpoint.go
+++ b/lib/upgrade/etcd/conversionv1v3/hostendpoint.go
@@ -111,13 +111,15 @@ func (_ HostEndpoint) BackendV1ToAPIV3(d *model.KVPair) (Resource, error) {
 		})
 	}
 
+	nodeName := ConvertNodeName(bk.Hostname)
+
 	ah := &apiv3.HostEndpoint{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   convertName(fmt.Sprintf("%s.%s", bk.Hostname, bk.EndpointID)),
+			Name:   convertName(fmt.Sprintf("%s.%s", nodeName, bk.EndpointID)),
 			Labels: bh.Labels,
 		},
 		Spec: apiv3.HostEndpointSpec{
-			Node:          convertName(bk.Hostname),
+			Node:          nodeName,
 			Ports:         ports,
 			InterfaceName: bh.Name,
 			Profiles:      convertProfiles(bh.ProfileIDs),

--- a/lib/upgrade/etcd/conversionv1v3/hostendpoint_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/hostendpoint_test.go
@@ -201,7 +201,7 @@ func TestHEPDataIsConvertedCorrectly(t *testing.T) {
 		b, err := convertHEPV1ToV3(a)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(b.ObjectMeta.Name).To(Equal("nod2.h3p.n.me"), "Should convert new name")
+		Expect(b.ObjectMeta.Name).To(Equal("nod2.h3p.n.me-7188e863"), "Should convert new name")
 	})
 
 	t.Run("converts protocol names", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestHEPDataIsConvertedCorrectly(t *testing.T) {
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(b.Spec.Profiles)).To(Equal(1))
-		Expect(b.Spec.Profiles[0]).To(Equal("pro.le"), "Should convert profile name")
+		Expect(b.Spec.Profiles[0]).To(Equal("pro.le-b1554692"), "Should convert profile name")
 	})
 
 	t.Run("converts profile names", func(t *testing.T) {

--- a/lib/upgrade/etcd/conversionv1v3/names.go
+++ b/lib/upgrade/etcd/conversionv1v3/names.go
@@ -15,6 +15,8 @@
 package conversionv1v3
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"regexp"
@@ -23,20 +25,26 @@ import (
 
 var (
 	nonNameChar               = regexp.MustCompile("[^-.a-z0-9]+")
-	nonNameNoDotChar          = regexp.MustCompile("[^-a-z0-9]+")
 	dotDashSeq                = regexp.MustCompile("[.-]*[.][.-]*")
 	trailingLeadingDotsDashes = regexp.MustCompile("^[.-]*(.*?)[.-]*$")
 )
 
-// Convert the v1 name to a standard v3 name.  This converts as follows (in the
-// listed order):
+// Convert the v1 node name to a standard v3 name.  This uses the standard name normalization
+// but does not add a qualifier.  Any overlapping names will result in a failed upgrade, so the
+// pre-upgrade validation script will check for conflicting names.
+func ConvertNodeName(v1Name string) string {
+	return normalizeName(v1Name)
+}
+
+// Convert a name to normalized form.  This is used for conversion of os.Hostname to a
+// suitable node name, and is also used for the v2->v3 migration code.
 // -  Convert to lowercase
 // -  Convert [/] to .
 // -  Convert any other char that is not in the set [-.a-z0-9] to -
 // -  Convert any multi-byte sequence of [-.] with at least one [.] to a single .
 // -  Remove leading and trailing dashes and dots
-func convertName(v1Name string) string {
-	name := strings.ToLower(v1Name)
+func normalizeName(name string) string {
+	name = strings.ToLower(name)
 	name = strings.Replace(name, "/", ".", -1)
 	name = nonNameChar.ReplaceAllString(name, "-")
 	name = dotDashSeq.ReplaceAllString(name, ".")
@@ -49,21 +57,35 @@ func convertName(v1Name string) string {
 	return name
 }
 
-// Convert the v1 name to a standard v3 name with no dots.
-// -  Convert to lowercase
-// -  Convert any char that is not in the set [-a-z0-9] to -
-// -  Remove leading and trailing dashes
-func convertNameNoDots(v1Name string) string {
-	name := strings.ToLower(v1Name)
-	name = nonNameNoDotChar.ReplaceAllString(name, "-")
+// Convert the v1 name to a standard v3 name.  This uses the standard name normalization,
+// and adds an additional qualifier if the name was modified.  The qualifier is calculated
+// from the original name.
+func convertName(v1Name string) string {
+	name := normalizeName(v1Name)
 
-	// Extract the trailing and leading dashes (there are no dots by this point).
-	// This should always match even if the matched substring is empty.  The second
-	// item in the returned submatc
-	// slice is the captured match group.
-	submatches := trailingLeadingDotsDashes.FindStringSubmatch(name)
-	name = submatches[1]
-	return name
+	// If the name is different append a qualifier.
+	return qualifiedName(v1Name, name)
+}
+
+// Convert the v1 name to a standard v3 name with no dots.
+func convertNameNoDots(v1Name string) string {
+	// Normalize the name and then convert dots to dashes.
+	name := normalizeName(v1Name)
+	name = strings.Replace(name, ".", "-", -1)
+
+	// If the name is different append a qualifier.
+	return qualifiedName(v1Name, name)
+}
+
+func qualifiedName(orig, final string) string {
+	// If the name was not modified, just return the unmodified name.
+	if orig == final {
+		return orig
+	}
+	// The name was modified.  Calculate an 8-byte hex qualifier to append.
+	h := sha1.New()
+	h.Write([]byte(orig))
+	return fmt.Sprintf("%s-%s", final, strings.ToLower(hex.EncodeToString(h.Sum(nil))[:8]))
 }
 
 // Convert an IP to an IPv4 or IPv6 representation

--- a/lib/upgrade/etcd/conversionv1v3/names_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/names_test.go
@@ -18,12 +18,144 @@ import (
 	"net"
 	"testing"
 
+	"strings"
+
 	. "github.com/onsi/gomega"
 )
 
 var namesTable = []struct {
-	v1Name string
-	v3Name string
+	v1Name          string
+	v3Name          string
+	expectQualifier bool
+}{
+	{"abcdef", "abcdef", false},
+	{"Abcdef", "abcdef", true},
+	{"abc-def", "abc-def", false},
+	{"abc---def", "abc---def", false},
+	{"abc/def", "abc.def", true},
+	{"abc$$def", "abc-def", true},
+	{"abc$!$def", "abc-def", true},
+	{"abc..def", "abc.def", true},
+	{"abc...def", "abc.def", true},
+	{"abc.-def", "abc.def", true},
+	{"abc.-.def", "abc.def", true},
+	{"abc-.def", "abc.def", true},
+	{"abc-.-def", "abc.def", true},
+	{"aBcDe019", "abcde019", true},
+	{"abc$def", "abc-def", true},
+	{"-abc.def", "abc.def", true},
+	{"abc.def-", "abc.def", true},
+	{".abc.def", "abc.def", true},
+	{"abc.def.", "abc.def", true},
+	{"-.abc.def", "abc.def", true},
+	{"abc.def.-", "abc.def", true},
+	{"$ABC/DeF-123.-456!", "abc.def-123.456", true},
+}
+
+func TestCanConvertV1ToV3Name(t *testing.T) {
+	for _, entry := range namesTable {
+		t.Run(entry.v1Name, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			// Get the converted name.
+			c1 := convertName(entry.v1Name)
+			if !entry.expectQualifier {
+				// No qualifier is expected, the names should match exactly.
+				Expect(c1).To(Equal(entry.v3Name))
+			} else {
+				// A qualifier is expected, the first part of the name should match and the
+				// last 9 chars should be the qualifier.
+				Expect(c1[:len(c1)-9]).To(Equal(entry.v3Name))
+				Expect(c1[len(c1)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+
+				// Convert an upper case variant of the input.  The first part of the name should
+				// match and the last 9 chars should be the qualifier - however the two converted
+				// names should be different.
+				c2 := convertName(strings.ToUpper(entry.v1Name))
+				Expect(c2[:len(c2)-9]).To(Equal(entry.v3Name))
+				Expect(c2[len(c2)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+				Expect(c2).NotTo(Equal(c1))
+			}
+		})
+	}
+}
+
+var namesNoDotsTable = []struct {
+	v1Name          string
+	v3Name          string
+	expectQualifier bool
+}{
+	{"abcdef", "abcdef", false},
+	{"Abcdef", "abcdef", true},
+	{"abc-def", "abc-def", false},
+	{"abc---def", "abc---def", false},
+	{"abc/def", "abc-def", true},
+	{"abc..def", "abc-def", true},
+	{"abc...def", "abc-def", true},
+	{"abc.-def", "abc-def", true},
+	{"abc.-.def", "abc-def", true},
+	{"abc-.def", "abc-def", true},
+	{"abc-.-def", "abc-def", true},
+	{"aBcDe019", "abcde019", true},
+	{"abc$def", "abc-def", true},
+	{"-abc.def", "abc-def", true},
+	{"abc.def-", "abc-def", true},
+	{".abc.def", "abc-def", true},
+	{"abc.def.", "abc-def", true},
+	{"-.abc.def", "abc-def", true},
+	{"abc.def.-", "abc-def", true},
+	{"$ABC/DeF-123.-456!", "abc-def-123-456", true},
+}
+
+func TestCanConvertV1ToV3NameNoDots(t *testing.T) {
+	for _, entry := range namesNoDotsTable {
+		t.Run(entry.v1Name, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			// Get the converted name.
+			c1 := convertNameNoDots(entry.v1Name)
+			if !entry.expectQualifier {
+				// No qualifier is expected, the names should match exactly.
+				Expect(c1).To(Equal(entry.v3Name))
+			} else {
+				// A qualifier is expected, the first part of the name should match and the
+				// last 9 chars should be the qualifier.
+				Expect(c1[:len(c1)-9]).To(Equal(entry.v3Name))
+				Expect(c1[len(c1)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+
+				// Convert an upper case variant of the input.  The first part of the name should
+				// match and the last 9 chars should be the qualifier - however the two converted
+				// names should be different.
+				c2 := convertNameNoDots(strings.ToUpper(entry.v1Name))
+				Expect(c2[:len(c2)-9]).To(Equal(entry.v3Name))
+				Expect(c2[len(c2)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+				Expect(c2).NotTo(Equal(c1))
+			}
+		})
+	}
+}
+
+var ipToNameTable = []struct {
+	ip   net.IP
+	name string
+}{
+	{net.ParseIP("192.168.0.1"), "192-168-0-1"},
+	{net.ParseIP("Aa:bb::"), "00aa-00bb-0000-0000-0000-0000-0000-0000"},
+	{net.ParseIP("0Aa:bb::50"), "00aa-00bb-0000-0000-0000-0000-0000-0050"},
+}
+
+func TestCanConvertIpToName(t *testing.T) {
+	for _, entry := range ipToNameTable {
+		t.Run(entry.ip.String(), func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(convertIpToName(entry.ip)).To(Equal(entry.name), entry.ip.String())
+		})
+	}
+}
+
+var nodeNamesTable = []struct {
+	before string
+	after  string
 }{
 	{"abc-def", "abc-def"},
 	{"abc---def", "abc---def"},
@@ -47,62 +179,11 @@ var namesTable = []struct {
 	{"$ABC/DEF-123.-456!", "abc.def-123.456"},
 }
 
-func TestCanConvertV1ToV3Name(t *testing.T) {
-	for _, entry := range namesTable {
-		t.Run(entry.v1Name, func(t *testing.T) {
+func TestCanConvertV1ToV3NodeName(t *testing.T) {
+	for _, entry := range nodeNamesTable {
+		t.Run(entry.before, func(t *testing.T) {
 			RegisterTestingT(t)
-			Expect(convertName(entry.v1Name)).To(Equal(entry.v3Name), entry.v1Name)
-		})
-	}
-}
-
-var namesNoDotsTable = []struct {
-	v1Name string
-	v3Name string
-}{
-	{"abc-def", "abc-def"},
-	{"abc---def", "abc---def"},
-	{"abc/def", "abc-def"},
-	{"abc..def", "abc-def"},
-	{"abc...def", "abc-def"},
-	{"abc.-def", "abc--def"},
-	{"abc.-.def", "abc---def"},
-	{"abc-.def", "abc--def"},
-	{"abc-.-def", "abc---def"},
-	{"aBcDe019", "abcde019"},
-	{"abc$def", "abc-def"},
-	{"-abc.def", "abc-def"},
-	{"abc.def-", "abc-def"},
-	{".abc.def", "abc-def"},
-	{"abc.def.", "abc-def"},
-	{"-.abc.def", "abc-def"},
-	{"abc.def.-", "abc-def"},
-	{"$ABC/DEF-123.-456!", "abc-def-123--456"},
-}
-
-func TestCanConvertV1ToV3NameNoDots(t *testing.T) {
-	for _, entry := range namesNoDotsTable {
-		t.Run(entry.v1Name, func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(convertNameNoDots(entry.v1Name)).To(Equal(entry.v3Name), entry.v1Name)
-		})
-	}
-}
-
-var ipToNameTable = []struct {
-	ip   net.IP
-	name string
-}{
-	{net.ParseIP("192.168.0.1"), "192-168-0-1"},
-	{net.ParseIP("Aa:bb::"), "00aa-00bb-0000-0000-0000-0000-0000-0000"},
-	{net.ParseIP("0Aa:bb::50"), "00aa-00bb-0000-0000-0000-0000-0000-0050"},
-}
-
-func TestCanConvertIpToName(t *testing.T) {
-	for _, entry := range ipToNameTable {
-		t.Run(entry.ip.String(), func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(convertIpToName(entry.ip)).To(Equal(entry.name), entry.ip.String())
+			Expect(ConvertNodeName(entry.before)).To(Equal(entry.after), entry.before)
 		})
 	}
 }

--- a/lib/upgrade/etcd/conversionv1v3/policy_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/policy_test.go
@@ -68,7 +68,7 @@ var policyTable = []struct {
 		},
 		v3API: apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "nameymcpolicyname",
+				Name: "nameymcpolicyname-32df456f",
 			},
 			Spec: apiv3.GlobalNetworkPolicySpec{
 				Order:          &order1,
@@ -116,7 +116,7 @@ var policyTable = []struct {
 		},
 		v3API: apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "make.make",
+				Name: "make.make-1b6971c8",
 			},
 			Spec: apiv3.GlobalNetworkPolicySpec{
 				Order:          &order1,
@@ -162,7 +162,7 @@ var policyTable = []struct {
 		},
 		v3API: apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "rawr",
+				Name: "rawr-03d81e1d",
 			},
 			Spec: apiv3.GlobalNetworkPolicySpec{
 				Order:          &order1,
@@ -256,7 +256,7 @@ var policyTable = []struct {
 		},
 		v3API: apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "make.make",
+				Name: "make.make-1b6971c8",
 			},
 			Spec: apiv3.GlobalNetworkPolicySpec{
 				Order: &order1,

--- a/lib/upgrade/etcd/conversionv1v3/profile_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/profile_test.go
@@ -61,7 +61,7 @@ var profileTable = []struct {
 		},
 		v3API: apiv3.Profile{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "nameymcprofilename",
+				Name: "nameymcprofilename-9740ed19",
 			},
 			Spec: apiv3.ProfileSpec{
 				Ingress:       []apiv3.Rule{V3InRule1, V3InRule2},
@@ -97,7 +97,7 @@ var profileTable = []struct {
 		},
 		v3API: apiv3.Profile{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "kns.flux.capacitor",
+				Name: "kns.flux.capacitor-a9ad9f16",
 			},
 			Spec: apiv3.ProfileSpec{
 				Ingress:       []apiv3.Rule{V3InRule1, V3InRule2},

--- a/lib/upgrade/etcd/conversionv1v3/workloadendpoint.go
+++ b/lib/upgrade/etcd/conversionv1v3/workloadendpoint.go
@@ -120,6 +120,7 @@ func (_ WorkloadEndpoint) BackendV1ToAPIV3(kvp *model.KVPair) (Resource, error) 
 	switch wepKey.OrchestratorID {
 	case "k8s":
 		namespace, pod = getPodNamespaceName(wepKey.WorkloadID)
+		container = wepValue.ActiveInstanceID
 	case "cni":
 		container = wepKey.WorkloadID
 	case "libnetwork":
@@ -143,7 +144,7 @@ func (_ WorkloadEndpoint) BackendV1ToAPIV3(kvp *model.KVPair) (Resource, error) 
 	wep.Spec = apiv3.WorkloadEndpointSpec{
 		Orchestrator:  convertName(wepKey.OrchestratorID),
 		Workload:      workload,
-		Node:          convertName(wepKey.Hostname),
+		Node:          ConvertNodeName(wepKey.Hostname),
 		Pod:           pod,
 		ContainerID:   container,
 		Endpoint:      convertName(wepKey.EndpointID),

--- a/lib/upgrade/etcd/conversionv1v3/workloadendpoint_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/workloadendpoint_test.go
@@ -90,6 +90,7 @@ var wepTable = []struct {
 				Node:          "testnode",
 				Pod:           "frontend-5gs43",
 				Endpoint:      "eth0",
+				ContainerID:   "1337495556942031415926535",
 				IPNetworks:    []string{"10.0.0.1/32", "2001::/128"},
 				IPNATs:        makeIPNATv3(),
 				IPv4Gateway:   "10.0.0.254",
@@ -157,6 +158,7 @@ var wepTable = []struct {
 				Orchestrator: "k8s",
 				Node:         "testnode",
 				Pod:          "frontend-5gs43",
+				ContainerID:   "1337495556942031415926535",
 				Endpoint:     "eth0",
 				IPNetworks:   []string{"10.0.0.1/32"},
 				IPNATs: []apiv3.IPNAT{apiv3.IPNAT{
@@ -179,7 +181,7 @@ var wepTable = []struct {
 				Workload:         "default.frontend-5gs43",
 				Orchestrator:     "k8s",
 				Node:             "TestNode",
-				ActiveInstanceID: "1337495556942031415926535",
+				ActiveInstanceID: "133749555694203141592653c",
 				Labels:           makeLabelsV1(),
 			},
 			Spec: apiv1.WorkloadEndpointSpec{
@@ -205,7 +207,7 @@ var wepTable = []struct {
 			},
 			Value: &model.WorkloadEndpoint{
 				Labels:           makeLabelsV1(),
-				ActiveInstanceID: "1337495556942031415926535",
+				ActiveInstanceID: "133749555694203141592653c",
 				State:            "active",
 				Name:             "cali1234",
 				Mac:              makeMac(),
@@ -227,6 +229,7 @@ var wepTable = []struct {
 				Orchestrator: "k8s",
 				Node:         "testnode",
 				Pod:          "frontend-5gs43",
+				ContainerID:   "133749555694203141592653c",
 				Endpoint:     "eth0",
 				IPNetworks:   []string{"2001::/128"},
 				IPNATs: []apiv3.IPNAT{apiv3.IPNAT{
@@ -249,7 +252,7 @@ var wepTable = []struct {
 				Workload:         "default.frontend-5gs43",
 				Orchestrator:     "k8s",
 				Node:             "TestNode",
-				ActiveInstanceID: "1337495556942031415926535",
+				ActiveInstanceID: "133749555694203141592653a",
 				Labels:           map[string]string{},
 			},
 			Spec: apiv1.WorkloadEndpointSpec{
@@ -272,7 +275,7 @@ var wepTable = []struct {
 			},
 			Value: &model.WorkloadEndpoint{
 				Labels:           map[string]string{},
-				ActiveInstanceID: "1337495556942031415926535",
+				ActiveInstanceID: "133749555694203141592653a",
 				State:            "active",
 				Name:             "cali1234",
 				Mac:              makeMac(),
@@ -295,6 +298,7 @@ var wepTable = []struct {
 				Orchestrator:  "k8s",
 				Node:          "testnode",
 				Pod:           "frontend-5gs43",
+				ContainerID:   "133749555694203141592653a",
 				Endpoint:      "eth0",
 				IPNetworks:    []string{"10.0.0.1/32", "2001::/128"},
 				IPNATs:        makeIPNATv3(),


### PR DESCRIPTION
## Description
Make the NameNormalization a public method and use it for the hostname normalization.
Update the name conversion to be deterministic by appending a qualifying hash.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```