### PR TITLE
support setting passive mode in bgp peer

### DIFF
--- a/lib/apis/v3/bgppeer.go
+++ b/lib/apis/v3/bgppeer.go
@@ -48,6 +48,8 @@ type BGPPeerSpec struct {
 	PeerIP string `json:"peerIP" validate:"omitempty,ip"`
 	// The AS Number of the peer.
 	ASNumber numorstring.ASNumber `json:"asNumber"`
+	// Passive specifies whether the peer is in passive mode
+	Passive bool `json:"passive,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -19,13 +19,12 @@
 package v3
 
 import (
-	reflect "reflect"
-
 	apis_v1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
 	numorstring "github.com/projectcalico/libcalico-go/lib/numorstring"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	reflect "reflect"
 )
 
 func init() {

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -854,6 +854,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				Spec: apiv3.BGPPeerSpec{
 					PeerIP:   "10.0.0.1",
 					ASNumber: numorstring.ASNumber(6513),
+					Passive:  true,
 				},
 			},
 		}

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -183,4 +183,7 @@ type BGPPeer struct {
 	// converts large uints to float e notation which breaks the BIRD
 	// configuration.
 	ASNum numorstring.ASNumber `json:"as_num,string"`
+
+	// Passive is the passive setting of the BGP peer.
+	Passive bool `json:"passive"`
 }

--- a/lib/backend/syncersv1/updateprocessors/bgppeerprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/bgppeerprocessor.go
@@ -64,8 +64,9 @@ func convertBGPPeerV2ToV1(kvp *model.KVPair) (*model.KVPair, error) {
 	return &model.KVPair{
 		Key: v1key,
 		Value: &model.BGPPeer{
-			PeerIP: *ip,
-			ASNum:  v3res.Spec.ASNumber,
+			PeerIP:  *ip,
+			ASNum:   v3res.Spec.ASNumber,
+			Passive: v3res.Spec.Passive,
 		},
 		Revision: kvp.Revision,
 	}, nil

--- a/lib/clientv3/bgppeer_e2e_test.go
+++ b/lib/clientv3/bgppeer_e2e_test.go
@@ -48,6 +48,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 		Node:     "node2",
 		PeerIP:   "20.0.0.1",
 		ASNumber: numorstring.ASNumber(6511),
+		Passive:  true,
 	}
 
 	DescribeTable("BGPPeer e2e CRUD tests",


### PR DESCRIPTION
For https://github.com/projectcalico/calico/issues/1603

This allow use to set `passive: true` in bgp peer spec so we can leverage that in calico/node to set proper bird config.

I think this should touches all the required place here. Then we would want to modify calico/node for confd config and calicoctl for updating new fields.

cc @caseydavenport 