### PR TITLE
Change default Types to be only Ingress when preDNAT is set true

### DIFF
--- a/lib/converter/policy.go
+++ b/lib/converter/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,7 +113,11 @@ func (p PolicyConverter) ConvertKVPairToAPI(d *model.KVPair) (unversioned.Resour
 		// before the explicit Types feature was available.  Calico's previous behaviour was
 		// always to apply policy to both ingress and egress traffic, so in this case we
 		// return Types as [ ingress, egress ].
-		ap.Spec.Types = []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress}
+		if bp.PreDNAT {
+			ap.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
+		} else {
+			ap.Spec.Types = []api.PolicyType{api.PolicyTypeIngress, api.PolicyTypeEgress}
+		}
 	} else {
 		// Convert from the backend-specified Types.
 		ap.Spec.Types = make([]api.PolicyType, len(bp.Types))

--- a/lib/upgrade/converters/policy.go
+++ b/lib/upgrade/converters/policy.go
@@ -78,7 +78,6 @@ func (_ Policy) APIV1ToBackendV1(a unversioned.Resource) (*model.KVPair, error) 
 		d.Value.(*model.Policy).Types = make([]string, len(ap.Spec.Types))
 		for i, t := range ap.Spec.Types {
 			d.Value.(*model.Policy).Types[i] = string(t)
-
 		}
 	}
 

--- a/lib/upgrade/converters/policy.go
+++ b/lib/upgrade/converters/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,6 +78,7 @@ func (_ Policy) APIV1ToBackendV1(a unversioned.Resource) (*model.KVPair, error) 
 		d.Value.(*model.Policy).Types = make([]string, len(ap.Spec.Types))
 		for i, t := range ap.Spec.Types {
 			d.Value.(*model.Policy).Types[i] = string(t)
+
 		}
 	}
 
@@ -124,7 +125,11 @@ func (_ Policy) BackendV1ToAPIV3(kvp *model.KVPair) (Resource, error) {
 		// before the explicit Types feature was available.  Calico's previous behaviour was
 		// always to apply policy to both ingress and egress traffic, so in this case we
 		// return Types as [ ingress, egress ].
-		ap.Spec.Types = []apiv3.PolicyType{apiv3.PolicyTypeIngress, apiv3.PolicyTypeEgress}
+		if bp.PreDNAT {
+			ap.Spec.Types = []apiv3.PolicyType{apiv3.PolicyTypeIngress}
+		} else {
+			ap.Spec.Types = []apiv3.PolicyType{apiv3.PolicyTypeIngress, apiv3.PolicyTypeEgress}
+		}
 	} else {
 		// Convert from the backend-specified Types.
 		ap.Spec.Types = make([]apiv3.PolicyType, len(bp.Types))


### PR DESCRIPTION
## Description

Addresses https://github.com/projectcalico/calico/issues/1796

## Todos

## Release Note

```release-note
When converting do not copy egress type when preDNAT is set on a policy.
```
