### PR TITLE
cherry-pick: support watching a single node (release-v3.0)

### DIFF
--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -1710,3 +1710,65 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 	})
 })
+
+var _ = Describe("Test Watch support", func() {
+	var (
+		c   *KubeClient
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		// Create a client
+		cfg := apiconfig.CalicoAPIConfigSpec{KubeConfig: apiconfig.KubeConfig{K8sAPIEndpoint: "http://localhost:8080"}}
+		client, err := NewKubeClient(&cfg)
+		Expect(err).NotTo(HaveOccurred())
+		c = client.(*KubeClient)
+
+		ctx = context.Background()
+	})
+
+	It("Should support watching Nodes", func() {
+		By("Watching a single node", func() {
+			name := "127.0.0.1" // Node created by test/mock-node.yaml
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: name, Kind: apiv3.KindNode}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			// We should get at least one event from the watch.
+			var receivedEvent bool
+			for i := 0; i < 10; i++ {
+				select {
+				case e := <-watch.ResultChan():
+					// Got an event. Check it's OK.
+					Expect(e.Error).NotTo(HaveOccurred())
+					Expect(e.Type).To(Equal(api.WatchAdded))
+					receivedEvent = true
+					break
+				default:
+					time.Sleep(50 * time.Millisecond)
+				}
+			}
+			Expect(receivedEvent).To(BeTrue(), "Did not receive watch event")
+		})
+
+		By("Watching all nodes", func() {
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNode}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			// We should get at least one event from the watch.
+			var receivedEvent bool
+			for i := 0; i < 10; i++ {
+				select {
+				case e := <-watch.ResultChan():
+					// Got an event. Check it's OK.
+					Expect(e.Error).NotTo(HaveOccurred())
+					Expect(e.Type).To(Equal(api.WatchAdded))
+					receivedEvent = true
+					break
+				default:
+					time.Sleep(50 * time.Millisecond)
+				}
+			}
+			Expect(receivedEvent).To(BeTrue(), "Did not receive watch event")
+		})
+	})
+})

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
@@ -159,11 +160,19 @@ func (c *nodeClient) EnsureInitialized() error {
 }
 
 func (c *nodeClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
-	if len(list.(model.ResourceListOptions).Name) != 0 {
-		return nil, fmt.Errorf("cannot watch specific resource instance: %s", list.(model.ResourceListOptions).Name)
+	// Build watch options to pass to k8s.
+	opts := metav1.ListOptions{ResourceVersion: revision, Watch: true}
+	rlo, ok := list.(model.ResourceListOptions)
+	if !ok {
+		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
+	}
+	if len(rlo.Name) != 0 {
+		// We've been asked to watch a specific node resource.
+		log.WithField("name", rlo.Name).Debug("Watching a single node")
+		opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", rlo.Name).String()
 	}
 
-	k8sWatch, err := c.clientSet.CoreV1().Nodes().Watch(metav1.ListOptions{ResourceVersion: revision})
+	k8sWatch, err := c.clientSet.CoreV1().Nodes().Watch(opts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
https://github.com/projectcalico/libcalico-go/pull/835

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve confd scale when using the Kubernetes API datastore and node-to-node mesh disabled.
```
