### PR TITLE
OpenStack derived object migration filters

### DIFF
--- a/lib/apis/v3/constants.go
+++ b/lib/apis/v3/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,4 +44,5 @@ const (
 	OrchestratorKubernetes = "k8s"
 	OrchestratorCNI        = "cni"
 	OrchestratorDocker     = "libnetwork"
+	OrchestratorOpenStack  = "openstack"
 )

--- a/lib/upgrade/migrator/felixconfig_test.go
+++ b/lib/upgrade/migrator/felixconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -174,9 +174,16 @@ func (fc fakeClientV1) Get(k model.Key) (*model.KVPair, error) {
 
 func (fc fakeClientV1) List(l model.ListInterface) ([]*model.KVPair, error) {
 	r := []*model.KVPair{}
+	_, isPL := l.(model.ProfileListOptions)
 	for _, kvp := range fc.kvps {
 		p, _ := model.KeyToDefaultPath(kvp.Key)
 		if l.KeyFromDefaultPath(p) != nil {
+			r = append(r, kvp)
+			// This profile specific check allows adding a ProfileKey in the kvps
+			// that does not get matched with the above To/From DefaultPath check.
+			// The normal client would return a ProfileKey as it does the work of
+			// combining the rules/tags/labels.
+		} else if _, ok := kvp.Key.(model.ProfileKey); ok && isPL {
 			r = append(r, kvp)
 		}
 	}

--- a/lib/upgrade/migrator/migrate.go
+++ b/lib/upgrade/migrator/migrate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -351,10 +351,16 @@ var filterGNP = func(k model.Key) bool {
 	return strings.HasPrefix(gk.Name, "knp.default.")
 }
 
-// Filter to filter out K8s (namespace) backed profiles
+// Filter to filter out K8s (namespace) and OpenStack backed profiles
 var filterProfile = func(k model.Key) bool {
 	gk := k.(model.ProfileKey)
-	return strings.HasPrefix(gk.Name, "k8s_ns.")
+	return strings.HasPrefix(gk.Name, "k8s_ns.") || strings.HasPrefix(gk.Name, "openstack-sg-")
+}
+
+// Filter to filter out OpenStack backed workload endpoints
+var filterWEP = func(k model.Key) bool {
+	gk := k.(model.WorkloadEndpointKey)
+	return gk.OrchestratorID == "openstack"
 }
 
 type ic interface {
@@ -473,7 +479,7 @@ func (m *migrationHelper) queryAndConvertResources() (*MigrationData, error) {
 		m.statusBullet("handling WorkloadEndpoint resources")
 		// Query and convert the WorkloadEndpoints
 		if err := m.queryAndConvertV1ToV3Resources(
-			data, model.WorkloadEndpointListOptions{}, converters.WorkloadEndpoint{}, noFilter,
+			data, model.WorkloadEndpointListOptions{}, converters.WorkloadEndpoint{}, filterWEP,
 		); err != nil {
 			return nil, err
 		}

--- a/lib/upgrade/migrator/migrate.go
+++ b/lib/upgrade/migrator/migrate.go
@@ -360,7 +360,7 @@ var filterProfile = func(k model.Key) bool {
 // Filter to filter out OpenStack backed workload endpoints
 var filterWEP = func(k model.Key) bool {
 	gk := k.(model.WorkloadEndpointKey)
-	return gk.OrchestratorID == "openstack"
+	return gk.OrchestratorID == apiv3.OrchestratorOpenStack
 }
 
 type ic interface {

--- a/lib/upgrade/migrator/migrate_test.go
+++ b/lib/upgrade/migrator/migrate_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
@@ -114,15 +115,14 @@ var _ = Describe("Test OpenStack migration filters", func() {
 	}
 
 	It("should not filter WorkloadEndpoints without openstack as OrchestratorID", func() {
-		clientv1 := fakeClientV1{}
-
-		kvps := []*model.KVPair{
-			&model.KVPair{
-				Key:   wk,
-				Value: &wv,
+		clientv1 := fakeClientV1{
+			kvps: []*model.KVPair{
+				&model.KVPair{
+					Key:   wk,
+					Value: &wv,
+				},
 			},
 		}
-		clientv1.kvps = kvps
 
 		// Convert the data back to a set of resources.
 		mh := &migrationHelper{clientv1: clientv1}
@@ -134,17 +134,16 @@ var _ = Describe("Test OpenStack migration filters", func() {
 	})
 
 	It("should filter WorkloadEndpoints with openstack as OrchestratorID", func() {
-		clientv1 := fakeClientV1{}
-
 		wepOSKey := wk
-		wepOSKey.OrchestratorID = "openstack"
-		kvps := []*model.KVPair{
-			&model.KVPair{
-				Key:   wepOSKey,
-				Value: &wv,
+		wepOSKey.OrchestratorID = v3.OrchestratorOpenStack
+		clientv1 := fakeClientV1{
+			kvps: []*model.KVPair{
+				&model.KVPair{
+					Key:   wepOSKey,
+					Value: &wv,
+				},
 			},
 		}
-		clientv1.kvps = kvps
 
 		// Convert the data back to a set of resources.
 		mh := &migrationHelper{clientv1: clientv1}
@@ -156,23 +155,22 @@ var _ = Describe("Test OpenStack migration filters", func() {
 	})
 
 	It("should not filter Profiles without openstack-sg", func() {
-		clientv1 := singleTypeClient{}
-
-		kvps := []*model.KVPair{
-			&model.KVPair{
-				Key: model.ProfileKey{
-					Name: "profileName",
-				},
-				Value: &model.Profile{
-					Rules: model.ProfileRules{
-						InboundRules: []model.Rule{converters.V1ModelInRule1},
+		clientv1 := singleTypeClient{
+			kvps: []*model.KVPair{
+				&model.KVPair{
+					Key: model.ProfileKey{
+						Name: "profileName",
 					},
-					Tags:   []string{},
-					Labels: map[string]string{"label1": "value1"},
+					Value: &model.Profile{
+						Rules: model.ProfileRules{
+							InboundRules: []model.Rule{converters.V1ModelInRule1},
+						},
+						Tags:   []string{},
+						Labels: map[string]string{"label1": "value1"},
+					},
 				},
 			},
 		}
-		clientv1.kvps = kvps
 
 		// Convert the data back to a set of resources.
 		mh := &migrationHelper{clientv1: clientv1}
@@ -182,24 +180,23 @@ var _ = Describe("Test OpenStack migration filters", func() {
 		By("Checking total conversion")
 		Expect(data.Resources).To(HaveLen(1), "Data %v", data)
 	})
-	It("should filter Profiles with openstack-sg", func() {
-		clientv1 := singleTypeClient{}
-
-		kvps := []*model.KVPair{
-			&model.KVPair{
-				Key: model.ProfileKey{
-					Name: "openstack-sg-profilename/rules",
-				},
-				Value: &model.Profile{
-					Rules: model.ProfileRules{
-						InboundRules: []model.Rule{converters.V1ModelInRule1},
+	It("should filter Profiles with openstack-sg- prefix", func() {
+		clientv1 := singleTypeClient{
+			kvps: []*model.KVPair{
+				&model.KVPair{
+					Key: model.ProfileKey{
+						Name: "openstack-sg-profilename/rules",
 					},
-					Tags:   []string{},
-					Labels: map[string]string{"label1": "value1"},
+					Value: &model.Profile{
+						Rules: model.ProfileRules{
+							InboundRules: []model.Rule{converters.V1ModelInRule1},
+						},
+						Tags:   []string{},
+						Labels: map[string]string{"label1": "value1"},
+					},
 				},
 			},
 		}
-		clientv1.kvps = kvps
 
 		// Convert the data back to a set of resources.
 		mh := &migrationHelper{clientv1: clientv1}


### PR DESCRIPTION
## Description

This adds filters to the migration to ignore the OpenStack derived WorkloadEndpoints and Profiles.

## Release Note

```release-note
Skip OpenStack derived WorkloadEndpoints and Profiles when migrating to the new data format.
```
