### PR TITLE
Allow mixed case containerIDs

### DIFF
--- a/lib/apis/v3/workloadendpoint.go
+++ b/lib/apis/v3/workloadendpoint.go
@@ -43,7 +43,7 @@ type WorkloadEndpointSpec struct {
 	// The node name identifying the Calico node instance.
 	Node string `json:"node,omitempty" validate:"omitempty,name"`
 	// The container ID.
-	ContainerID string `json:"containerID,omitempty" validate:"omitempty,name"`
+	ContainerID string `json:"containerID,omitempty" validate:"omitempty,containerID"`
 	// The Pod name.
 	Pod string `json:"pod,omitempty" validate:"omitempty,name"`
 	// The Endpoint name.

--- a/lib/names/workloadendpoint.go
+++ b/lib/names/workloadendpoint.go
@@ -36,9 +36,9 @@ import (
 // will be escaped to a double-dash (--) in the constructed name.
 //
 // List queries allow for prefix lists (for non-KDD), the client should verify that
-// then items returned in the list match the supplied identifiers using the
+// the items returned in the list match the supplied identifiers using the
 // NameMatches() method.  This is necessary because a prefix match may return endpoints
-// that do not exactly match the required identifiers.  For example , suppose you are
+// that do not exactly match the required identifiers.  For example, suppose you are
 // querying endpoints with node=node1, orch=k8s, pod=pod and endpoints is wild carded:
 // -  The name prefix would be `node1-k8s-pod-`
 // -  A list query using that prefix would also return endpoints with, for example,

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -51,6 +51,9 @@ var (
 	// more restrictive naming requirements.
 	nameRegex = regexp.MustCompile("^" + nameSubdomainFmt + "$")
 
+	containerIDFmt = "[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?"
+	containerIDRegex = regexp.MustCompile("^" + containerIDFmt + "$")
+
 	// NetworkPolicy names must either be a simple DNS1123 label format (nameLabelFmt), or
 	// must be the standard name format (nameRegex) prefixed with "knp.default".
 	networkPolicyNameRegex = regexp.MustCompile("^((" + nameLabelFmt + ")|(knp\\.default\\.(" + nameSubdomainFmt + ")))$")
@@ -131,6 +134,7 @@ func init() {
 	registerFieldValidator("interface", validateInterface)
 	registerFieldValidator("datastoreType", validateDatastoreType)
 	registerFieldValidator("name", validateName)
+	registerFieldValidator("containerID", validateContainerID)
 	registerFieldValidator("selector", validateSelector)
 	registerFieldValidator("labels", validateLabels)
 	registerFieldValidator("ipVersion", validateIPVersion)
@@ -226,6 +230,12 @@ func validateName(v *validator.Validate, topStruct reflect.Value, currentStructO
 	s := field.String()
 	log.Debugf("Validate name: %s", s)
 	return nameRegex.MatchString(s)
+}
+
+func validateContainerID(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
+	s := field.String()
+	log.Debugf("Validate containerID: %s", s)
+	return containerIDRegex.MatchString(s)
 }
 
 func validatePortName(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -473,6 +473,11 @@ func init() {
 					{InternalIP: ipv6_1, ExternalIP: ipv6_2},
 				},
 			}, true),
+		Entry("should accept workload endpoint with mixed-case ContainerID",
+			api.WorkloadEndpointSpec{
+				InterfaceName: "cali012371237",
+				ContainerID:   "Cath01234-G",
+			}, true),
 		Entry("should reject workload endpoint with no config", api.WorkloadEndpointSpec{}, false),
 		Entry("should reject workload endpoint with IPv4 networks that contain >1 address",
 			api.WorkloadEndpointSpec{
@@ -500,6 +505,21 @@ func init() {
 				InterfaceName: "cali012371237",
 				IPNetworks:    []string{netv6_1},
 				IPNATs:        []api.IPNAT{{InternalIP: ipv6_2, ExternalIP: ipv6_1}},
+			}, false),
+		Entry("should reject workload endpoint containerID that starts with a dash",
+			api.WorkloadEndpointSpec{
+				InterfaceName: "cali0134",
+				ContainerID:   "-abcdefg",
+			}, false),
+		Entry("should reject workload endpoint containerID that ends with a dash",
+			api.WorkloadEndpointSpec{
+				InterfaceName: "cali0134",
+				ContainerID:   "abcdeSg-",
+			}, false),
+		Entry("should reject workload endpoint containerID that contains a period",
+			api.WorkloadEndpointSpec{
+				InterfaceName: "cali0134",
+				ContainerID:   "abcde-j.g",
 			}, false),
 
 		// (API) HostEndpointSpec


### PR DESCRIPTION
## Description
In order to accommodate container orchestrators such as `rkt` which allow mixed-cased container names, loosen the containerID validation to do the same.

This addresses one part (`containerID`) of https://github.com/projectcalico/libcalico-go/issues/684.

## Todos
- [X] Tests
- [ ] Documentation - cc @emanic, this may entail some doc changes
- [ ] Release note - since we haven't released v3.0 yet, I think just docs are sufficient

## Release Note

```release-note
None required
```
