### PR TITLE
Add support for stopping watcher syncers

### DIFF
--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,6 +120,9 @@ type Client interface {
 type Syncer interface {
 	// Starts the Syncer.  May start a background goroutine.
 	Start()
+	// Stops the Syncer.  Stops all background goroutines. Any cached updates that the syncer knows about
+	// are emitted as delete events.
+	Stop()
 }
 
 type SyncerCallbacks interface {

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -158,6 +158,10 @@ func (syn *etcdSyncer) Start() {
 	}
 	go syn.readSnapshotsFromEtcd(snapshotUpdateC, snapshotRequestC)
 	go syn.mergeUpdates(snapshotUpdateC, watcherUpdateC, snapshotRequestC)
+}
+
+func (sync *etcdSyncer) Stop() {
+	panic("Not implemented")
 }
 
 // readSnapshotsFromEtcd is a goroutine that, when requested, reads a new

--- a/lib/backend/k8s/resources/client.go
+++ b/lib/backend/k8s/resources/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ type K8sResourceClient interface {
 	// Non-zero fields in the struct are used as filters.
 	List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error)
 
-	// Watch returns a WatchInterface used for watching a resources matching the
+	// Watch returns a WatchInterface used for watching resources matching the
 	// input list options.
 	Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error)
 

--- a/lib/testutils/syncertester.go
+++ b/lib/testutils/syncertester.go
@@ -159,7 +159,7 @@ func (st *SyncerTester) ExpectStatusUpdate(status api.SyncStatus) {
 		defer st.lock.Unlock()
 		return st.status
 	}
-	Eventually(cs, 6*time.Second, 500*time.Millisecond).Should(Equal(status))
+	Eventually(cs, 6*time.Second, time.Millisecond).Should(Equal(status))
 	Consistently(cs).Should(Equal(status))
 
 	log.Infof("Status is at expected status: %s", status)
@@ -190,7 +190,7 @@ func (st *SyncerTester) ExpectStatusUnchanged() {
 		defer st.lock.Unlock()
 		return st.statusChanged
 	}
-	Eventually(sc, 6*time.Second, 500*time.Millisecond).Should(BeFalse())
+	Eventually(sc, 6*time.Second, time.Millisecond).Should(BeFalse())
 	Consistently(sc).Should(BeFalse(), "Status changed unexpectedly")
 }
 
@@ -211,13 +211,13 @@ func (st *SyncerTester) ExpectData(kvp model.KVPair) {
 		value := func() interface{} {
 			return st.GetCacheValue(key)
 		}
-		Eventually(value, 6*time.Second, 500*time.Millisecond).Should(Equal(kvp.Value))
+		Eventually(value, 6*time.Second, time.Millisecond).Should(Equal(kvp.Value))
 		Consistently(value).Should(Equal(kvp.Value), "KVPair data was incorrect")
 	} else {
 		kv := func() interface{} {
 			return st.GetCacheKVPair(key)
 		}
-		Eventually(kv, 6*time.Second, 500*time.Millisecond).Should(Equal(kvp))
+		Eventually(kv, 6*time.Second, time.Millisecond).Should(Equal(kvp))
 		Consistently(kv).Should(Equal(kvp), "KVPair data (or revision) was incorrect")
 	}
 }
@@ -231,7 +231,7 @@ func (st *SyncerTester) ExpectValueMatches(k model.Key, match gomegatypes.Gomega
 		return st.GetCacheValue(key)
 	}
 
-	Eventually(value, 6*time.Second, 500*time.Millisecond).Should(match)
+	Eventually(value, 6*time.Second, time.Millisecond).Should(match)
 	Consistently(value).Should(match)
 }
 


### PR DESCRIPTION
When a watchersyncer is stopped, it will emit all the cached resources
that it knew about as delete events.