### PR TITLE
Remove syncer() method from client interface.

### DIFF
--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -100,12 +100,6 @@ type Client interface {
 	// input list options.
 	Watch(ctx context.Context, list model.ListInterface, revision string) (WatchInterface, error)
 
-	// Syncer creates an object that generates a series of KVPair updates,
-	// which paint an eventually-consistent picture of the full state of
-	// the datastore and then generates subsequent KVPair updates for
-	// changes to the datastore.
-	Syncer(callbacks SyncerCallbacks) Syncer
-
 	// EnsureInitialized ensures that the backend is initialized
 	// any ready to be used.
 	EnsureInitialized() error

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -266,10 +266,6 @@ func (c *ModelAdaptor) Watch(ctx context.Context, l model.ListInterface, revisio
 	return c.client.Watch(ctx, l, revision)
 }
 
-func (c *ModelAdaptor) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
-	return c.client.Syncer(callbacks)
-}
-
 // getProfile gets the composite profile by getting the individual components
 // and joining the results together.
 func (c *ModelAdaptor) getProfile(ctx context.Context, k model.Key) (*model.KVPair, error) {

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -29,7 +29,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
 
@@ -434,11 +433,6 @@ func (c *etcdV3Client) IsClean() (bool, error) {
 
 	// The datastore is clean if no results were enumerated.
 	return len(resp.Kvs) == 0, nil
-}
-
-// Syncer returns a v1 Syncer used to stream resource updates.
-func (c *etcdV3Client) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
-	return felixsyncer.New(c, callbacks, apiconfig.EtcdV3)
 }
 
 // getTTLOption returns a OpOption slice containing a Lease granted for the TTL.

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -32,7 +32,7 @@ import (
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
 
-	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
+	//"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -355,11 +355,6 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 	schemeBuilder.AddToScheme(scheme.Scheme)
 
 	return cli, nil
-}
-
-// Syncer returns a v1 Syncer used to stream resource updates.
-func (c *KubeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
-	return felixsyncer.New(c, callbacks, apiconfig.Kubernetes)
 }
 
 // Create an entry in the datastore.  This errors if the entry already exists.

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
 
 	log "github.com/sirupsen/logrus"
 
@@ -290,7 +291,7 @@ func CreateClientAndSyncer(cfg apiconfig.KubeConfig) (*KubeClient, *cb, api.Sync
 		Lock:       &sync.Mutex{},
 		updateChan: updateChan,
 	}
-	syncer := c.Syncer(callback)
+	syncer := felixsyncer.New(c, callback)
 	return c.(*KubeClient), &callback, syncer
 }
 

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
@@ -53,7 +54,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			// Create a SyncerTester to receive the BGP syncer callback events and to allow us
 			// to assert state.
 			syncTester := testutils.NewSyncerTester()
-			syncer := be.Syncer(syncTester)
+			syncer := felixsyncer.New(be, syncTester)
 			syncer.Start()
 			expectedCacheSize := 0
 
@@ -299,7 +300,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			// We need to create a new syncTester and syncer.
 			current := syncTester.GetCacheEntries()
 			syncTester = testutils.NewSyncerTester()
-			syncer = be.Syncer(syncTester)
+			syncer = felixsyncer.New(be, syncTester)
 			syncer.Start()
 
 			// Verify the data is the same as the data from the previous cache.  We got the cache in the previous

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
@@ -15,7 +15,6 @@
 package felixsyncer
 
 import (
-	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -23,9 +22,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
 )
 
-// New creates a new Felix v1 Syncer.  Currently only the etcdv3 backend is supported
-// since KDD does not yet fully support Watchers.
-func New(client api.Client, callbacks api.SyncerCallbacks, datastoreType apiconfig.DatastoreType) api.Syncer {
+// New creates a new Felix v1 Syncer.
+func New(client api.Client, callbacks api.SyncerCallbacks) api.Syncer {
 	// Create the set of ResourceTypes required for Felix.  Since the update processors
 	// also cache state, we need to create individual ones per syncer rather than create
 	// a common global set.


### PR DESCRIPTION
## Description
It's no longer a part of the client, so this method can lead to circular
dependencies.

## Release Note
```release-note
Syncer() method is no longer part of the client interface.
```
