### PR TITLE
Fix policy conversion producing protocol 0

### DIFF
--- a/lib/upgrade/etcd/conversionv1v3/policy_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/policy_test.go
@@ -271,6 +271,61 @@ var policyTable = []struct {
 			},
 		},
 	},
+	{
+		description: "policy test3",
+		v1API: &apiv1.Policy{
+			Metadata: apiv1.PolicyMetadata{
+				Name: "policy1",
+			},
+			Spec: apiv1.PolicySpec{
+				Order: &order1,
+				// Source Nets selector in V1InRule1 and V1EgressRule1 are non-strictly masked CIDRs.
+				IngressRules: []apiv1.Rule{
+					{
+						Action: "deny",
+						Source: apiv1.EntityRule{
+							Selector: "type=='application'",
+						},
+					},
+				},
+				Selector: "type=='database'",
+			},
+		},
+		v1KVP: &model.KVPair{
+			Key: model.PolicyKey{
+				Name: "policy1",
+			},
+			Value: &model.Policy{
+				Order: &order1,
+				// Source Nets selector in V1ModelInRule1 and V1ModelEgressRule1 are non-strictly masked CIDRs.
+				InboundRules: []model.Rule{{
+					Action:      "deny",
+					SrcSelector: "type=='application'",
+				}},
+				OutboundRules: []model.Rule{},
+				Selector:      "type=='database'",
+				Types:         []string{"ingress"},
+			},
+		},
+		v3API: apiv3.GlobalNetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "policy1",
+			},
+			Spec: apiv3.GlobalNetworkPolicySpec{
+				Order: &order1,
+				// Source Nets selector in V3InRule1 and V3EgressRule1 are strictly masked CIDRs.
+				Ingress: []apiv3.Rule{{
+					Action: apiv3.Deny,
+					Source: apiv3.EntityRule{
+						Selector: "type=='application'",
+					},
+				}},
+				Egress:   []apiv3.Rule{},
+				Selector: "type=='database'",
+				Types:    []apiv3.PolicyType{apiv3.PolicyTypeIngress},
+			},
+		},
+	},
 }
 
 func TestCanConvertV1ToV3Policy(t *testing.T) {

--- a/lib/upgrade/etcd/conversionv1v3/rule.go
+++ b/lib/upgrade/etcd/conversionv1v3/rule.go
@@ -166,17 +166,24 @@ func rulebackendToAPIv3(br model.Rule) apiv3.Rule {
 	notSrcSelector := mergeTagsAndSelectors(br.NotSrcSelector, br.NotSrcTag)
 	notDstSelector := mergeTagsAndSelectors(br.NotDstSelector, br.NotDstTag)
 
-	var v3Protocol numorstring.Protocol
+	var v3Protocol *numorstring.Protocol
 	if br.Protocol != nil {
-		v3Protocol = numorstring.ProtocolV3FromProtocolV1(*br.Protocol)
+		protocol := numorstring.ProtocolV3FromProtocolV1(*br.Protocol)
+		v3Protocol = &protocol
+	}
+
+	var v3NotProtocol *numorstring.Protocol
+	if br.NotProtocol != nil {
+		notProtocol := numorstring.ProtocolV3FromProtocolV1(*br.NotProtocol)
+		v3NotProtocol = &notProtocol
 	}
 
 	return apiv3.Rule{
 		Action:      ruleActionV1ToV3API(br.Action),
 		IPVersion:   br.IPVersion,
-		Protocol:    &v3Protocol,
+		Protocol:    v3Protocol,
 		ICMP:        icmp,
-		NotProtocol: br.NotProtocol,
+		NotProtocol: v3NotProtocol,
 		NotICMP:     notICMP,
 		Source: apiv3.EntityRule{
 			Nets:        srcNetsStr,


### PR DESCRIPTION
## Context
I noticed this when testing out the `calicoctl convert` command with this policy:
```
apiVersion: v1
kind: policy
metadata:
  name: policy1
spec:
  order: 100
  ingress:
  - action: deny
    source: 
      selector: type=='application'
  selector: type=='database'
```

Without the fix included in this PR, the conversion of the above would produce:
```
apiVersion: projectcalico.org/v3
kind: GlobalNetworkPolicy
metadata:
  creationTimestamp: null
  name: policy1
spec:
  ingress:
  - action: Deny
    destination: {}
    protocol: 0
    source:
      selector: type=='application'
  order: 100
  selector: type=='database'
  types:
  - Ingress
```

## Description
Without the fix included in this PR, the test added in this PR produces the error below.

```
    --- FAIL: TestCanConvertV1ToV3Policy/policy_test3 (0.00s)
        testing_t_support.go:22:  
                        /home/tomjoad/code/src/github.com/projectcalico/libcalico-go/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x1ef
                github.com/projectcalico/libcalico-go/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).To(0xc42013df80, 0xc75dc0, 0xc4202f9790, 0xc4202f97a0, 0x1, 0x1, 0xc42013df80)
                        /home/tomjoad/code/src/github.com/projectcalico/libcalico-go/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:35 +0xae
                github.com/projectcalico/libcalico-go/lib/upgrade/etcd/conversionv1v3.TestCanConvertV1ToV3Policy.func1(0xc42022ef70)
                        /home/tomjoad/code/src/github.com/projectcalico/libcalico-go/lib/upgrade/etcd/conversionv1v3/policy_test.go:348 +0x92e
                testing.tRunner(0xc42022ef70, 0xc4202f8de0)
                        /usr/local/go/src/testing/testing.go:657 +0x96
                created by testing.(*T).Run
                        /usr/local/go/src/testing/testing.go:697 +0x2ca

                policy test3
                Expected
                    <v3.GlobalNetworkPolicySpec>: {
                        Order: 1000,
                        Ingress: [
                            {
                                Action: "Deny",
                                IPVersion: nil,
                                Protocol: {Type: 0, NumVal: 0, StrVal: ""},
                                ICMP: nil,
                                NotProtocol: nil,
                                NotICMP: nil,
                                Source: {
                                    Nets: nil,
                                    Selector: "type=='application'",
                                    NamespaceSelector: "",
                                    Ports: nil,
                                    NotNets: nil,
                                    NotSelector: "",
                                    NotPorts: nil,
                                    ServiceAccounts: nil,
                                },
                                Destination: {
                                    Nets: nil,
                                    Selector: "",
                                    NamespaceSelector: "",
                                    Ports: nil,
                                    NotNets: nil,
                                    NotSelector: "",
                                    NotPorts: nil,
                                    ServiceAccounts: nil,
                                },
                                HTTP: nil,
                            },
                        ],
                        Egress: [],
                        Selector: "type=='database'",
                        Types: ["Ingress"],
                        DoNotTrack: false,
                        PreDNAT: false,
                        ApplyOnForward: false,
                    }
                to equal
                    <v3.GlobalNetworkPolicySpec>: {
                        Order: 1000,
                        Ingress: [
                            {
                                Action: "Deny",
                                IPVersion: nil,
                                Protocol: nil,
                                ICMP: nil,
                                NotProtocol: nil,
                                NotICMP: nil,
                                Source: {
                                    Nets: nil,
                                    Selector: "type=='application'",
                                    NamespaceSelector: "",
                                    Ports: nil,
                                    NotNets: nil,
                                    NotSelector: "",
                                    NotPorts: nil,
                                    ServiceAccounts: nil,
                                },
                                Destination: {
                                    Nets: nil,
                                    Selector: "",
                                    NamespaceSelector: "",
                                    Ports: nil,
                                    NotNets: nil,
                                    NotSelector: "",
                                    NotPorts: nil,
                                    ServiceAccounts: nil,
                                },
                                HTTP: nil,
                            },
                        ],
                        Egress: nil,
                        Selector: "type=='database'",
                        Types: ["Ingress"],
                        DoNotTrack: false,
                        PreDNAT: false,
                        ApplyOnForward: false,
                    }
```
