### PR TITLE
Changing output format of felix config

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
@@ -236,9 +236,9 @@ func (c *configUpdateProcessor) processAddOrModified(kvp *model.KVPair) ([]*mode
 					case "milliseconds":
 						ms := vt.Duration / time.Millisecond
 						nMs := vt.Duration % time.Millisecond
-						value = fmt.Sprintf("%.3f", float64(ms)+float64(nMs)/1e6)
+						value = fmt.Sprintf("%v", float64(ms)+float64(nMs)/1e6)
 					default:
-						value = fmt.Sprintf("%.3f", vt.Seconds())
+						value = fmt.Sprintf("%v", vt.Seconds())
 					}
 				default:
 					value = fmt.Sprintf("%v", vt)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -187,10 +187,14 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		res := apiv3.NewFelixConfiguration()
 		duration1 := metav1.Duration{Duration: time.Duration(12.345 * float64(time.Second))}
 		duration2 := metav1.Duration{Duration: time.Duration(54.321 * float64(time.Millisecond))}
+		duration3 := metav1.Duration{Duration: time.Duration(0)}
+		duration4 := metav1.Duration{Duration: time.Duration(0.1 * float64(time.Second))}
 		bool1 := false
 		uint1 := uint32(1313)
 		res.Spec.RouteRefreshInterval = &duration1
 		res.Spec.IptablesLockProbeInterval = &duration2
+		res.Spec.EndpointReportingDelay = &duration3
+		res.Spec.IpsetsRefreshInterval = &duration4
 		res.Spec.InterfacePrefix = "califoobar"
 		res.Spec.IPIPEnabled = &bool1
 		res.Spec.IptablesMarkMask = &uint1
@@ -212,6 +216,8 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		expected := map[string]interface{}{
 			"RouteRefreshInterval":            "12.345",
 			"IptablesLockProbeIntervalMillis": "54.321",
+			"EndpointReportingDelaySecs":      "0",
+			"IpsetsRefreshInterval":           "0.1",
 			"InterfacePrefix":                 "califoobar",
 			"IpInIpEnabled":                   "false",
 			"IptablesMarkMask":                "1313",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes projectcalico/felix#1656
Changing the way the configurationprocessor converts the `time.Duration`s to Strings to be more compliant with how Felix expects them to come through. With this change we get:

`0`    -> `"0"`
`0.0` -> `"0"`
`0.1` -> `"0.1"`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
