### PR TITLE
Use %v format for non-strings (and don't have String() method)

### DIFF
--- a/lib/apiconfig/load.go
+++ b/lib/apiconfig/load.go
@@ -24,7 +24,7 @@ func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
 
 		c, err := LoadClientConfigFromBytes(b)
 		if err != nil {
-			return nil, fmt.Errorf("syntax error in %s: %s", filename, err)
+			return nil, fmt.Errorf("syntax error in %s: %v", filename, err)
 		}
 		return c, nil
 	}

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -202,7 +202,7 @@ func (c *EtcdClient) Delete(d *model.KVPair) error {
 		log.Debugf("Delete empty Key: %s", parent)
 		_, err2 := c.etcdKeysAPI.Delete(context.Background(), parent, etcdDeleteEmptyOpts)
 		if err2 != nil {
-			log.Debugf("Unable to delete parent: %s", err2)
+			log.Debugf("Unable to delete parent: %v", err2)
 			break
 		}
 	}

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -122,7 +122,7 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 
 	crdClientV1, err := buildCRDClientV1(*config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to build V1 CRD client: %s", err)
+		return nil, fmt.Errorf("Failed to build V1 CRD client: %v", err)
 	}
 
 	kubeClient := &KubeClient{

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -177,7 +177,7 @@ func (c cb) ProcessUpdates() {
 func (c cb) ExpectExists(updates []api.Update) {
 	// For each Key, wait for it to exist.
 	for _, update := range updates {
-		log.Infof("[TEST] Expecting key: %s", update.Key)
+		log.Infof("[TEST] Expecting key: %v", update.Key)
 		matches := false
 
 		wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
@@ -201,7 +201,7 @@ func (c cb) ExpectExists(updates []api.Update) {
 		})
 
 		// Expect the key to have existed.
-		Expect(matches).To(Equal(true), fmt.Sprintf("Expected update not found: %s", update.Key))
+		Expect(matches).To(Equal(true), fmt.Sprintf("Expected update not found: %v", update.Key))
 	}
 }
 
@@ -209,7 +209,7 @@ func (c cb) ExpectExists(updates []api.Update) {
 // via an update over the Syncer.
 func (c cb) ExpectDeleted(kvps []model.KVPair) {
 	for _, kvp := range kvps {
-		log.Infof("[TEST] Not expecting key: %s", kvp.Key)
+		log.Infof("[TEST] Not expecting key: %v", kvp.Key)
 		exists := true
 
 		wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
@@ -230,7 +230,7 @@ func (c cb) ExpectDeleted(kvps []model.KVPair) {
 		})
 
 		// Expect the key to not exist.
-		Expect(exists).To(Equal(false), fmt.Sprintf("Expected key not to exist: %s", kvp.Key))
+		Expect(exists).To(Equal(false), fmt.Sprintf("Expected key not to exist: %v", kvp.Key))
 	}
 }
 
@@ -241,7 +241,7 @@ func (c cb) ExpectDeleted(kvps []model.KVPair) {
 // exist in the cache.
 func (c cb) GetSyncerValueFunc(key model.Key) func() interface{} {
 	return func() interface{} {
-		log.Infof("Checking entry in cache: %s", key)
+		log.Infof("Checking entry in cache: %v", key)
 		c.Lock.Lock()
 		defer func() {
 			c.Lock.Unlock()
@@ -262,7 +262,7 @@ func (c cb) GetSyncerValueFunc(key model.Key) func() interface{} {
 // The returned function returns true if the entry is present.
 func (c cb) GetSyncerValuePresentFunc(key model.Key) func() interface{} {
 	return func() interface{} {
-		log.Infof("Checking entry in cache: %s", key)
+		log.Infof("Checking entry in cache: %v", key)
 		c.Lock.Lock()
 		defer func() { c.Lock.Unlock() }()
 		_, ok := c.State[key.String()]

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -101,7 +101,7 @@ func (c *nodeClient) Get(ctx context.Context, key model.Key, revision string) (*
 
 	kvp, err := K8sNodeToCalico(node)
 	if err != nil {
-		log.Panicf("%s", err)
+		log.Panicf("%v", err)
 	}
 
 	return kvp, nil

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -160,7 +160,7 @@ func LoadClientConfig(filename string) (*api.CalicoAPIConfig, error) {
 
 		c, err := LoadClientConfigFromBytes(b)
 		if err != nil {
-			return nil, fmt.Errorf("syntax error in %s: %s", filename, err)
+			return nil, fmt.Errorf("syntax error in %s: %v", filename, err)
 		}
 		return c, nil
 	} else {

--- a/lib/client/node.go
+++ b/lib/client/node.go
@@ -261,7 +261,7 @@ func (h *nodes) RemoveBGPNode(metadata api.NodeMetadata) error {
 	if err != nil {
 		// Return the error unless the resource does not exist.
 		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
-			log.Errorf("Error removing BGP Node: %s", err)
+			log.Errorf("Error removing BGP Node: %v", err)
 			return err
 		}
 	}

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -36,7 +36,7 @@ type ErrorResourceDoesNotExist struct {
 }
 
 func (e ErrorResourceDoesNotExist) Error() string {
-	return fmt.Sprintf("resource does not exist: %s", e.Identifier)
+	return fmt.Sprintf("resource does not exist: %v", e.Identifier)
 }
 
 // Error indicating an operation is not supported.
@@ -48,9 +48,9 @@ type ErrorOperationNotSupported struct {
 
 func (e ErrorOperationNotSupported) Error() string {
 	if e.Reason == "" {
-		return fmt.Sprintf("operation %s is not supported on %s", e.Operation, e.Identifier)
+		return fmt.Sprintf("operation %s is not supported on %v", e.Operation, e.Identifier)
 	} else {
-		return fmt.Sprintf("operation %s is not supported on %s: %s", e.Operation, e.Identifier, e.Reason)
+		return fmt.Sprintf("operation %s is not supported on %v: %s", e.Operation, e.Identifier, e.Reason)
 	}
 }
 
@@ -62,7 +62,7 @@ type ErrorResourceAlreadyExists struct {
 }
 
 func (e ErrorResourceAlreadyExists) Error() string {
-	return fmt.Sprintf("resource already exists: %s", e.Identifier)
+	return fmt.Sprintf("resource already exists: %v", e.Identifier)
 }
 
 // Error indicating a problem connecting to the backend.
@@ -130,7 +130,7 @@ type ErrorResourceUpdateConflict struct {
 }
 
 func (e ErrorResourceUpdateConflict) Error() string {
-	return fmt.Sprintf("update conflict: %s", e.Identifier)
+	return fmt.Sprintf("update conflict: %v", e.Identifier)
 }
 
 // UpdateErrorIdentifier modifies the supplied error to use the new resource
@@ -167,7 +167,7 @@ type ErrorWatchTerminated struct {
 }
 
 func (e ErrorWatchTerminated) Error() string {
-	return fmt.Sprintf("watch terminated (closedByRemote:%v): %s", e.ClosedByRemote, e.Err)
+	return fmt.Sprintf("watch terminated (closedByRemote:%v): %v", e.ClosedByRemote, e.Err)
 }
 
 // Error indicating the datastore has failed to parse an entry.
@@ -178,5 +178,5 @@ type ErrorParsingDatastoreEntry struct {
 }
 
 func (e ErrorParsingDatastoreEntry) Error() string {
-	return fmt.Sprintf("failed to parse datastore entry key=%s; value=%s: %s", e.RawKey, e.RawValue, e.Err)
+	return fmt.Sprintf("failed to parse datastore entry key=%s; value=%s: %v", e.RawKey, e.RawValue, e.Err)
 }

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -48,7 +48,7 @@ func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ve
 			return []cnet.IPNet{}, nil
 
 		} else {
-			log.Errorf("Error getting affine blocks: %s", err)
+			log.Errorf("Error getting affine blocks: %v", err)
 			return nil, err
 		}
 	}
@@ -82,7 +82,7 @@ func (rw blockReaderWriter) claimNewAffineBlock(ctx context.Context, host string
 	// Get all the configured pools.
 	enabledPools, err := rw.pools.GetEnabledPools(version.Number)
 	if err != nil {
-		log.Errorf("Error reading configured pools: %s", err)
+		log.Errorf("Error reading configured pools: %v", err)
 		return nil, err
 	}
 	log.Debugf("enabled IPPools: %v", enabledPools)
@@ -135,7 +135,7 @@ func (rw blockReaderWriter) claimNewAffineBlock(ctx context.Context, host string
 					err = rw.claimBlockAffinity(ctx, *subnet, host, config)
 					return subnet, err
 				} else {
-					log.Errorf("Error getting block: %s", err)
+					log.Errorf("Error getting block: %v", err)
 					return nil, err
 				}
 			}
@@ -211,7 +211,7 @@ func (rw blockReaderWriter) claimBlockAffinity(ctx context.Context, subnet cnet.
 			// Some other host beat us to this block.  Cleanup and return error.
 			_, err = rw.client.Delete(ctx, model.BlockAffinityKey{Host: host, CIDR: b.CIDR}, "")
 			if err != nil {
-				log.Errorf("Error cleaning up block affinity: %s", err)
+				log.Errorf("Error cleaning up block affinity: %v", err)
 				return err
 			}
 			return affinityClaimedError{Block: b}
@@ -229,7 +229,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, host strin
 		// so that we can pass it back to the datastore on Update.
 		obj, err := rw.client.Get(ctx, model.BlockKey{CIDR: blockCIDR}, "")
 		if err != nil {
-			log.Errorf("Error getting block %s: %s", blockCIDR.String(), err)
+			log.Errorf("Error getting block %s: %v", blockCIDR.String(), err)
 			return err
 		}
 		b := allocationBlock{obj.Value.(*model.AllocationBlock)}
@@ -252,7 +252,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, host strin
 			if err != nil {
 				// Return the error unless the block didn't exist.
 				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-					log.Errorf("Error deleting block: %s", err)
+					log.Errorf("Error deleting block: %v", err)
 					return err
 				}
 			}
@@ -283,7 +283,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, host strin
 		if err != nil {
 			// Return the error unless the affinity didn't exist.
 			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-				log.Errorf("Error deleting block affinity: %s", err)
+				log.Errorf("Error deleting block affinity: %v", err)
 				return err
 			}
 		}

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -614,7 +614,7 @@ func getAffineBlocks(backend bapi.Client, host string) []cnet.IPNet {
 		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
 			log.Printf("No affined blocks found")
 		} else {
-			Expect(err).NotTo(HaveOccurred(), "Error getting affine blocks: %s", err)
+			Expect(err).NotTo(HaveOccurred(), "Error getting affine blocks: %v", err)
 		}
 	}
 

--- a/lib/testutils/createRule.go
+++ b/lib/testutils/createRule.go
@@ -43,7 +43,7 @@ func CreateRule(ipv, icmpType, icmpCode int, proto, cidrStr, tag, selector, inAc
 
 	_, cidr, err := net.ParseCIDR(cidrStr)
 	if err != nil {
-		log.Printf("Error parsing CIDR: %s\n", err)
+		log.Printf("Error parsing CIDR: %v\n", err)
 	}
 
 	src := api.EntityRule{


### PR DESCRIPTION
- errors
- KVPair.Key
- Identifier fields in lib/errors/errors.go
