### PR TITLE
Fix crash on named port

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -202,7 +202,9 @@ func (c Converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.K
 	for _, r := range np.Spec.Ingress {
 		rules, err := c.k8sRuleToCalico(r.From, r.Ports, np.ObjectMeta.Namespace, true)
 		if err != nil {
-			return nil, err
+			// If we fail to parse this rule, skip it.
+			log.WithError(err).Warnf("Failed to parse rule")
+			continue
 		}
 		inboundRules = append(inboundRules, rules...)
 	}
@@ -212,7 +214,9 @@ func (c Converter) NetworkPolicyToPolicy(np *extensions.NetworkPolicy) (*model.K
 	for _, r := range np.Spec.Egress {
 		rules, err := c.k8sRuleToCalico(r.To, r.Ports, np.ObjectMeta.Namespace, false)
 		if err != nil {
-			return nil, err
+			// If we fail to parse this rule, skip it.
+			log.WithError(err).Warnf("Failed to parse rule")
+			continue
 		}
 		outboundRules = append(outboundRules, rules...)
 	}

--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -445,7 +445,9 @@ func (c Converter) k8sPortToCalico(port extensions.NetworkPolicyPort) []numorstr
 	if port.Port != nil {
 		p, err := numorstring.PortFromString(port.Port.String())
 		if err != nil {
-			log.Panic("Invalid port %+v: %s", port.Port, err)
+			// If we get an invalid port, ignore it.
+			log.Errorf("Invalid port %+v: %s", port.Port, err)
+			return portList
 		}
 		return append(portList, p)
 	}

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -475,7 +475,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		})
 	})
 
-	It("should not parse a NetworkPolicy with named ports", func() {
+	It("should not parse a NetworkPolicy rule with named ports", func() {
 		namedPort := intstr.FromString("namedport")
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -512,8 +512,8 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 
 		// Parse the policy.
 		pol, err := c.NetworkPolicyToPolicy(&np)
-		Expect(err).To(HaveOccurred())
-		Expect(pol).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(pol.Value.(*model.Policy).InboundRules)).To(Equal(0))
 	})
 
 	It("should parse a NetworkPolicy with empty podSelector", func() {

--- a/lib/backend/k8s/conversion_test.go
+++ b/lib/backend/k8s/conversion_test.go
@@ -73,6 +73,23 @@ var _ = Describe("Test parsing strings", func() {
 	})
 })
 
+var _ = Describe("Test parsing ports", func() {
+
+	// Use a single instance of the Converter for these tests.
+	c := Converter{}
+
+	It("should not parse named ports", func() {
+		portval := intstr.FromString("webport")
+		port := extensions.NetworkPolicyPort{}
+		protoTCP := extensions.ProtocolTCP
+		port.Port = &portval
+		port.Protocol = &protoTCP
+
+		ret := c.k8sPortToCalico(port)
+		Expect(len(ret)).To(Equal(0))
+	})
+})
+
 var _ = Describe("Test Pod conversion", func() {
 
 	// Use a single instance of the Converter for these tests.

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -664,7 +664,8 @@ func (c *KubeClient) listPolicies(l model.PolicyListOptions) ([]*model.KVPair, e
 	for _, p := range networkPolicies.Items {
 		kvp, err := c.converter.NetworkPolicyToPolicy(&p)
 		if err != nil {
-			return nil, err
+			log.WithError(err).Warnf("Failed to list policy")
+			continue
 		}
 		ret = append(ret, kvp)
 	}

--- a/lib/backend/k8s/k8s_fv_test.go
+++ b/lib/backend/k8s/k8s_fv_test.go
@@ -589,14 +589,13 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		_, err := c.List(model.PolicyListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Perform a Get - it shouldn't show up in the Calico API.
+		// Perform a Get - it shouldn't have any rules.
 		k := model.PolicyKey{Name: fmt.Sprintf("knp.default.default.%s", np.ObjectMeta.Name)}
-		_, err = c.Get(k)
-		Expect(err).To(HaveOccurred())
+		kvp, err := c.Get(k)
+		Expect(len(kvp.Value.(*model.Policy).InboundRules)).To(Equal(0))
 
 		// The NP should not show up in the Syncer.
-		Consistently(cb.GetSyncerValueFunc(k)).Should(BeNil())
-
+		Eventually(cb.GetSyncerValueFunc(k)).Should(Equal(kvp.Value))
 	})
 
 	// Add a defer to wait for policies to clean up.

--- a/lib/backend/k8s/syncer.go
+++ b/lib/backend/k8s/syncer.go
@@ -682,6 +682,8 @@ func (syn *kubeSyncer) performSnapshot(versions *resourceVersions) (map[string][
 				if err == nil {
 					snap[KEY_NP] = append(snap[KEY_NP], *pol)
 					keys[KEY_NP][pol.Key.String()] = true
+				} else {
+					log.WithError(err).Warnf("Failed to parse policy")
 				}
 			}
 		}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

xref: https://github.com/projectcalico/felix/issues/1685

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed bug where Felix would crash when parsing a NetworkPolicy with a named port
```
