### PR TITLE
Normalize source Net, Nets, NotNet, NotNets

### DIFF
--- a/lib/converter/rule.go
+++ b/lib/converter/rule.go
@@ -84,8 +84,8 @@ func ruleAPIToBackend(ar api.Rule) model.Rule {
 		NotICMPType: notICMPType,
 
 		SrcTag:      ar.Source.Tag,
-		SrcNet:      ar.Source.Net,
-		SrcNets:     ar.Source.Nets,
+		SrcNet:      normalizeIPNet(ar.Source.Net),
+		SrcNets:     normalizeIPNets(ar.Source.Nets),
 		SrcSelector: ar.Source.Selector,
 		SrcPorts:    ar.Source.Ports,
 		DstTag:      ar.Destination.Tag,
@@ -95,8 +95,8 @@ func ruleAPIToBackend(ar api.Rule) model.Rule {
 		DstPorts:    ar.Destination.Ports,
 
 		NotSrcTag:      ar.Source.NotTag,
-		NotSrcNet:      ar.Source.NotNet,
-		NotSrcNets:     ar.Source.NotNets,
+		NotSrcNet:      normalizeIPNet(ar.Source.NotNet),
+		NotSrcNets:     normalizeIPNets(ar.Source.NotNets),
 		NotSrcSelector: ar.Source.NotSelector,
 		NotSrcPorts:    ar.Source.NotPorts,
 		NotDstTag:      ar.Destination.NotTag,
@@ -143,6 +143,20 @@ func ruleBackendToAPI(br model.Rule) api.Rule {
 			Type: br.NotICMPType,
 		}
 	}
+
+	// Normalize the backend source Net/Nets/NotNet/NotNets
+	// This is because of a bug where we didn't normalize
+	// source (Not)Net(s) while converting API to backend in v1.
+	br.SrcNet = normalizeIPNet(br.SrcNet)
+	br.SrcNets = normalizeIPNets(br.SrcNets)
+	br.NotSrcNet = normalizeIPNet(br.NotSrcNet)
+	br.NotSrcNets = normalizeIPNets(br.NotSrcNets)
+	// Also normalize destination (Not)Net(s) for consistency.
+	br.DstNet = normalizeIPNet(br.DstNet)
+	br.DstNets = normalizeIPNets(br.DstNets)
+	br.NotDstNet = normalizeIPNet(br.NotDstNet)
+	br.NotDstNets = normalizeIPNets(br.NotDstNets)
+
 	return api.Rule{
 		Action:      ruleActionBackendToAPI(br.Action),
 		IPVersion:   br.IPVersion,

--- a/lib/converter/rule_test.go
+++ b/lib/converter/rule_test.go
@@ -26,14 +26,14 @@ import (
 )
 
 var (
-	cidr1     = net.MustParseCIDR("10.0.0.1/24")
-	cidr2     = net.MustParseCIDR("11.0.0.1/24")
-	cidr3     = net.MustParseCIDR("12.0.0.1/24")
-	cidr4     = net.MustParseCIDR("13.0.0.1/24")
-	cidr3Net  = net.MustParseCIDR("12.0.0.0/24")
-	cidr4Net  = net.MustParseCIDR("13.0.0.0/24")
-	cidr3Norm = (&cidr3Net).Network()
-	cidr4Norm = (&cidr4Net).Network()
+	cidr1    = net.MustParseCIDR("10.0.0.1/24")
+	cidr2    = net.MustParseCIDR("11.0.0.1/24")
+	cidr3    = net.MustParseCIDR("12.0.0.1/24")
+	cidr4    = net.MustParseCIDR("13.0.0.1/24")
+	cidr1Net = net.MustParseNetwork("10.0.0.0/24")
+	cidr2Net = net.MustParseNetwork("11.0.0.0/24")
+	cidr3Net = net.MustParseNetwork("12.0.0.0/24")
+	cidr4Net = net.MustParseNetwork("13.0.0.0/24")
 )
 
 var _ = DescribeTable("RulesAPIToBackend",
@@ -42,7 +42,7 @@ var _ = DescribeTable("RulesAPIToBackend",
 		Expect(output).To(ConsistOf(expected))
 	},
 	Entry("empty rule", api.Rule{}, model.Rule{}),
-	Entry("should normalise destination net fields",
+	Entry("should normalize source and destination net fields",
 		api.Rule{
 			Source: api.EntityRule{
 				Net:    &cidr1,
@@ -54,13 +54,13 @@ var _ = DescribeTable("RulesAPIToBackend",
 			},
 		},
 		model.Rule{
-			SrcNet:    &cidr1,
-			NotSrcNet: &cidr2,
-			DstNet:    cidr3Norm,
-			NotDstNet: cidr4Norm,
+			SrcNet:    &cidr1Net,
+			NotSrcNet: &cidr2Net,
+			DstNet:    &cidr3Net,
+			NotDstNet: &cidr4Net,
 		},
 	),
-	Entry("should normalise destination nets fields",
+	Entry("should normalize source and destination nets fields",
 		api.Rule{
 			Source: api.EntityRule{
 				Nets:    []*net.IPNet{&cidr1},
@@ -72,10 +72,10 @@ var _ = DescribeTable("RulesAPIToBackend",
 			},
 		},
 		model.Rule{
-			SrcNets:    []*net.IPNet{&cidr1},
-			NotSrcNets: []*net.IPNet{&cidr2},
-			DstNets:    []*net.IPNet{cidr3Norm},
-			NotDstNets: []*net.IPNet{cidr4Norm},
+			SrcNets:    []*net.IPNet{&cidr1Net},
+			NotSrcNets: []*net.IPNet{&cidr2Net},
+			DstNets:    []*net.IPNet{&cidr3Net},
+			NotDstNets: []*net.IPNet{&cidr4Net},
 		},
 	),
 )
@@ -96,12 +96,12 @@ var _ = DescribeTable("RulesBackendToAPI",
 		api.Rule{
 			Action: "allow",
 			Source: api.EntityRule{
-				Nets:    []*net.IPNet{&cidr1},
-				NotNets: []*net.IPNet{&cidr2},
+				Nets:    []*net.IPNet{&cidr1Net},
+				NotNets: []*net.IPNet{&cidr2Net},
 			},
 			Destination: api.EntityRule{
-				Nets:    []*net.IPNet{&cidr3},
-				NotNets: []*net.IPNet{&cidr4},
+				Nets:    []*net.IPNet{&cidr3Net},
+				NotNets: []*net.IPNet{&cidr4Net},
 			},
 		},
 	),
@@ -115,12 +115,12 @@ var _ = DescribeTable("RulesBackendToAPI",
 		api.Rule{
 			Action: "allow",
 			Source: api.EntityRule{
-				Nets:    []*net.IPNet{&cidr1},
-				NotNets: []*net.IPNet{&cidr2},
+				Nets:    []*net.IPNet{&cidr1Net},
+				NotNets: []*net.IPNet{&cidr2Net},
 			},
 			Destination: api.EntityRule{
-				Nets:    []*net.IPNet{&cidr3},
-				NotNets: []*net.IPNet{&cidr4},
+				Nets:    []*net.IPNet{&cidr3Net},
+				NotNets: []*net.IPNet{&cidr4Net},
 			},
 		},
 	),

--- a/lib/upgrade/etcd/conversionv1v3/rule.go
+++ b/lib/upgrade/etcd/conversionv1v3/rule.go
@@ -77,8 +77,8 @@ func ruleAPIToBackend(ar apiv1.Rule) model.Rule {
 		NotICMPType: notICMPType,
 
 		SrcTag:      ar.Source.Tag,
-		SrcNet:      ar.Source.Net,
-		SrcNets:     ar.Source.Nets,
+		SrcNet:      normalizeIPNet(ar.Source.Net),
+		SrcNets:     normalizeIPNets(ar.Source.Nets),
 		SrcSelector: ar.Source.Selector,
 		SrcPorts:    ar.Source.Ports,
 		DstTag:      ar.Destination.Tag,
@@ -88,8 +88,8 @@ func ruleAPIToBackend(ar apiv1.Rule) model.Rule {
 		DstPorts:    ar.Destination.Ports,
 
 		NotSrcTag:      ar.Source.NotTag,
-		NotSrcNet:      ar.Source.NotNet,
-		NotSrcNets:     ar.Source.NotNets,
+		NotSrcNet:      normalizeIPNet(ar.Source.NotNet),
+		NotSrcNets:     normalizeIPNets(ar.Source.NotNets),
 		NotSrcSelector: ar.Source.NotSelector,
 		NotSrcPorts:    ar.Source.NotPorts,
 		NotDstTag:      ar.Destination.NotTag,
@@ -136,6 +136,19 @@ func rulebackendToAPIv3(br model.Rule) apiv3.Rule {
 			Type: br.NotICMPType,
 		}
 	}
+
+	// Normalize the backend source Net/Nets/NotNet/NotNets
+	// This is because of a bug where we didn't normalize
+	// source (not)net(s) while converting API to backend in v1.
+	br.SrcNet = normalizeIPNet(br.SrcNet)
+	br.SrcNets = normalizeIPNets(br.SrcNets)
+	br.NotSrcNet = normalizeIPNet(br.NotSrcNet)
+	br.NotSrcNets = normalizeIPNets(br.NotSrcNets)
+	// Also normalize destination (Not)Net(s) for consistency.
+	br.DstNet = normalizeIPNet(br.DstNet)
+	br.DstNets = normalizeIPNets(br.DstNets)
+	br.NotDstNet = normalizeIPNet(br.NotDstNet)
+	br.NotDstNets = normalizeIPNets(br.NotDstNets)
 
 	srcNets := br.AllSrcNets()
 	var srcNetsStr []string

--- a/lib/upgrade/etcd/conversionv1v3/rules_def.go
+++ b/lib/upgrade/etcd/conversionv1v3/rules_def.go
@@ -33,15 +33,25 @@ var numProtocol1 = numorstring.ProtocolFromInt(240)
 var icmpType1 = 100
 var icmpCode1 = 200
 
-var cidr1StrictMaskStr = "10.0.0.0/24"
+var cidr1StrictMaskStr = "192.168.0.128/25"
 var cidr2StrictMaskStr = "20.0.0.0/24"
-var cidr1Str = "10.0.0.1/24"
+var cidr3StrictMaskStr = "30.0.0.0/24"
+var cidr4StrictMaskStr = "40.0.0.0/24"
+var cidr1Str = "192.168.0.129/25"
 var cidr2Str = "20.0.0.2/24"
+var cidr3Str = "30.0.0.3/24"
+var cidr4Str = "40.0.0.4/24"
 var cidrv61Str = "abcd:5555::/120"
 var cidrv62Str = "abcd:2345::/120"
 
-var cidr1 = net.MustParseNetwork(cidr1Str)
-var cidr2 = net.MustParseNetwork(cidr2Str)
+var cidr1 = net.MustParseCIDR(cidr1Str)
+var cidr1Net = net.MustParseNetwork(cidr1Str)
+var cidr2 = net.MustParseCIDR(cidr2Str)
+var cidr2Net = net.MustParseNetwork(cidr2Str)
+var cidr3 = net.MustParseCIDR(cidr3Str)
+var cidr3Net = net.MustParseNetwork(cidr3Str)
+var cidr4 = net.MustParseCIDR(cidr4Str)
+var cidr4Net = net.MustParseNetwork(cidr4Str)
 var cidrv61 = net.MustParseNetwork(cidrv61Str)
 var cidrv62 = net.MustParseNetwork(cidrv62Str)
 
@@ -63,7 +73,17 @@ var V1InRule1 = apiv1.Rule{
 	Source: apiv1.EntityRule{
 		Tag:      "tag1",
 		Net:      &cidr1,
+		Nets:     []*net.IPNet{&cidr3, &cidr4},
+		NotNet:   &cidr2,
+		NotNets:  []*net.IPNet{&cidr1, &cidr3},
 		Selector: "label1 == 'value1' || bake == 'cake'",
+	},
+	Destination: apiv1.EntityRule{
+		Tag:     "kingindanorth",
+		Net:     &cidr2,
+		Nets:    []*net.IPNet{&cidr1, &cidr3},
+		NotNet:  &cidr1,
+		NotNets: []*net.IPNet{&cidr3, &cidr4},
 	},
 }
 
@@ -74,7 +94,15 @@ var V1ModelInRule1 = model.Rule{
 	ICMPType:    &icmpType1,
 	ICMPCode:    &icmpCode1,
 	SrcTag:      "tag1",
-	SrcNet:      &cidr1,
+	SrcNet:      &cidr1Net,
+	SrcNets:     []*net.IPNet{&cidr3Net, &cidr4Net},
+	NotSrcNet:   &cidr2Net,
+	NotSrcNets:  []*net.IPNet{&cidr1Net, &cidr3Net},
+	DstTag:      "kingindanorth",
+	DstNet:      &cidr2Net,
+	DstNets:     []*net.IPNet{&cidr1Net, &cidr3Net},
+	NotDstNet:   &cidr1Net,
+	NotDstNets:  []*net.IPNet{&cidr3Net, &cidr4Net},
 	SrcSelector: "label1 == 'value1' || bake == 'cake'",
 }
 
@@ -84,8 +112,14 @@ var V3InRule1 = apiv3.Rule{
 	Protocol:  &v3strProtocol1,
 	ICMP:      &v3icmp1,
 	Source: apiv3.EntityRule{
-		Nets:     []string{cidr1StrictMaskStr},
+		Nets:     []string{cidr3StrictMaskStr, cidr4StrictMaskStr, cidr1StrictMaskStr},
+		NotNets:  []string{cidr1StrictMaskStr, cidr3StrictMaskStr, cidr2StrictMaskStr},
 		Selector: "(label1 == 'value1' || bake == 'cake') && tag1 == ''",
+	},
+	Destination: apiv3.EntityRule{
+		Nets:     []string{cidr1StrictMaskStr, cidr3StrictMaskStr, cidr2StrictMaskStr},
+		NotNets:  []string{cidr3StrictMaskStr, cidr4StrictMaskStr, cidr1StrictMaskStr},
+		Selector: "kingindanorth == ''",
 	},
 }
 
@@ -142,7 +176,7 @@ var V1ModelEgressRule1 = model.Rule{
 	ICMPType:    &icmpType1,
 	ICMPCode:    &icmpCode1,
 	SrcTag:      "tag3",
-	SrcNet:      &cidr2,
+	SrcNet:      &cidr2Net,
 	SrcSelector: "all()",
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Destination Net/Nets/NotNet/NotNets is normalized when stored in the backend. Source Net/Nets/NotNet/NotNets should also be normalized. This PR fixes that in both v1 and in for v1->v3 upgrade converters


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
