### PR TITLE
Validate ALP only used on ingress, allow rules

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -790,6 +790,12 @@ func validateRule(v *validator.Validate, structLevel *validator.StructLevel) {
 	scanNets(rule.Source.NotNets, "Source.NotNets")
 	scanNets(rule.Destination.Nets, "Destination.Nets")
 	scanNets(rule.Destination.NotNets, "Destination.NotNets")
+
+	usesALP, alpValue, alpField := ruleUsesAppLayerPolicy(&rule)
+	if rule.Action != api.Allow && usesALP {
+		structLevel.ReportError(alpValue, alpField,
+			"", reason("only valid for Allow rules"))
+	}
 }
 
 func validateNodeSpec(v *validator.Validate, structLevel *validator.StructLevel) {
@@ -896,11 +902,12 @@ func validateNetworkPolicy(v *validator.Validate, structLevel *validator.StructL
 	validateObjectMetaAnnotations(v, structLevel, np.Annotations)
 	validateObjectMetaLabels(v, structLevel, np.Labels)
 
-	// Check (and disallow) rules with HTTPMatch for egress rules.
+	// Check (and disallow) rules with application layer policy for egress rules.
 	if len(spec.Egress) > 0 {
 		for _, r := range spec.Egress {
-			if r.HTTP != nil {
-				structLevel.ReportError(reflect.ValueOf(r.HTTP), "HTTP", "", reason("HTTP match not allowed in egress rule"))
+			useALP, v, f := ruleUsesAppLayerPolicy(&r)
+			if useALP {
+				structLevel.ReportError(v, f, "", reason("not allowed in egress rule"))
 			}
 		}
 	}
@@ -985,11 +992,12 @@ func validateGlobalNetworkPolicy(v *validator.Validate, structLevel *validator.S
 		}
 	}
 
-	// Check (and disallow) rules with HTTPMatch for egress rules.
+	// Check (and disallow) rules with application layer policy for egress rules.
 	if len(spec.Egress) > 0 {
 		for _, r := range spec.Egress {
-			if r.HTTP != nil {
-				structLevel.ReportError(reflect.ValueOf(r.HTTP), "HTTP", "", reason("HTTP match not allowed in egress rules"))
+			useALP, v, f := ruleUsesAppLayerPolicy(&r)
+			if useALP {
+				structLevel.ReportError(v, f, "", reason("not allowed in egress rules"))
 			}
 		}
 	}
@@ -1038,4 +1046,20 @@ func validateObjectMetaLabels(v *validator.Validate, structLevel *validator.Stru
 			)
 		}
 	}
+}
+
+// ruleUsesAppLayerPolicy checks if a rule uses application layer policy, and
+// if it does, returns true and the type of application layer clause. If it does
+// not it returns false and the empty string.
+func ruleUsesAppLayerPolicy(rule *api.Rule) (bool, reflect.Value, string) {
+	if rule.HTTP != nil {
+		return true, reflect.ValueOf(rule.HTTP), "HTTP"
+	}
+	if rule.Source.ServiceAccounts != nil {
+		return true, reflect.ValueOf(rule.Source.ServiceAccounts), "Source.ServiceAccounts"
+	}
+	if rule.Destination.ServiceAccounts != nil {
+		return true, reflect.ValueOf(rule.Destination.ServiceAccounts), "Destination.ServiceAccounts"
+	}
+	return false, reflect.Value{}, ""
 }

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1112,6 +1112,16 @@ func init() {
 				Protocol:  protocolFromString("ICMP"),
 				IPVersion: &V6,
 			}, false),
+		Entry("should accept Allow rule with HTTP clause",
+			api.Rule{
+				Action: "Allow",
+				HTTP:   &api.HTTPMatch{Methods: []string{"GET"}},
+			}, true),
+		Entry("should reject Deny rule with HTTP clause",
+			api.Rule{
+				Action: "Deny",
+				HTTP:   &api.HTTPMatch{Methods: []string{"GET"}},
+			}, false),
 
 		// (API) BGPPeerSpec
 		Entry("should accept valid BGPPeerSpec", api.BGPPeerSpec{PeerIP: ipv4_1}, true),


### PR DESCRIPTION
## Description
Validators now only allow ALP clauses on ingress rules with allow action.

## Todos
- [X] Tests
- [X] Documentation

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
