### PR TITLE
Allow . in interface names

### DIFF
--- a/lib/validator/v1/validator.go
+++ b/lib/validator/v1/validator.go
@@ -42,7 +42,7 @@ var (
 	labelValueRegex     = regexp.MustCompile("^[a-zA-Z0-9]?([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
 	nameRegex           = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
 	namespacedNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_./-]{1,128}$`)
-	interfaceRegex      = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
+	interfaceRegex      = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,15}$")
 	actionRegex         = regexp.MustCompile("^(allow|deny|log|pass)$")
 	backendActionRegex  = regexp.MustCompile("^(allow|deny|log|next-tier|)$")
 	protocolRegex       = regexp.MustCompile("^(tcp|udp|icmp|icmpv6|sctp|udplite)$")

--- a/lib/validator/v1/validator_test.go
+++ b/lib/validator/v1/validator_test.go
@@ -433,11 +433,10 @@ func init() {
 		Entry("should reject label value ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "gold~"}}, false),
 
 		// (API) Interface.
-		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "ValidIntface0-9"}, true),
+		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "Valid_Iface.0-9"}, true),
 		Entry("should reject an interface that is too long", api.WorkloadEndpointSpec{InterfaceName: "interfaceTooLong"}, false),
 		Entry("should reject & in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid&Intface"}, false),
 		Entry("should reject # in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid#Intface"}, false),
-		Entry("should reject . in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid.Intface"}, false),
 		Entry("should reject : in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid:Intface"}, false),
 
 		// (API) Scope

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -62,7 +62,7 @@ var (
 	// GlobalNetworkPolicy names must be a simple DNS1123 label format (nameLabelFmt).
 	globalNetworkPolicyNameRegex = regexp.MustCompile("^(" + nameLabelFmt + ")$")
 
-	interfaceRegex        = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
+	interfaceRegex        = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,15}$")
 	actionRegex           = regexp.MustCompile("^(Allow|Deny|Log|Pass)$")
 	protocolRegex         = regexp.MustCompile("^(TCP|UDP|ICMP|ICMPv6|SCTP|UDPLite)$")
 	ipipModeRegex         = regexp.MustCompile("^(Always|CrossSubnet|Never)$")

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -454,11 +454,10 @@ func init() {
 		),
 
 		// (API) Interface.
-		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "ValidIntface0-9"}, true),
+		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "Valid_Iface.0-9"}, true),
 		Entry("should reject an interface that is too long", api.WorkloadEndpointSpec{InterfaceName: "interfaceTooLong"}, false),
 		Entry("should reject & in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid&Intface"}, false),
 		Entry("should reject # in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid#Intface"}, false),
-		Entry("should reject . in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid.Intface"}, false),
 		Entry("should reject : in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid:Intface"}, false),
 
 		// (API) FelixConfiguration.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This is common in vlan setups (eth0.1234, bond0.1234). The validator regex currently disallows `.`, I've updated the regex and the unit test in both of the validator versions.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```