### PR TITLE
Support pod and namespace selectors in K8s policy

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -377,6 +377,10 @@ func (c Converter) k8sSelectorToCalico(s *metav1.LabelSelector, selectorType sel
 		selectors = append(selectors, fmt.Sprintf("%s == 'k8s'", apiv3.LabelOrchestrator))
 	}
 
+	if s == nil {
+		return strings.Join(selectors, " && ")
+	}
+
 	// For namespace selectors, if they are present but have no terms, it means "select all
 	// namespaces". We use empty string to represent the nil namespace selector, so use all() to
 	// represent all namespaces.
@@ -533,16 +537,6 @@ func (c Converter) k8sPeerToCalicoFields(peer *extensions.NetworkPolicyPeer, ns 
 	}
 	// Peer information available.
 	// Determine the source selector for the rule.
-	// Only one of PodSelector / NamespaceSelector can be defined.
-	if peer.PodSelector != nil {
-		selector = c.k8sSelectorToCalico(peer.PodSelector, SelectorPod)
-		return
-	}
-	if peer.NamespaceSelector != nil {
-		nsSelector = c.k8sSelectorToCalico(peer.NamespaceSelector, SelectorNamespace)
-		selector = fmt.Sprintf("%s == 'k8s'", apiv3.LabelOrchestrator)
-		return
-	}
 	if peer.IPBlock != nil {
 		// Convert the CIDR to include.
 		_, ipNet, err := cnet.ParseCIDR(peer.IPBlock.CIDR)
@@ -562,8 +556,14 @@ func (c Converter) k8sPeerToCalicoFields(peer *extensions.NetworkPolicyPeer, ns 
 			}
 			notNets = append(notNets, ipNet.String())
 		}
+		// If IPBlock is set, then PodSelector and NamespaceSelector cannot be.
 		return
 	}
+
+	// IPBlock is not set to get here.
+	// Note that k8sSelectorToCalico() accepts nil values of the selector.
+	selector = c.k8sSelectorToCalico(peer.PodSelector, SelectorPod)
+	nsSelector = c.k8sSelectorToCalico(peer.NamespaceSelector, SelectorNamespace)
 	return
 }
 

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -1093,18 +1093,18 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 	})
 
 	It("should parse a NetworkPolicy with pod and namespace selectors", func() {
-		np := networkingv1.NetworkPolicy{
+		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
 			},
-			Spec: networkingv1.NetworkPolicySpec{
+			Spec: extensions.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"label": "value"},
 				},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{
+				Ingress: []extensions.NetworkPolicyIngressRule{
 					{
-						From: []networkingv1.NetworkPolicyPeer{
+						From: []extensions.NetworkPolicyPeer{
 							{
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
@@ -1122,7 +1122,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 						},
 					},
 				},
-				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				PolicyTypes: []extensions.PolicyType{extensions.PolicyTypeIngress},
 			},
 		}
 

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -85,20 +85,20 @@ var _ = Describe("Test parsing strings", func() {
 
 var _ = Describe("Test selector conversion", func() {
 	DescribeTable("selector conversion table",
-		func(inSelector metav1.LabelSelector, selectorType selectorType, expected string) {
+		func(inSelector *metav1.LabelSelector, selectorType selectorType, expected string) {
 			// First, convert the NetworkPolicy using the k8s conversion logic.
 			c := Converter{}
 
-			converted := c.k8sSelectorToCalico(&inSelector, selectorType)
+			converted := c.k8sSelectorToCalico(inSelector, selectorType)
 
 			// Finally, assert the expected result.
 			Expect(converted).To(Equal(expected))
 		},
 
-		Entry("should handle an empty pod selector", metav1.LabelSelector{}, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
-		Entry("should handle an empty namespace selector", metav1.LabelSelector{}, SelectorNamespace, "all()"),
+		Entry("should handle an empty pod selector", &metav1.LabelSelector{}, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
+		Entry("should handle an empty namespace selector", &metav1.LabelSelector{}, SelectorNamespace, "all()"),
 		Entry("should handle an OpDoesNotExist namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpDoesNotExist},
 				},
@@ -107,7 +107,7 @@ var _ = Describe("Test selector conversion", func() {
 			"! has(toast)",
 		),
 		Entry("should handle an OpExists namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpExists},
 				},
@@ -116,7 +116,7 @@ var _ = Describe("Test selector conversion", func() {
 			"has(toast)",
 		),
 		Entry("should handle an OpIn namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpIn, Values: []string{"butter", "jam"}},
 				},
@@ -125,7 +125,7 @@ var _ = Describe("Test selector conversion", func() {
 			"toast in { 'butter', 'jam' }",
 		),
 		Entry("should handle an OpNotIn namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"marmite", "milk"}},
 				},
@@ -134,7 +134,7 @@ var _ = Describe("Test selector conversion", func() {
 			"toast not in { 'marmite', 'milk' }",
 		),
 		Entry("should handle an OpDoesNotExist pod selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpDoesNotExist},
 				},
@@ -142,6 +142,8 @@ var _ = Describe("Test selector conversion", func() {
 			SelectorPod,
 			"projectcalico.org/orchestrator == 'k8s' && ! has(toast)",
 		),
+		Entry("should handle nil pod selector", nil, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
+		Entry("should handle nil namespace selector", nil, SelectorNamespace, ""),
 	)
 })
 
@@ -1081,6 +1083,62 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.NamespaceSelector).To(Equal("all()"))
+
+		// There should be no Egress rules.
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))
+
+		// Check that Types field exists and has only 'ingress'
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
+	})
+
+	It("should parse a NetworkPolicy with pod and namespace selectors", func() {
+		np := networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.policy",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"label": "value"},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"namespaceRole": "dev",
+										"namespaceFoo":  "bar",
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"podA": "B",
+										"podC": "D",
+									},
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			},
+		}
+
+		// Parse the policy.
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert key fields are correct.
+		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.test.policy"))
+
+		// Assert value fields are correct.
+		Expect(int(*pol.Value.(*apiv3.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && podA == 'B' && podC == 'D'"))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.NamespaceSelector).To(Equal("namespaceFoo == 'bar' && namespaceRole == 'dev'"))
 
 		// There should be no Egress rules.
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

#867 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
@spikecurtis For updated Kubernetes clusters that allow it, you may include both a pod and namespace selector on a NetworkPolicyPeer.
```
