### PR TITLE
Add a IsClean() method to the etcdv3 datastore

### DIFF
--- a/lib/backend/backend_suite_test.go
+++ b/lib/backend/backend_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestEtcd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Datastore backend Suite")
+}

--- a/lib/backend/clean_e2e_test.go
+++ b/lib/backend/clean_e2e_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+)
+
+type isClean interface {
+	IsClean() (bool, error)
+}
+
+// Perform additional watch tests
+var _ = testutils.E2eDatastoreDescribe("Backend API tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+
+	Describe("Test Clean() and IsClean() functionality", func() {
+		It("should return correct clean status", func() {
+			c, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Clean the datastore
+			By("Cleaning the datastore")
+			c.Clean()
+
+			// The backend that we are testing should implement the isClean interface.
+			isCleanIf, ok := c.(isClean)
+			Expect(ok).To(BeTrue())
+
+			By("Checking the datastore is clean")
+			clean, err := isCleanIf.IsClean()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clean).To(BeTrue())
+
+			By("Adding an entry to the datastore")
+			kvp := &model.KVPair{
+				Key: model.ResourceKey{
+					Kind: "IPPool",
+					Name: "ippool-1",
+				},
+				Value: apiv3.IPPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ippool-1",
+					},
+					Spec: apiv3.IPPoolSpec{
+						CIDR: "1.2.3.0/24",
+					},
+				},
+			}
+			kvp, err = c.Create(ctx, kvp)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking the datastore is not clean")
+			clean, err = isCleanIf.IsClean()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clean).To(BeFalse())
+
+			By("Cleaning the datastore")
+			c.Clean()
+
+			By("Checking the datastore is clean")
+			clean, err = isCleanIf.IsClean()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clean).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Description
Add a semi-private "IsClean()" method to the etcdv3 backend client.

If I end up implementing for KDD then I'll make it part of the backend API.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```