### PR TITLE
Adding ability to define a floating ip for a kubernetes workload via annotation

### DIFF
--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -299,6 +299,38 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(ConsistOf("192.168.0.1/32"))
 	})
 
+	It("should look in the calico annotation for a floating IP", func() {
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "podA",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"arbitrary":                         "annotation",
+					"cni.projectcalico.org/podIP":       "192.168.0.1",
+					"cni.projectcalico.org/floatingIPs": "[\"1.1.1.1\"]",
+				},
+				Labels: map[string]string{
+					"labelA": "valueA",
+					"labelB": "valueB",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+		}
+
+		wep, err := c.PodToWorkloadEndpoint(&pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.HasIPAddress(&pod)).To(BeTrue())
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(ConsistOf("192.168.0.1/32"))
+
+		// Assert that the endpoint contains the appropriate DNAT
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNATs).To(ConsistOf(apiv3.IPNAT{InternalIP: "192.168.0.1", ExternalIP: "1.1.1.1"}))
+
+	})
+
 	It("should return an error for a bad pod IP", func() {
 		pod := kapiv1.Pod{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
KDD implementation of https://github.com/projectcalico/cni-plugin/pull/419

Description

This PR adds the ability to define DNAT/floating IP for a kubernetes workload via annotation. Most of the plumbing was already in place, this adds the missing link.

Release Note

```
You can now define a floating IP ( DNAT ) via container annotation `cni.projectcalico.org/floatingIPs`
```