### PR TITLE
Removed ApplyOnForward from v1 API.

### DIFF
--- a/lib/apis/v1/policy.go
+++ b/lib/apis/v1/policy.go
@@ -118,9 +118,6 @@ type PolicySpec struct {
 	// PreDNAT indicates to apply the rules in this policy before any DNAT.
 	PreDNAT bool `json:"preDNAT,omitempty"`
 
-	// ApplyOnForward indicates to apply the rules in this policy on forward traffic.
-	ApplyOnForward bool `json:"applyOnForward,omitempty"`
-
 	// Types indicates whether this policy applies to ingress, or to egress, or to both.  When
 	// not explicitly specified (and so the value on creation is empty or nil), Calico defaults
 	// Types according to what IngressRules and EgressRules are present in the policy.  The

--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -45,16 +45,22 @@ func (p PolicyConverter) ConvertAPIToKVPair(a unversioned.Resource) (*model.KVPa
 	d := model.KVPair{
 		Key: k,
 		Value: &model.Policy{
-			Order:          ap.Spec.Order,
-			InboundRules:   RulesAPIToBackend(ap.Spec.IngressRules),
-			OutboundRules:  RulesAPIToBackend(ap.Spec.EgressRules),
-			Selector:       ap.Spec.Selector,
-			DoNotTrack:     ap.Spec.DoNotTrack,
-			Annotations:    ap.Metadata.Annotations,
-			PreDNAT:        ap.Spec.PreDNAT,
-			ApplyOnForward: ap.Spec.ApplyOnForward,
-			Types:          nil, // filled in below
+			Order:         ap.Spec.Order,
+			InboundRules:  RulesAPIToBackend(ap.Spec.IngressRules),
+			OutboundRules: RulesAPIToBackend(ap.Spec.EgressRules),
+			Selector:      ap.Spec.Selector,
+			DoNotTrack:    ap.Spec.DoNotTrack,
+			Annotations:   ap.Metadata.Annotations,
+			PreDNAT:       ap.Spec.PreDNAT,
+			Types:         nil, // filled in below
 		},
+	}
+
+	if ap.Spec.DoNotTrack || ap.Spec.PreDNAT {
+		// This case happens when there is a pre-existing policy in the datastore, from before
+		// the ApplyOnForward feature was available. DoNotTrack or PreDNAT policy applies to
+		// forward traffic by nature. So in this case we return ApplyOnForward flag as true.
+		d.Value.(*model.Policy).ApplyOnForward = true
 	}
 
 	if len(ap.Spec.Types) == 0 {
@@ -100,15 +106,7 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 	ap.Spec.Selector = bp.Selector
 	ap.Spec.DoNotTrack = bp.DoNotTrack
 	ap.Spec.PreDNAT = bp.PreDNAT
-	ap.Spec.ApplyOnForward = bp.ApplyOnForward
 	ap.Spec.Types = nil
-
-	if !bp.ApplyOnForward && (bp.DoNotTrack || bp.PreDNAT) {
-		// This case happens when there is a pre-existing policy in the datastore, from before
-		// the ApplyOnForward feature was available. DoNotTrack or PreDNAT policy applies to
-		// forward traffic by nature. So in this case we return ApplyOnForward flag as true.
-		ap.Spec.ApplyOnForward = true
-	}
 
 	if len(bp.Types) == 0 {
 		// This case happens when there is a pre-existing policy in an etcd datastore, from

--- a/lib/upgrade/etcd/conversionv1v3/policy.go
+++ b/lib/upgrade/etcd/conversionv1v3/policy.go
@@ -38,16 +38,22 @@ func (_ Policy) APIV1ToBackendV1(a unversioned.Resource) (*model.KVPair, error) 
 			Name: ap.Metadata.Name,
 		},
 		Value: &model.Policy{
-			Order:          ap.Spec.Order,
-			InboundRules:   rulesAPIV1ToBackend(ap.Spec.IngressRules),
-			OutboundRules:  rulesAPIV1ToBackend(ap.Spec.EgressRules),
-			Selector:       ap.Spec.Selector,
-			DoNotTrack:     ap.Spec.DoNotTrack,
-			Annotations:    ap.Metadata.Annotations,
-			PreDNAT:        ap.Spec.PreDNAT,
-			ApplyOnForward: ap.Spec.ApplyOnForward,
-			Types:          nil, // filled in below
+			Order:         ap.Spec.Order,
+			InboundRules:  rulesAPIV1ToBackend(ap.Spec.IngressRules),
+			OutboundRules: rulesAPIV1ToBackend(ap.Spec.EgressRules),
+			Selector:      ap.Spec.Selector,
+			DoNotTrack:    ap.Spec.DoNotTrack,
+			Annotations:   ap.Metadata.Annotations,
+			PreDNAT:       ap.Spec.PreDNAT,
+			Types:         nil, // filled in below
 		},
+	}
+
+	if ap.Spec.DoNotTrack || ap.Spec.PreDNAT {
+		// This case happens when there is a pre-existing policy in the datastore, from before
+		// the ApplyOnForward feature was available. DoNotTrack or PreDNAT policy applies to
+		// forward traffic by nature. So in this case we return ApplyOnForward flag as true.
+		d.Value.(*model.Policy).ApplyOnForward = true
 	}
 
 	if len(ap.Spec.Types) == 0 {

--- a/lib/upgrade/etcd/conversionv1v3/policy_test.go
+++ b/lib/upgrade/etcd/conversionv1v3/policy_test.go
@@ -41,14 +41,13 @@ var policyTable = []struct {
 				Name: "nameyMcPolicyName",
 			},
 			Spec: apiv1.PolicySpec{
-				Order:          &order1,
-				IngressRules:   []apiv1.Rule{V1InRule1, V1InRule2},
-				EgressRules:    []apiv1.Rule{V1EgressRule1, V1EgressRule2},
-				Selector:       "calico/k8s_ns == 'default' || thing == 'value'",
-				DoNotTrack:     true,
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				Types:          []apiv1.PolicyType{apiv1.PolicyTypeIngress},
+				Order:        &order1,
+				IngressRules: []apiv1.Rule{V1InRule1, V1InRule2},
+				EgressRules:  []apiv1.Rule{V1EgressRule1, V1EgressRule2},
+				Selector:     "calico/k8s_ns == 'default' || thing == 'value'",
+				DoNotTrack:   false, // DoNotTrack and PreDNAT can not both be true.
+				PreDNAT:      true,
+				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
 		v1KVP: &model.KVPair{
@@ -60,7 +59,7 @@ var policyTable = []struct {
 				InboundRules:   []model.Rule{V1ModelInRule1, V1ModelInRule2},
 				OutboundRules:  []model.Rule{V1ModelEgressRule1, V1ModelEgressRule2},
 				Selector:       "calico/k8s_ns == 'default' || thing == 'value'",
-				DoNotTrack:     true,
+				DoNotTrack:     false,
 				PreDNAT:        true,
 				ApplyOnForward: true,
 				Types:          []string{"ingress"},
@@ -75,7 +74,7 @@ var policyTable = []struct {
 				Ingress:        []apiv3.Rule{V3InRule1, V3InRule2},
 				Egress:         []apiv3.Rule{V3EgressRule1, V3EgressRule2},
 				Selector:       "projectcalico.org/namespace == 'default' || thing == 'value'",
-				DoNotTrack:     true,
+				DoNotTrack:     false,
 				PreDNAT:        true,
 				ApplyOnForward: true,
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
@@ -89,14 +88,13 @@ var policyTable = []struct {
 				Name: "MaKe.-.MaKe",
 			},
 			Spec: apiv1.PolicySpec{
-				Order:          &order1,
-				IngressRules:   []apiv1.Rule{V1InRule2},
-				EgressRules:    []apiv1.Rule{V1EgressRule1},
-				Selector:       "thing == 'value'",
-				DoNotTrack:     true,
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				Types:          []apiv1.PolicyType{apiv1.PolicyTypeIngress},
+				Order:        &order1,
+				IngressRules: []apiv1.Rule{V1InRule2},
+				EgressRules:  []apiv1.Rule{V1EgressRule1},
+				Selector:     "thing == 'value'",
+				DoNotTrack:   true,
+				PreDNAT:      false,
+				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
 		v1KVP: &model.KVPair{
@@ -109,7 +107,7 @@ var policyTable = []struct {
 				OutboundRules:  []model.Rule{V1ModelEgressRule1},
 				Selector:       "thing == 'value'",
 				DoNotTrack:     true,
-				PreDNAT:        true,
+				PreDNAT:        false,
 				ApplyOnForward: true,
 				Types:          []string{"ingress"},
 			},
@@ -124,26 +122,67 @@ var policyTable = []struct {
 				Egress:         []apiv3.Rule{V3EgressRule1},
 				Selector:       "thing == 'value'",
 				DoNotTrack:     true,
-				PreDNAT:        true,
+				PreDNAT:        false,
 				ApplyOnForward: true,
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
 	},
 	{
-		description: "policy with ApplyOnForward set to it's zero value (missing), and PreDNAT and DoNotTrack set to true " +
+		description: "policy with PreDNAT set to true " +
 			"should convert ApplyOnForward to true in v3 API",
 		v1API: &apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "RAWR",
 			},
 			Spec: apiv1.PolicySpec{
+				Order:        &order1,
+				IngressRules: []apiv1.Rule{V1InRule2},
+				PreDNAT:      true,
+				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
+			},
+		},
+		v1KVP: &model.KVPair{
+			Key: model.PolicyKey{
+				Name: "RAWR",
+			},
+			Value: &model.Policy{
 				Order:          &order1,
-				IngressRules:   []apiv1.Rule{V1InRule2},
-				DoNotTrack:     true,
+				InboundRules:   []model.Rule{V1ModelInRule2},
+				OutboundRules:  []model.Rule{},
+				DoNotTrack:     false,
 				PreDNAT:        true,
-				ApplyOnForward: false,
-				Types:          []apiv1.PolicyType{apiv1.PolicyTypeIngress},
+				ApplyOnForward: true,
+				Types:          []string{"ingress"},
+			},
+		},
+		v3API: apiv3.GlobalNetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "rawr-03d81e1d",
+			},
+			Spec: apiv3.GlobalNetworkPolicySpec{
+				Order:          &order1,
+				Ingress:        []apiv3.Rule{V3InRule2},
+				Egress:         []apiv3.Rule{},
+				DoNotTrack:     false,
+				PreDNAT:        true,
+				ApplyOnForward: true, // notice this gets converted to true, because PreDNAT are true.
+				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
+			},
+		},
+	},
+	{
+		description: "policy with DoNotTrack set to true " +
+			"should convert ApplyOnForward to true in v3 API",
+		v1API: &apiv1.Policy{
+			Metadata: apiv1.PolicyMetadata{
+				Name: "RAWR",
+			},
+			Spec: apiv1.PolicySpec{
+				Order:        &order1,
+				IngressRules: []apiv1.Rule{V1InRule2},
+				DoNotTrack:   true,
+				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
 		v1KVP: &model.KVPair{
@@ -155,8 +194,8 @@ var policyTable = []struct {
 				InboundRules:   []model.Rule{V1ModelInRule2},
 				OutboundRules:  []model.Rule{},
 				DoNotTrack:     true,
-				PreDNAT:        true,
-				ApplyOnForward: false,
+				PreDNAT:        false,
+				ApplyOnForward: true,
 				Types:          []string{"ingress"},
 			},
 		},
@@ -169,26 +208,25 @@ var policyTable = []struct {
 				Ingress:        []apiv3.Rule{V3InRule2},
 				Egress:         []apiv3.Rule{},
 				DoNotTrack:     true,
-				PreDNAT:        true,
-				ApplyOnForward: true, // notice this gets converted to true, because DoNotTrack and PreDNAT are true.
+				PreDNAT:        false,
+				ApplyOnForward: true, // notice this gets converted to true, because DoNotTrack are true.
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
 	},
 	{
-		description: "policy with ApplyOnForward set to it's zero value (missing), and PreDNAT and DoNotTrack both " +
+		description: "policy with PreDNAT and DoNotTrack both " +
 			"set to false should NOT convert ApplyOnForward to true in v3 API",
 		v1API: &apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "meow",
 			},
 			Spec: apiv1.PolicySpec{
-				Order:          &order1,
-				IngressRules:   []apiv1.Rule{V1InRule2},
-				DoNotTrack:     false,
-				PreDNAT:        false,
-				ApplyOnForward: true,
-				Types:          []apiv1.PolicyType{apiv1.PolicyTypeIngress},
+				Order:        &order1,
+				IngressRules: []apiv1.Rule{V1InRule2},
+				DoNotTrack:   false,
+				PreDNAT:      false,
+				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
 		v1KVP: &model.KVPair{
@@ -201,7 +239,7 @@ var policyTable = []struct {
 				OutboundRules:  []model.Rule{},
 				DoNotTrack:     false,
 				PreDNAT:        false,
-				ApplyOnForward: true,
+				ApplyOnForward: false,
 				Types:          []string{"ingress"},
 			},
 		},
@@ -215,7 +253,7 @@ var policyTable = []struct {
 				Egress:         []apiv3.Rule{},
 				DoNotTrack:     false,
 				PreDNAT:        false,
-				ApplyOnForward: true, // notice this gets converted to true, because DoNotTrack and PreDNAT are true.
+				ApplyOnForward: false,
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
@@ -229,13 +267,12 @@ var policyTable = []struct {
 			Spec: apiv1.PolicySpec{
 				Order: &order1,
 				// Source Nets selector in V1InRule1 and V1EgressRule1 are non-strictly masked CIDRs.
-				IngressRules:   []apiv1.Rule{V1InRule1},
-				EgressRules:    []apiv1.Rule{V1EgressRule1},
-				Selector:       "thing == 'value'",
-				DoNotTrack:     true,
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				Types:          []apiv1.PolicyType{apiv1.PolicyTypeIngress, apiv1.PolicyTypeEgress},
+				IngressRules: []apiv1.Rule{V1InRule1},
+				EgressRules:  []apiv1.Rule{V1EgressRule1},
+				Selector:     "thing == 'value'",
+				DoNotTrack:   true,
+				PreDNAT:      true,
+				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress, apiv1.PolicyTypeEgress},
 			},
 		},
 		v1KVP: &model.KVPair{

--- a/lib/validator/v1/validator.go
+++ b/lib/validator/v1/validator.go
@@ -588,11 +588,6 @@ func validatePolicySpec(v *validator.Validate, structLevel *validator.StructLeve
 		}
 	}
 
-	if !m.ApplyOnForward && (m.DoNotTrack || m.PreDNAT) {
-		structLevel.ReportError(reflect.ValueOf(m.ApplyOnForward),
-			"PolicySpec.ApplyOnForward", "", reason("ApplyOnForward must be true if either PreDNAT or DoNotTrack is true, for a given PolicySpec"))
-	}
-
 	// Check (and disallow) any repeats in Types field.
 	mp := map[api.PolicyType]bool{}
 	for _, t := range m.Types {

--- a/lib/validator/v1/validator_test.go
+++ b/lib/validator/v1/validator_test.go
@@ -974,71 +974,28 @@ func init() {
 		Entry("should reject node with IPv4 address in IPv6 field", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: &netv4_1}}, false),
 		Entry("should reject Policy with both PreDNAT and DoNotTrack",
 			api.PolicySpec{
-				PreDNAT:        true,
-				DoNotTrack:     true,
-				ApplyOnForward: true,
+				PreDNAT:    true,
+				DoNotTrack: true,
 			}, false),
 		Entry("should accept Policy with PreDNAT but not DoNotTrack",
 			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
+				PreDNAT: true,
 			}, true),
 		Entry("should accept Policy with DoNotTrack but not PreDNAT",
 			api.PolicySpec{
-				PreDNAT:        false,
-				DoNotTrack:     true,
-				ApplyOnForward: true,
+				PreDNAT:    false,
+				DoNotTrack: true,
 			}, true),
 		Entry("should reject pre-DNAT Policy with egress rules",
 			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				EgressRules:    []api.Rule{{Action: "allow"}},
+				PreDNAT:     true,
+				EgressRules: []api.Rule{{Action: "allow"}},
 			}, false),
 		Entry("should accept pre-DNAT Policy with ingress rules",
 			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				IngressRules:   []api.Rule{{Action: "allow"}},
+				PreDNAT:      true,
+				IngressRules: []api.Rule{{Action: "allow"}},
 			}, true),
-
-		// PolicySpec ApplyOnForward field checks.
-		Entry("should accept Policy with ApplyOnForward but not PreDNAT",
-			api.PolicySpec{
-				PreDNAT:        false,
-				ApplyOnForward: true,
-			}, true),
-		Entry("should accept Policy with ApplyOnForward but not DoNotTrack",
-			api.PolicySpec{
-				DoNotTrack:     false,
-				ApplyOnForward: true,
-			}, true),
-		Entry("should accept Policy with ApplyOnForward and PreDNAT",
-			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
-			}, true),
-		Entry("should accept Policy with ApplyOnForward and DoNotTrack",
-			api.PolicySpec{
-				DoNotTrack:     true,
-				ApplyOnForward: true,
-			}, true),
-		Entry("should accept Policy with no ApplyOnForward DoNotTrack PreDNAT",
-			api.PolicySpec{
-				PreDNAT:        false,
-				DoNotTrack:     false,
-				ApplyOnForward: false,
-			}, true),
-		Entry("should reject Policy with PreDNAT but not ApplyOnForward",
-			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: false,
-			}, false),
-		Entry("should reject Policy with DoNotTrack but not ApplyOnForward",
-			api.PolicySpec{
-				DoNotTrack:     true,
-				ApplyOnForward: false,
-			}, false),
 
 		// PolicySpec Types field checks.
 		Entry("allow missing Types", api.PolicySpec{}, true),
@@ -1086,21 +1043,18 @@ func init() {
 			}, true),
 		Entry("allow ingress Types with pre-DNAT",
 			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				Types:          []api.PolicyType{api.PolicyTypeIngress},
+				PreDNAT: true,
+				Types:   []api.PolicyType{api.PolicyTypeIngress},
 			}, true),
 		Entry("disallow egress Types with pre-DNAT",
 			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				Types:          []api.PolicyType{api.PolicyTypeEgress},
+				PreDNAT: true,
+				Types:   []api.PolicyType{api.PolicyTypeEgress},
 			}, false),
 		Entry("disallow ingress+egress Types with pre-DNAT",
 			api.PolicySpec{
-				PreDNAT:        true,
-				ApplyOnForward: true,
-				Types:          []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
+				PreDNAT: true,
+				Types:   []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress},
 			}, false),
 	)
 }


### PR DESCRIPTION
## Description
ApplyOnForward is a feature for v3. Remove it from v1 API to allow migration.
Update conversionv1v3 for policy.