### PR TITLE
Add basic selector conversion parsing

### DIFF
--- a/lib/upgrade/etcd/conversionv1v3/selectors.go
+++ b/lib/upgrade/etcd/conversionv1v3/selectors.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversionv1v3
+
+import (
+	"strings"
+)
+
+var (
+	v1NamespaceSelector = "calico/k8s_ns"
+	v3NamespaceSelector = "projectcalico.org/namespace"
+)
+
+// convertSelector converts a v1 selector to a v3 selector.
+func convertSelector(sel string) (string, error) {
+	// v1 selectors used calico/k8s_ns, v3 instead uses projectcalico.org/namespace
+	return strings.Replace(sel, v1NamespaceSelector, v3NamespaceSelector, -1), nil
+}

--- a/lib/upgrade/etcd/conversionv1v3/selectors_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/selectors_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversionv1v3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var table = []struct {
+	v1 string
+	v3 string
+}{
+	{"foo == 'bar'", "foo == 'bar'"},
+	{"calico/k8s_ns == 'default'", "projectcalico.org/namespace == 'default'"},
+	{"calico/k8s_ns in {'default'}", "projectcalico.org/namespace in {'default'}"},
+	{"has(calico/k8s_ns)", "has(projectcalico.org/namespace)"},
+	{"has(calico/k8s_ns) || foo == 'bar'", "has(projectcalico.org/namespace) || foo == 'bar'"},
+}
+
+func TestCanConvertSelectors(t *testing.T) {
+	for _, entry := range table {
+		t.Run(entry.v1, func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(convertSelector(entry.v1)).To(Equal(entry.v3), entry.v1)
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

A really basic implementation of the selector conversion, to get us unblocked for now.

We may want to consider fortifying it.

Namely, I think `calico/k8s_ns == 'default'` should really resolve to `projectcalico.org/namespace == 'default' && projectcalico.org/orchestrator == 'k8s'`, but I haven't implemented that yet and it's a lot harder.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
