### PR TITLE
Version check added for migration

### DIFF
--- a/lib/migrate/migrate.go
+++ b/lib/migrate/migrate.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -655,6 +656,62 @@ func (m *migrationHelper) queryAndConvertV1ToV3Nodes(data *MigrationData) error 
 	return nil
 }
 
+// ShouldMigrate checks version information and reports if migration is needed
+// and is possible.
+func (m *migrationHelper) ShouldMigrate() (bool, error) {
+	_, err := m.clientv3.ClusterInformation().Get(context.Background(), "default", options.GetOptions{})
+	if err == nil {
+		// Nothing to do ClusterInformation exists so data has already been migrated
+		return false, nil
+	} else if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+		// The error indicates a problem with accessing the resource
+		return false, err
+	} else {
+		// Grab the version from the clientv1
+		v, err := m.getV1ClusterVersion()
+		if err != nil {
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+				return false, nil
+			} else {
+				return false, err
+			}
+		}
+
+		// Migrate only if it is possible to migrate from the current version
+		if !canMigrate(v) {
+			return false, errors.New(fmt.Sprintf("Migration to v3 requires a base of Calico v2.6.4+, currently at %s", v))
+		}
+		return true, nil
+	}
+}
+
+// getV1ClusterVersion reads the CalicoVersion from the v1 client interface.
+func (m *migrationHelper) getV1ClusterVersion() (string, error) {
+	if kv, err := m.clientv1.Get(model.GlobalConfigKey{Name: "CalicoVersion"}); err == nil {
+		return kv.Value.(string), nil
+	} else {
+		return "", err
+	}
+}
+
+// canMigrate returns true if the given version can be upgraded, otherwise
+// returns false.
+func canMigrate(v string) bool {
+	sv, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
+	// Using 2.6.3 for the comparison point because '2.6.4-rc1' is LessThan
+	// '2.6.4', and we want the -rc1 to be upgradeable.
+	sv263 := semver.New("2.6.3")
+	if err != nil {
+		log.Warnf("Error converting version %s: %v", v, err)
+		return false
+	} else if sv263.LessThan(*sv) {
+		return true
+	}
+	log.Warnf("Cannot migrate from version %s", v)
+	return false
+
+}
+
 // convertLogLevel converts the v1 log level to the equivalent v3 log level. We
 // ignore errors, defaulting to info in the event of a conversion error.
 func convertLogLevel(logLevel string) string {
@@ -677,6 +734,15 @@ func convertLogLevel(logLevel string) string {
 		return "Info"
 	}
 }
+
+// NilStatusWriter implments the StatusWriterInterface for use by non-cli
+// commands since the migration helper already logs the messages written
+// to the StatusWriter.
+type NilStatusWriter struct{}
+
+func (_ *NilStatusWriter) Msg(msg string)    {}
+func (_ *NilStatusWriter) Bullet(msg string) {}
+func (_ *NilStatusWriter) Error(msg string)  {}
 
 // Display a 79-char word wrapped status message and log.
 func (m *migrationHelper) status(format string, a ...interface{}) {

--- a/lib/migrate/migrate_test.go
+++ b/lib/migrate/migrate_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UT for checking the version for migration.", func() {
+
+	DescribeTable("Checking canMigrate.",
+		func(ver string, result bool) {
+			Expect(canMigrate(ver)).To(Equal(result))
+		},
+
+		Entry("Expect v2.6.4 to migrate", "v2.6.4", true),
+		Entry("Expect v2.6.4-rc1 to migrate", "v2.6.4-rc1", true),
+		Entry("Expect v2.6.4-15-g0986c6cd to migrate", "v2.6.4-15-g0986c6cd", true),
+		Entry("Expect v2.6.5 to migrate", "v2.6.5", true),
+		Entry("Expect v2.6.5-rc1 to migrate", "v2.6.5-rc1", true),
+		Entry("Expect v2.7.0 to migrate", "v2.7.0", true),
+		Entry("Expect v2.7.0-rc1 to migrate", "v2.7.0-rc1", true),
+		Entry("Expect v2.6.3 to not migrate", "v2.6.3", false),
+		Entry("Expect v2.6.3-rc1 to not migrate", "v2.6.3-rc1", false),
+		Entry("Expect v2.6.3-15-g0986c6cd to not migrate", "v2.6.3-15-g0986c6cd", false),
+		Entry("Expect v2.6.x-deadbeef to not migrate", "v2.6.x-deadbeef", false),
+		Entry("Expect master to not migrate", "master", false),
+		Entry("Expect empty string to not migrate", "", false),
+		Entry("Expect garbage to not migrate", "garbage", false),
+		Entry("Expect 1.2.3.4.5 to not migrate", "1.2.3.4.5", false),
+	)
+})


### PR DESCRIPTION
## Description
This adds a function to check the version in the datastore to see if it looks like a migration is still needed or has been done already.

## Todos
- [ ] Maybe make the version check configurable

## Release Note

```release-note
None required
```
