### PR TITLE
Felix config intervals

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -43,43 +43,43 @@ type FelixConfigurationSpec struct {
 	IPv6Support    *bool `json:"ipv6Support,omitempty" confignamev1:"Ipv6Support"`
 	IgnoreLooseRPF *bool `json:"ignoreLooseRPF,omitempty"`
 
-	// RouterefreshInterval is the period, in seconds, at which Felix re-checks the routes
+	// RouterefreshInterval is the period at which Felix re-checks the routes
 	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.
-	// Set to 0 to disable route refresh. [Default: 90]
-	RouteRefreshIntervalSecs *int `json:"routeRefreshIntervalSecs,omitempty" confignamev1:"RouteRefreshInterval"`
-	// IptablesRefreshInterval is the period, in seconds, at which Felix re-checks the IP sets
+	// Set to 0 to disable route refresh. [Default: 90s]
+	RouteRefreshInterval *metav1.Duration `json:"routeRefreshInterval,omitempty" configv1timescale:"seconds"`
+	// IptablesRefreshInterval is the period at which Felix re-checks the IP sets
 	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.
 	// Set to 0 to disable IP sets refresh. Note: the default for this value is lower than the
 	// other refresh intervals as a workaround for a Linux kernel bug that was fixed in kernel
 	// version 4.11. If you are using v4.11 or greater you may want to set this to, a higher value
-	// to reduce Felix CPU usage. [Default: 10]
-	IptablesRefreshIntervalSecs *int `json:"iptablesRefreshIntervalSecs,omitempty" confignamev1:"IptablesRefreshInterval"`
-	// IptablesPostWriteCheckIntervalSecs is the period, in seconds, after Felix has done a write
+	// to reduce Felix CPU usage. [Default: 10s]
+	IptablesRefreshInterval *metav1.Duration `json:"iptablesRefreshInterval,omitempty" configv1timescale:"seconds"`
+	// IptablesPostWriteCheckInterval is the period after Felix has done a write
 	// to the dataplane that it schedules an extra read back in order to check the write was not
 	// clobbered by another process. This should only occur if another application on the system
-	// doesn’t respect the iptables lock. [Default: 1]
-	IptablesPostWriteCheckIntervalSecs *int `json:"iptablesPostWriteCheckIntervalSecs,omitempty"`
+	// doesn’t respect the iptables lock. [Default: 1s]
+	IptablesPostWriteCheckInterval *metav1.Duration `json:"iptablesPostWriteCheckInterval,omitempty" configv1timescale:"seconds" confignamev1:"IptablesPostWriteCheckIntervalSecs"`
 	// IptablesLockFilePath is the location of the iptables lock file. You may need to change this
 	// if the lock file is not in its standard location (for example if you have mapped it into Felix’s
 	// container at a different path). [Default: /run/xtables.lock]
 	IptablesLockFilePath string `json:"iptablesLockFilePath,omitempty"`
-	// IptablesLockTimeoutSecs is the time, in seconds, that Felix will wait for the iptables lock,
+	// IptablesLockTimeout is the time that Felix will wait for the iptables lock,
 	// or 0, to disable. To use this feature, Felix must share the iptables lock file with all other
 	// processes that also take the lock. When running Felix inside a container, this requires the
 	// /run directory of the host to be mounted into the calico/node or calico/felix container.
-	// [Default: 0 disabled]
-	IptablesLockTimeoutSecs *int `json:"iptablesLockTimeoutSecs,omitempty"`
-	// IptablesLockProbeIntervalMillis is the time, in milliseconds, that Felix will wait between
+	// [Default: 0s disabled]
+	IptablesLockTimeout *metav1.Duration `json:"iptablesLockTimeout,omitempty" configv1timescale:"seconds" confignamev1:"IptablesLockTimeoutSecs"`
+	// IptablesLockProbeInterval is the time that Felix will wait between
 	// attempts to acquire the iptables lock if it is not available. Lower values make Felix more
-	// responsive when the lock is contended, but use more CPU. [Default: 50]
-	IptablesLockProbeIntervalMillis *int `json:"iptablesLockProbeIntervalMillis,omitempty"`
-	// IpsetsRefreshIntervalSecs is the period, in seconds, at which Felix re-checks all iptables
+	// responsive when the lock is contended, but use more CPU. [Default: 50ms]
+	IptablesLockProbeInterval *metav1.Duration `json:"iptablesLockProbeInterval,omitempty" configv1timescale:"milliseconds" confignamev1:"IptablesLockProbeIntervalMillis"`
+	// IpsetsRefreshInterval is the period at which Felix re-checks all iptables
 	// state to ensure that no other process has accidentally broken Calico’s rules. Set to 0 to
-	// disable iptables refresh. [Default: 90]
-	IpsetsRefreshIntervalSecs *int `json:"ipsetsRefreshIntervalSecs,omitempty" confignamev1:"IpsetsRefreshInterval"`
-	MaxIpsetSize              *int `json:"maxIpsetSize,omitempty"`
+	// disable iptables refresh. [Default: 90s]
+	IpsetsRefreshInterval *metav1.Duration `json:"ipsetsRefreshInterval,omitempty" configv1timescale:"seconds"`
+	MaxIpsetSize          *int `json:"maxIpsetSize,omitempty"`
 
-	NetlinkTimeoutSecs *int `json:"netlinkTimeoutSecs,omitempty"`
+	NetlinkTimeout *metav1.Duration `json:"netlinkTimeout,omitempty" configv1timescale:"seconds" confignamev1:"NetlinkTimeoutSecs"`
 
 	// MetadataAddr is the IP address or domain name of the server that can answer VM queries for
 	// cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in
@@ -135,14 +135,14 @@ type FelixConfigurationSpec struct {
 	// IPIPMTU is the MTU to set on the tunnel device. See Configuring MTU [Default: 1440]
 	IPIPMTU *int `json:"ipipMTU,omitempty" confignamev1:"IpInIpMtu"`
 
-	// ReportingIntervalSecs is the interval at which Felix reports its status into the datastore or 0 to disable.
-	// Must be non-zero in OpenStack deployments. [Default: 30]
-	ReportingIntervalSecs *int `json:"reportingIntervalSecs,omitempty"`
-	// ReportingTTLSecs is the time-to-live setting for process-wide status reports. [Default: 90]
-	ReportingTTLSecs *int `json:"reportingTTLSecs,omitempty"`
+	// ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.
+	// Must be non-zero in OpenStack deployments. [Default: 30s]
+	ReportingInterval *metav1.Duration `json:"reportingInterval,omitempty" configv1timescale:"seconds" confignamev1:"ReportingIntervalSecs"`
+	// ReportingTTL is the time-to-live setting for process-wide status reports. [Default: 90s]
+	ReportingTTL *metav1.Duration `json:"reportingTTL,omitempty" configv1timescale:"seconds" confignamev1:"ReportingTTLSecs"`
 
 	EndpointReportingEnabled   *bool `json:"endpointReportingEnabled,omitempty"`
-	EndpointReportingDelaySecs *int  `json:"endpointReportingDelaySecs,omitempty"`
+	EndpointReportingDelay     *metav1.Duration  `json:"endpointReportingDelay,omitempty" configv1timescale:"seconds" confignamev1:"EndpointReportingDelaySecs"`
 
 	// IptablesMarkMask is the mask that Felix selects its IPTables Mark bits from. Should be a 32 bit hexadecimal
 	// number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
@@ -180,15 +180,15 @@ type FelixConfigurationSpec struct {
 	// UsageReportingEnabled reports anonymous Calico version number and cluster size to projectcalico.org. Logs warnings returned by the usage
 	// server. For example, if a significant security vulnerability has been discovered in the version of Calico being used. [Default: true]
 	UsageReportingEnabled *bool `json:"usageReportingEnabled,omitempty"`
-	// UsageReportingInitialDelaySecs controls the minimum delay (in seconds) before Felix makes a report. [Default: 300]
-	UsageReportingInitialDelaySecs *int `json:"usageReportingInitialDelaySecs,omitempty"`
-	// UsageReportingIntervalSecs controls the interval (in seconds) at which Felix makes reports. [Default: 86400]
-	UsageReportingIntervalSecs *int `json:"usageReportingIntervalSecs,omitempty"`
+	// UsageReportingInitialDelay controls the minimum delay before Felix makes a report. [Default: 300s]
+	UsageReportingInitialDelay *metav1.Duration `json:"usageReportingInitialDelay,omitempty" configv1timescale:"seconds" confignamev1:"UsageReportingInitialDelaySecs"`
+	// UsageReportingInterval controls the interval at which Felix makes reports. [Default: 86400s]
+	UsageReportingInterval *metav1.Duration `json:"usageReportingInterval,omitempty" configv1timescale:"seconds" confignamev1:"UsageReportingIntervalSecs"`
 
-	DebugMemoryProfilePath              string `json:"debugMemoryProfilePath,omitempty"`
-	DebugDisableLogDropping             *bool  `json:"debugDisableLogDropping,omitempty"`
-	DebugSimulateCalcGraphHangAfterSecs *int   `json:"debugSimulateCalcGraphHangAfterSecs,omitempty" confignamev1:"DebugSimulateCalcGraphHangAfter"`
-	DebugSimulateDataplaneHangAfterSecs *int   `json:"debugSimulateDataplaneHangAfterSecs,omitempty" confignamev1:"DebugSimualteDataplaneHangAfter"`
+	DebugMemoryProfilePath          string `json:"debugMemoryProfilePath,omitempty"`
+	DebugDisableLogDropping         *bool  `json:"debugDisableLogDropping,omitempty"`
+	DebugSimulateCalcGraphHangAfter *metav1.Duration   `json:"debugSimulateCalcGraphHangAfter,omitempty" configv1timescale:"seconds"`
+	DebugSimulateDataplaneHangAfter *metav1.Duration   `json:"debugSimulateDataplaneHangAfter,omitempty" configv1timescale:"seconds"`
 }
 
 // ProtoPort is combination of protocol and port, both must be specified.

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -19,11 +19,11 @@
 package v3
 
 import (
-	reflect "reflect"
-
 	numorstring "github.com/projectcalico/libcalico-go/lib/numorstring"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	reflect "reflect"
 )
 
 func init() {
@@ -104,6 +104,10 @@ func RegisterDeepCopies(scheme *runtime.Scheme) error {
 			in.(*GlobalNetworkPolicySpec).DeepCopyInto(out.(*GlobalNetworkPolicySpec))
 			return nil
 		}, InType: reflect.TypeOf(&GlobalNetworkPolicySpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: func(in interface{}, out interface{}, c *conversion.Cloner) error {
+			in.(*HTTPRule).DeepCopyInto(out.(*HTTPRule))
+			return nil
+		}, InType: reflect.TypeOf(&HTTPRule{})},
 		conversion.GeneratedDeepCopyFunc{Fn: func(in interface{}, out interface{}, c *conversion.Cloner) error {
 			in.(*HostEndpoint).DeepCopyInto(out.(*HostEndpoint))
 			return nil
@@ -188,6 +192,10 @@ func RegisterDeepCopies(scheme *runtime.Scheme) error {
 			in.(*Rule).DeepCopyInto(out.(*Rule))
 			return nil
 		}, InType: reflect.TypeOf(&Rule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: func(in interface{}, out interface{}, c *conversion.Cloner) error {
+			in.(*ServiceAccountMatch).DeepCopyInto(out.(*ServiceAccountMatch))
+			return nil
+		}, InType: reflect.TypeOf(&ServiceAccountMatch{})},
 		conversion.GeneratedDeepCopyFunc{Fn: func(in interface{}, out interface{}, c *conversion.Cloner) error {
 			in.(*WorkloadEndpoint).DeepCopyInto(out.(*WorkloadEndpoint))
 			return nil
@@ -504,6 +512,15 @@ func (in *EntityRule) DeepCopyInto(out *EntityRule) {
 		*out = make([]numorstring.Port, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServiceAccounts != nil {
+		in, out := &in.ServiceAccounts, &out.ServiceAccounts
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ServiceAccountMatch)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 
@@ -609,57 +626,57 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			**out = **in
 		}
 	}
-	if in.RouteRefreshIntervalSecs != nil {
-		in, out := &in.RouteRefreshIntervalSecs, &out.RouteRefreshIntervalSecs
+	if in.RouteRefreshInterval != nil {
+		in, out := &in.RouteRefreshInterval, &out.RouteRefreshInterval
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.IptablesRefreshIntervalSecs != nil {
-		in, out := &in.IptablesRefreshIntervalSecs, &out.IptablesRefreshIntervalSecs
+	if in.IptablesRefreshInterval != nil {
+		in, out := &in.IptablesRefreshInterval, &out.IptablesRefreshInterval
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.IptablesPostWriteCheckIntervalSecs != nil {
-		in, out := &in.IptablesPostWriteCheckIntervalSecs, &out.IptablesPostWriteCheckIntervalSecs
+	if in.IptablesPostWriteCheckInterval != nil {
+		in, out := &in.IptablesPostWriteCheckInterval, &out.IptablesPostWriteCheckInterval
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.IptablesLockTimeoutSecs != nil {
-		in, out := &in.IptablesLockTimeoutSecs, &out.IptablesLockTimeoutSecs
+	if in.IptablesLockTimeout != nil {
+		in, out := &in.IptablesLockTimeout, &out.IptablesLockTimeout
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.IptablesLockProbeIntervalMillis != nil {
-		in, out := &in.IptablesLockProbeIntervalMillis, &out.IptablesLockProbeIntervalMillis
+	if in.IptablesLockProbeInterval != nil {
+		in, out := &in.IptablesLockProbeInterval, &out.IptablesLockProbeInterval
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.IpsetsRefreshIntervalSecs != nil {
-		in, out := &in.IpsetsRefreshIntervalSecs, &out.IpsetsRefreshIntervalSecs
+	if in.IpsetsRefreshInterval != nil {
+		in, out := &in.IpsetsRefreshInterval, &out.IpsetsRefreshInterval
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
@@ -672,12 +689,12 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			**out = **in
 		}
 	}
-	if in.NetlinkTimeoutSecs != nil {
-		in, out := &in.NetlinkTimeoutSecs, &out.NetlinkTimeoutSecs
+	if in.NetlinkTimeout != nil {
+		in, out := &in.NetlinkTimeout, &out.NetlinkTimeout
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
@@ -708,21 +725,21 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			**out = **in
 		}
 	}
-	if in.ReportingIntervalSecs != nil {
-		in, out := &in.ReportingIntervalSecs, &out.ReportingIntervalSecs
+	if in.ReportingInterval != nil {
+		in, out := &in.ReportingInterval, &out.ReportingInterval
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.ReportingTTLSecs != nil {
-		in, out := &in.ReportingTTLSecs, &out.ReportingTTLSecs
+	if in.ReportingTTL != nil {
+		in, out := &in.ReportingTTL, &out.ReportingTTL
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
@@ -735,12 +752,12 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			**out = **in
 		}
 	}
-	if in.EndpointReportingDelaySecs != nil {
-		in, out := &in.EndpointReportingDelaySecs, &out.EndpointReportingDelaySecs
+	if in.EndpointReportingDelay != nil {
+		in, out := &in.EndpointReportingDelay, &out.EndpointReportingDelay
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
@@ -851,6 +868,24 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			**out = **in
 		}
 	}
+	if in.UsageReportingInitialDelay != nil {
+		in, out := &in.UsageReportingInitialDelay, &out.UsageReportingInitialDelay
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
+	if in.UsageReportingInterval != nil {
+		in, out := &in.UsageReportingInterval, &out.UsageReportingInterval
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.DebugDisableLogDropping != nil {
 		in, out := &in.DebugDisableLogDropping, &out.DebugDisableLogDropping
 		if *in == nil {
@@ -860,21 +895,21 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			**out = **in
 		}
 	}
-	if in.DebugSimulateCalcGraphHangAfterSecs != nil {
-		in, out := &in.DebugSimulateCalcGraphHangAfterSecs, &out.DebugSimulateCalcGraphHangAfterSecs
+	if in.DebugSimulateCalcGraphHangAfter != nil {
+		in, out := &in.DebugSimulateCalcGraphHangAfter, &out.DebugSimulateCalcGraphHangAfter
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
-	if in.DebugSimulateDataplaneHangAfterSecs != nil {
-		in, out := &in.DebugSimulateDataplaneHangAfterSecs, &out.DebugSimulateDataplaneHangAfterSecs
+	if in.DebugSimulateDataplaneHangAfter != nil {
+		in, out := &in.DebugSimulateDataplaneHangAfter, &out.DebugSimulateDataplaneHangAfter
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(int)
+			*out = new(v1.Duration)
 			**out = **in
 		}
 	}
@@ -993,6 +1028,27 @@ func (in *GlobalNetworkPolicySpec) DeepCopy() *GlobalNetworkPolicySpec {
 		return nil
 	}
 	out := new(GlobalNetworkPolicySpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *HTTPRule) DeepCopyInto(out *HTTPRule) {
+	*out = *in
+	if in.Methods != nil {
+		in, out := &in.Methods, &out.Methods
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new HTTPRule.
+func (in *HTTPRule) DeepCopy() *HTTPRule {
+	if in == nil {
+		return nil
+	}
+	out := new(HTTPRule)
 	in.DeepCopyInto(out)
 	return out
 }
@@ -1622,6 +1678,15 @@ func (in *Rule) DeepCopyInto(out *Rule) {
 	}
 	in.Source.DeepCopyInto(&out.Source)
 	in.Destination.DeepCopyInto(&out.Destination)
+	if in.HTTP != nil {
+		in, out := &in.HTTP, &out.HTTP
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(HTTPRule)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 
@@ -1631,6 +1696,27 @@ func (in *Rule) DeepCopy() *Rule {
 		return nil
 	}
 	out := new(Rule)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *ServiceAccountMatch) DeepCopyInto(out *ServiceAccountMatch) {
+	*out = *in
+	if in.Names != nil {
+		in, out := &in.Names, &out.Names
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new ServiceAccountMatch.
+func (in *ServiceAccountMatch) DeepCopy() *ServiceAccountMatch {
+	if in == nil {
+		return nil
+	}
+	out := new(ServiceAccountMatch)
 	in.DeepCopyInto(out)
 	return out
 }

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,6 +231,13 @@ func (c *configUpdateProcessor) processAddOrModified(kvp *model.KVPair) ([]*mode
 				switch vt := value.(type) {
 				case string:
 					value = vt
+				case v1.Duration:
+					switch fieldInfo.Tag.Get("configv1timescale") {
+					case "milliseconds":
+						value = fmt.Sprintf("%.3f", float64(vt.Duration/time.Millisecond))
+					default:
+						value = fmt.Sprintf("%.3f", vt.Seconds())
+					}
 				default:
 					value = fmt.Sprintf("%v", vt)
 				}

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -16,9 +16,11 @@ package updateprocessors_test
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -183,10 +185,11 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		cc := updateprocessors.NewFelixConfigUpdateProcessor()
 		By("converting a per-node felix KVPair with certain values and checking for the correct number of fields")
 		res := apiv3.NewFelixConfiguration()
-		int1 := int(12345)
+		duration := metav1.Duration{Duration: time.Duration(1 * time.Minute)}
 		bool1 := false
 		uint1 := uint32(1313)
-		res.Spec.RouteRefreshIntervalSecs = &int1
+		res.Spec.RouteRefreshInterval = &duration
+		res.Spec.IptablesLockProbeInterval = &duration
 		res.Spec.InterfacePrefix = "califoobar"
 		res.Spec.IPIPEnabled = &bool1
 		res.Spec.IptablesMarkMask = &uint1
@@ -206,12 +209,13 @@ var _ = Describe("Test the generic configuration update processor and the concre
 			},
 		}
 		expected := map[string]interface{}{
-			"RouteRefreshInterval":      "12345",
-			"InterfacePrefix":           "califoobar",
-			"IpInIpEnabled":             "false",
-			"IptablesMarkMask":          "1313",
-			"FailsafeInboundHostPorts":  "none",
-			"FailsafeOutboundHostPorts": "tcp:1234,udp:22,tcp:65535",
+			"RouteRefreshInterval":            "60.000",
+			"IptablesLockProbeIntervalMillis": "60000.000",
+			"InterfacePrefix":                 "califoobar",
+			"IpInIpEnabled":                   "false",
+			"IptablesMarkMask":                "1313",
+			"FailsafeInboundHostPorts":        "none",
+			"FailsafeOutboundHostPorts":       "tcp:1234,udp:22,tcp:65535",
 		}
 		kvps, err := cc.Process(&model.KVPair{
 			Key:   perNodeFelixKey,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes #712 
Changing the type for all of the `FexixConfigurationSpec.*Secs` to be of type `*time.Duration` instead of `*int` to ensure we don't loose precision and to match what Felix uses (as we can do fractional seconds in Felix) and setting `config:"seconds"` to match what Felix expects.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
