### PR TITLE
Removed KubeIPVSSupportEnabled from felix configuration.

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -178,12 +178,8 @@ type FelixConfigurationSpec struct {
 	// does not get cut off from etcd as well as allowing DHCP and DNS. [Default: tcp:2379, tcp:2380, tcp:4001, tcp:7001, udp:53, udp:67]
 	FailsafeOutboundHostPorts *[]ProtoPort `json:"failsafeOutboundHostPorts,omitempty"`
 
-	// KubeIPVSSupportEnabled must be set (only) if using Calico with Kubernetes and kube-proxy is running in ipvs mode.  It changes the way
-	// Felix renders iptables policy to be compatible with the ipvs packet flow. [Default: false]
-	KubeIPVSSupportEnabled *bool `json:"kubeIPVSSupportEnabled,omitempty"`
-
-	// KubeNodePortRanges holds list of port ranges used for service node ports. Only used if ipvs support is enabled.  Felix uses these
-	// ranges to separate host and workload traffic. [Default: 30000:32767].
+	// KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
+	// Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
 	KubeNodePortRanges *[]numorstring.Port `json:"kubeNodePortRanges,omitempty" validate:"omitempty,dive"`
 
 	// UsageReportingEnabled reports anonymous Calico version number and cluster size to projectcalico.org. Logs warnings returned by the usage

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -872,15 +872,6 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 			}
 		}
 	}
-	if in.KubeIPVSSupportEnabled != nil {
-		in, out := &in.KubeIPVSSupportEnabled, &out.KubeIPVSSupportEnabled
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
-	}
 	if in.KubeNodePortRanges != nil {
 		in, out := &in.KubeNodePortRanges, &out.KubeNodePortRanges
 		if *in == nil {

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 51
+	numFelixConfigs := 50
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3


### PR DESCRIPTION
## Description
Felix is now auto detecting kube-proxy mode (iptables or ipvs). Users do not need to set configuration flag `KubeIPVSSupportEnabled` anymore.

## Todos
None.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
