### PR TITLE
cherry-pick: add keep alive support on etcdv3 connections

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ee2ca161587aa178e381cfb3b0f304b2c6dd68e5bfead27a347a9f203c33af39
-updated: 2017-11-16T16:07:52.422843395-08:00
+hash: 0ca7abb9153b6d5e0b0adde07829a5abd6da0a3199b449f0a3c003ebdcb71a94
+updated: 2018-02-02T14:53:03.348248361-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -18,7 +18,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
-  version: bb66589f8cf18960c7f3d56b1b83753caeed9c7a
+  version: c23606781f63d09917a1e7abfcefeb337a9608ea
   subpackages:
   - auth/authpb
   - client
@@ -61,7 +61,9 @@ imports:
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
+  - gogoproto
   - proto
+  - protoc-gen-gogo/descriptor
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
@@ -176,13 +178,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -190,13 +192,13 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  version: bdcc60b419d136a85cdf2e7cbcac34b3f1cd6e57
   subpackages:
   - codec
 - name: golang.org/x/crypto
@@ -265,18 +267,29 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/grpc
-  version: 8050b9cbc271307e5a716a9d782803d09b0d6f2d
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
   subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e
+  subpackages:
+  - balancer
   - codes
+  - connectivity
   - credentials
+  - grpclb/grpc_lb_v1/messages
   - grpclog
+  - health
+  - health/grpc_health_v1
   - internal
   - keepalive
   - metadata
   - naming
   - peer
+  - resolver
   - stats
+  - status
   - tap
   - transport
 - name: gopkg.in/go-playground/validator.v8
@@ -290,7 +303,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
+  version: 389dfa299845bcf399c16af89987e8775718ea48
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -317,7 +330,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: 4972c8e335e32ab65ba45bde0a99c6544c8a8e4c
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -415,7 +428,7 @@ imports:
   - util/integer
   - util/jsonpath
 - name: k8s.io/code-generator
-  version: 6db2ee6aa9ab51230d6e0d970b398274a88e81b0
+  version: 306be794f1b124a9c939ab168e9ea3944387e66b
 - name: k8s.io/gengo
   version: 70ad626ed2d7a483d89d2c4c56364d60b48ee8fc
 - name: k8s.io/kube-openapi

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/projectcalico/libcalico-go
 import:
 - package: github.com/coreos/etcd
-  version: 3.2.7
+  version: ^3.3.0
   subpackages:
   - client
   - clientv3
@@ -30,9 +30,9 @@ import:
   subpackages:
   - patricia
 - package: k8s.io/apimachinery
-  version: release-1.8 
+  version: release-1.8
 - package: k8s.io/api
-  version: release-1.8 
+  version: release-1.8
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: k8s.io/code-generator

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -33,7 +33,9 @@ import (
 )
 
 var (
-	clientTimeout = 30 * time.Second
+	clientTimeout    = 10 * time.Second
+	keepaliveTime    = 30 * time.Second
+	keepaliveTimeout = 10 * time.Second
 )
 
 type etcdV3Client struct {
@@ -60,10 +62,13 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 	}
 	tls, _ := tlsInfo.ClientConfig()
 
+	// Build the etcdv3 config.
 	cfg := clientv3.Config{
-		Endpoints:   etcdLocation,
-		TLS:         tls,
-		DialTimeout: clientTimeout,
+		Endpoints:            etcdLocation,
+		TLS:                  tls,
+		DialTimeout:          clientTimeout,
+		DialKeepAliveTime:    keepaliveTime,
+		DialKeepAliveTimeout: keepaliveTimeout,
 	}
 
 	// Plumb through the username and password if both are configured.

--- a/lib/backend/etcdv3/watcher.go
+++ b/lib/backend/etcdv3/watcher.go
@@ -16,6 +16,7 @@ package etcdv3
 
 import (
 	"context"
+	goerrors "errors"
 	"strconv"
 	"sync/atomic"
 
@@ -130,7 +131,11 @@ func (wc *watcher) watchLoop() {
 			}
 		}
 	}
-	log.Debug("End of watcher.watchLoop")
+
+	// If we exit the loop, it means the watcher has closed for some reason.
+	// Bubble this up as a watch termination error.
+	log.Warn("etcdv3 watch channel closed")
+	wc.sendError(goerrors.New("etcdv3 watch channel closed"), true)
 }
 
 // listCurrent retrieves the existing entries and sends an event for each listed


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Cherry-pick of #777 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes bug where Calico would silently lost its connection to etcd and never recover when the etcd server was terminated.
```
