### PR TITLE
more descriptive error for field validation

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -119,7 +119,7 @@ func convertError(err error) errors.ErrorValidation {
 			errors.ErroredField{
 				Name:   f.Name,
 				Value:  f.Value,
-				Reason: extractReason(f.Tag),
+				Reason: extractReason(f),
 			})
 	}
 	return verr
@@ -195,11 +195,15 @@ func reason(r string) string {
 
 // extractReason extracts the error reason from the field tag in a validator
 // field error (if there is one).
-func extractReason(tag string) string {
-	if strings.HasPrefix(tag, reasonString) {
-		return strings.TrimPrefix(tag, reasonString)
+func extractReason(e *validator.FieldError) string {
+	if strings.HasPrefix(e.Tag, reasonString) {
+		return strings.TrimPrefix(e.Tag, reasonString)
 	}
-	return ""
+	return fmt.Sprintf("%sfailed to validate Field: %s because of Tag: %s ",
+		reasonString,
+		e.Field,
+		e.Tag,
+	)
 }
 
 func registerFieldValidator(key string, fn validator.Func) {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1139,6 +1139,7 @@ func init() {
 
 		// GlobalNetworkPolicy validation.
 		Entry("disallow name with invalid character", &api.GlobalNetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "t~!s.h.i.ng"}}, false),
+		Entry("disallow name with mixed case characters", &api.GlobalNetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "tHiNg"}}, false),
 		Entry("allow valid name", &api.GlobalNetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "thing"}}, true),
 		Entry("disallow k8s policy name", &api.GlobalNetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "knp.default.thing"}}, false),
 		Entry("disallow name with dot", &api.GlobalNetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "t.h.i.ng"}}, false),
@@ -1411,6 +1412,7 @@ func init() {
 		// NetworkPolicySpec Types field checks.
 		Entry("allow valid name", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "thing"}}, true),
 		Entry("disallow name with dot", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "t.h.i.ng"}}, false),
+		Entry("disallow name with mixed case", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "tHiNg"}}, false),
 		Entry("allow valid name of 253 chars", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: string(longValue[:maxNameLength])}}, true),
 		Entry("disallow a name of 254 chars", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: string(longValue[:maxNameLength+1])}}, false),
 		Entry("allow k8s policy name", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "knp.default.thing"}}, true),


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Change validation message from:
```bash
ETCD_ENDPOINTS=http://127.0.0.1:2382 calicoctl apply -f wep 
Failed to execute command: error with the following fields:
-  pod = 'wep-TOM'
-  node = 'nodeTOM'
```
to:
```bash
Failed to execute command: error with the following fields:   
-  pod = 'wep-TOM' (Reason: failed to validate Field: Pod because of Tag: name )                                  
-  node = 'nodeTOM' (Reason: failed to validate Field: Node because of Tag: name )    
```

Because of how field validation [occurs](https://github.com/projectcalico/libcalico-go/blob/master/lib/validator/v3/validator.go#L136), errors during validation of field types (name, containerID, selector, labels, etc.) were without a useful message. This PR adds more detail about what specific field and tag failed because of validation. 

fixes https://github.com/projectcalico/libcalico-go/issues/854

## Release Note

```release-note
None required
```

Signed-off-by: derek mcquay <derek@tigera.io>