### PR TITLE
Require HostEndpointSpecs specify a Node name

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -534,6 +534,11 @@ func validateHostEndpointSpec(v *validator.Validate, structLevel *validator.Stru
 		structLevel.ReportError(reflect.ValueOf(h.InterfaceName),
 			"InterfaceName", "", reason("no interface or expected IPs have been specified"))
 	}
+	// A host endpoint must have a nodename specified.
+	if h.Node == "" {
+		structLevel.ReportError(reflect.ValueOf(h.Node),
+			"InterfaceName", "", reason("no node has been specified"))
+	}
 }
 
 func validateIPPoolSpec(v *validator.Validate, structLevel *validator.StructLevel) {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -196,6 +196,7 @@ func init() {
 						Port:     1234,
 					},
 				},
+				Node: "node01",
 			},
 			true,
 		),
@@ -204,6 +205,20 @@ func init() {
 				InterfaceName: "eth0",
 				Ports: []api.EndpointPort{
 					{
+						Protocol: protoTCP,
+						Port:     1234,
+					},
+				},
+				Node: "node01",
+			},
+			false,
+		),
+		Entry("should reject HostEndpointSpec with a missing node",
+			api.HostEndpointSpec{
+				InterfaceName: "eth0",
+				Ports: []api.EndpointPort{
+					{
+						Name:     "a-valid-port",
 						Protocol: protoTCP,
 						Port:     1234,
 					},
@@ -226,6 +241,7 @@ func init() {
 						Port:     5456,
 					},
 				},
+				Node: "node01",
 			},
 			true,
 		),
@@ -501,39 +517,46 @@ func init() {
 			}, false),
 
 		// (API) HostEndpointSpec
-		Entry("should accept host endpoint with interface",
+		Entry("should accept host endpoint with interface and node",
 			api.HostEndpointSpec{
 				InterfaceName: "eth0",
+				Node:          "node01",
 			}, true),
 		Entry("should accept host endpoint with expected IPs",
 			api.HostEndpointSpec{
 				ExpectedIPs: []string{ipv4_1, ipv6_1},
+				Node:        "node01",
 			}, true),
 		Entry("should accept host endpoint with interface and expected IPs",
 			api.HostEndpointSpec{
 				InterfaceName: "eth0",
 				ExpectedIPs:   []string{ipv4_1, ipv6_1},
+				Node:          "node01",
 			}, true),
 		Entry("should reject host endpoint with no config", api.HostEndpointSpec{}, false),
 		Entry("should reject host endpoint with blank interface an no IPs",
 			api.HostEndpointSpec{
 				InterfaceName: "",
 				ExpectedIPs:   []string{},
+				Node:          "node01",
 			}, false),
 		Entry("should accept host endpoint with prefixed profile name",
 			api.HostEndpointSpec{
 				InterfaceName: "eth0",
 				Profiles:      []string{"knp.default.fun", "knp.default.funner.11234-a"},
+				Node:          "node01",
 			}, true),
 		Entry("should accept host endpoint without prefixed profile name",
 			api.HostEndpointSpec{
 				InterfaceName: "eth0",
 				Profiles:      []string{"fun-funner1234"},
+				Node:          "node01",
 			}, true),
 		Entry("should reject host endpoint with no prefix and dots at the start of the name",
 			api.HostEndpointSpec{
 				InterfaceName: "eth0",
 				Profiles:      []string{".fun"},
+				Node:          "node01",
 			}, false),
 
 		// (API) IPPool


### PR DESCRIPTION
## Description
Require HostEndpointSpecs specify a Node name. This PR addresses issue: https://github.com/projectcalico/libcalico-go/issues/690.

Since this change only affects unreleased v3.0, no release notes required. All libcalico-go tests pass, and also ran calicoctl STs against this change (no failures).

## Todos
- [X] Tests

## Release Note

```release-note
None required
```
