### PR TITLE
[release-v3.0] cherry pick: bugfix: IPAM block affinity leaks after upgrade

### DIFF
--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -15,12 +15,12 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
-	"reflect"
-	"strings"
-
 	"fmt"
 	net2 "net"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/projectcalico/libcalico-go/lib/net"
@@ -283,10 +283,25 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 	iface := value.Interface()
 	err = json.Unmarshal(rawData, iface)
 	if err != nil {
-		log.Warningf("Failed to unmarshal %#v into value %#v",
-			string(rawData), value)
-		return nil, err
+		// This is a special case to address backwards compatibility from the time when we had no state information as block affinity value.
+		// example:
+		// Key: "/calico/ipam/v2/host/myhost.io/ipv4/block/172.29.82.0-26"
+		// Value: ""
+		// In 3.0.7 we added block affinity state as the value, so old "" value is no longer a valid JSON, so for that
+		// particular case we replace the "" with a "{}" so it can be parsed and we don't leak blocks after upgrade to Calico 3.0.7
+		// See: https://github.com/projectcalico/calico/issues/1956
+		if bytes.Equal(rawData, []byte(``)) && valueType == typeBlockAff {
+			rawData = []byte(`{}`)
+			if err = json.Unmarshal(rawData, iface); err != nil {
+				return nil, err
+			}
+		} else {
+			log.Warningf("Failed to unmarshal %#v into value %#v",
+				string(rawData), value)
+			return nil, err
+		}
 	}
+
 	if elem.Kind() != reflect.Struct {
 		// Pointer to a map or slice, unwrap.
 		iface = elem.Interface()

--- a/lib/backend/model/keys_test.go
+++ b/lib/backend/model/keys_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -93,6 +94,60 @@ var _ = DescribeTable(
 		"ready flag",
 		"/calico/v1/Ready",
 		ReadyFlagKey{},
+	),
+)
+
+var _ = DescribeTable(
+	"value parsing",
+	func(key Key, rawVal string, expectedVal interface{}) {
+		val, err := ParseValue(key, []byte(rawVal))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(val).To(Equal(expectedVal))
+	},
+	Entry(
+		"Block affinity claims with confirmed state",
+		BlockAffinityKey{
+			CIDR: mustParseCIDR("172.29.128.64/26"),
+			Host: "happyhost.io",
+		},
+		`{"state":"confirmed"}`,
+		&BlockAffinity{State: StateConfirmed},
+	),
+	Entry(
+		"Block affinity claims with pending state",
+		BlockAffinityKey{
+			CIDR: mustParseCIDR("172.29.128.0/26"),
+			Host: "slightlyhappyhost.io",
+		},
+		`{"state":"pending"}`,
+		&BlockAffinity{State: StatePending},
+	),
+	Entry(
+		"Block affinity claims with pending-deletion state",
+		BlockAffinityKey{
+			CIDR: mustParseCIDR("172.29.128.192/26"),
+			Host: "notsohappyhost.io",
+		},
+		`{"state":"pendingDeletion"}`,
+		&BlockAffinity{State: StatePendingDeletion},
+	),
+	Entry(
+		"Pre-3.0.7 style block affinity claims with no state i.e. empty string in value",
+		BlockAffinityKey{
+			CIDR: mustParseCIDR("172.29.128.128/26"),
+			Host: "oldhost.io",
+		},
+		``,
+		&BlockAffinity{},
+	),
+	Entry(
+		"Block affinity claims with empty state {} in value",
+		BlockAffinityKey{
+			CIDR: mustParseCIDR("172.29.128.128/26"),
+			Host: "oldhost.io",
+		},
+		`{}`,
+		&BlockAffinity{},
 	),
 )
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
#868 
## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
bugfix: IPAM doesn't use old IP blocks after upgrade to Calico 3.0.7
```
