### PR TITLE
Track generateName from k8s object metadata.

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -270,6 +270,7 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 		CreationTimestamp: pod.CreationTimestamp,
 		UID:               pod.UID,
 		Labels:            labels,
+		GenerateName:      pod.GenerateName,
 	}
 	wep.Spec = apiv3.WorkloadEndpointSpec{
 		Orchestrator:  "k8s",

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -427,6 +427,28 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should parse a Pod with GenerateName set in metadata", func() {
+		gname := "generatedname"
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:         "podA",
+				Namespace:    "default",
+				GenerateName: gname,
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName: "nodeA",
+			},
+			Status: kapiv1.PodStatus{
+				PodIP: "192.168.0.1",
+			},
+		}
+
+		wep, err := c.PodToWorkloadEndpoint(&pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure the GenerateName information is correct.
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).GenerateName).To(Equal(gname))
+	})
 })
 
 var _ = Describe("Test NetworkPolicy conversion", func() {

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -161,6 +161,7 @@ type WorkloadEndpoint struct {
 	IPv4Gateway      *net.IP           `json:"ipv4_gateway,omitempty" validate:"omitempty,ipv4"`
 	IPv6Gateway      *net.IP           `json:"ipv6_gateway,omitempty" validate:"omitempty,ipv6"`
 	Ports            []EndpointPort    `json:"ports,omitempty" validate:"dive"`
+	GenerateName     string            `json:"generate_name,omitempty"`
 }
 
 type EndpointPort struct {

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -140,18 +140,19 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 	}
 
 	v1value := &model.WorkloadEndpoint{
-		State:       "active",
-		Name:        v3res.Spec.InterfaceName,
-		Mac:         cmac,
-		ProfileIDs:  v3res.Spec.Profiles,
-		IPv4Nets:    ipv4Nets,
-		IPv6Nets:    ipv6Nets,
-		IPv4NAT:     ipv4NAT,
-		IPv6NAT:     ipv6NAT,
-		Labels:      labels,
-		IPv4Gateway: ipv4Gateway,
-		IPv6Gateway: ipv6Gateway,
-		Ports:       ports,
+		State:        "active",
+		Name:         v3res.Spec.InterfaceName,
+		Mac:          cmac,
+		ProfileIDs:   v3res.Spec.Profiles,
+		IPv4Nets:     ipv4Nets,
+		IPv6Nets:     ipv6Nets,
+		IPv4NAT:      ipv4NAT,
+		IPv6NAT:      ipv6NAT,
+		Labels:       labels,
+		IPv4Gateway:  ipv4Gateway,
+		IPv6Gateway:  ipv6Gateway,
+		Ports:        ports,
+		GenerateName: v3res.GenerateName,
 	}
 
 	return v1value, nil


### PR DESCRIPTION
## Description
(cherry picked from commit cd733a3858af2de3a19a4bb43ed4e0a084be8a75)
Pick the `generateName`  tracking from `master` to `v3.1`
Had to re-generate the `apis/v3/zz_generated.deepcopy.go` as we are skipping on some of the newer entries added in `master`.

#879 