### PR TITLE
Include HealthHost in v3.FelixConfigurationSpec

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -152,8 +152,10 @@ type FelixConfigurationSpec struct {
 
 	DisableConntrackInvalidCheck *bool `json:"disableConntrackInvalidCheck,omitempty"`
 
-	HealthEnabled *bool `json:"healthEnabled,omitempty"`
-	HealthPort    *int  `json:"healthPort,omitempty"`
+	HealthEnabled *bool   `json:"healthEnabled,omitempty"`
+	HealthHost    *string `json:"healthHost,omitempty"`
+	HealthPort    *int    `json:"healthPort,omitempty"`
+
 	// PrometheusMetricsEnabled enables the experimental Prometheus metrics server in Felix if set to true. [Default: false]
 	PrometheusMetricsEnabled *bool `json:"prometheusMetricsEnabled,omitempty"`
 	// PrometheusMetricsPort is the TCP port that the experimental Prometheus metrics server should bind to. [Default:9091]

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 51
+	numFelixConfigs := 52
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3

--- a/lib/clientv3/felixconfig_e2e_test.go
+++ b/lib/clientv3/felixconfig_e2e_test.go
@@ -42,6 +42,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 	ptrFalse := false
 	ptrInt1 := 1432
 	ptrInt2 := 6341
+	hostString := "localhost"
 	spec1 := apiv3.FelixConfigurationSpec{
 		UseInternalDataplaneDriver: &ptrTrue,
 		DataplaneDriver:            "test-dataplane-driver1",
@@ -50,6 +51,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 	spec2 := apiv3.FelixConfigurationSpec{
 		UseInternalDataplaneDriver: &ptrFalse,
 		DataplaneDriver:            "test-dataplane-driver2",
+		HealthHost:                 &hostString,
 		HealthPort:                 &ptrInt2,
 	}
 

--- a/run-uts
+++ b/run-uts
@@ -15,7 +15,7 @@ find . -name "*.coverprofile" -type f -delete
 if [ -z $WHAT ]
 then
     echo "Calculating packages to cover..."
-    go_dirs=$(find -type f -name '*.go' | \
+    go_dirs=$(find . -type f -name '*.go' | \
 	          grep -vE '/vendor/|.glide|.git' | \
 	          xargs -n 1 dirname | \
 	          sort | uniq | \


### PR DESCRIPTION
## Description

Continuation of #818, needed in order to bring this configuration into `projectcalico/felix`.

This also includes a small integration test to ensure the property is configurable.