### PR TITLE
godoc fix for lib/apis/v3 to ignore build tags

### DIFF
--- a/lib/apis/v3/doc.go
+++ b/lib/apis/v3/doc.go
@@ -30,4 +30,5 @@ format also used by calicoctl is directly mapped from the JSON.
 */
 
 // +k8s:deepcopy-gen=package,register
+
 package v3

--- a/lib/upgrade/migrator/clients/v1/k8s/custom/doc.go
+++ b/lib/upgrade/migrator/clients/v1/k8s/custom/doc.go
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
+
 package custom


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
add newline for godoc not to render build tag.

Before:
```bash
PACKAGE DOCUMENTATION                    
                                         
package v3                                
   import “.”                            
                                         
   +k8s:deepcopy-gen=package,register
```

after:
```bash
PACKAGE DOCUMENTATION          
                               
package v3                      
   import “.”
```

```release-note
None required
```
Signed-off-by: derek mcquay <derek@tigera.io>