### PR TITLE
add error to ErrorResourceDoesNotExist

### DIFF
--- a/lib/clientv3/bgpconfig_e2e_test.go
+++ b/lib/clientv3/bgpconfig_e2e_test.go
@@ -76,7 +76,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 				Spec:       specDefault1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + nameDefault + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPConfiguration(" + nameDefault + ") with error:"))
 
 			By("Attempting to creating a new BGPConfiguration with name1/specInfo and a non-empty ResourceVersion")
 			_, outError = c.BGPConfigurations().Create(ctx, &apiv3.BGPConfiguration{
@@ -114,7 +114,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 			By("Getting BGPConfiguration (name2) before it is created")
 			_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPConfiguration(" + name2 + ") with error:"))
 
 			By("Listing all the BGPConfigurations, expecting a single result with name1/specInfo")
 			outList, outError := c.BGPConfigurations().List(ctx, options.ListOptions{})
@@ -235,7 +235,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 				time.Sleep(2 * time.Second)
 				_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPConfiguration(" + name2 + ") with error:"))
 
 				By("Creating BGPConfiguration name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.BGPConfigurations().Create(ctx, &apiv3.BGPConfiguration{
@@ -249,7 +249,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 				time.Sleep(2 * time.Second)
 				_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPConfiguration(" + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -263,7 +263,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 			By("Attempting to deleting BGPConfiguration (name2) again")
 			_, outError = c.BGPConfigurations().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPConfiguration(" + name2 + ") with error:"))
 
 			By("Listing all BGPConfigurations and expecting no items")
 			outList, outError = c.BGPConfigurations().List(ctx, options.ListOptions{})
@@ -273,7 +273,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 			By("Getting BGPConfiguration (name2) and expecting an error")
 			_, outError = c.BGPConfigurations().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPConfiguration(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPConfiguration(" + name2 + ") with error:"))
 
 			By("Creating a default BGPConfiguration with node to node mesh enabled and a default AS number")
 			resDefault, outError := c.BGPConfigurations().Create(ctx, &apiv3.BGPConfiguration{

--- a/lib/clientv3/bgppeer_e2e_test.go
+++ b/lib/clientv3/bgppeer_e2e_test.go
@@ -65,7 +65,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPPeer(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new BGPPeer with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.BGPPeers().Create(ctx, &apiv3.BGPPeer{
@@ -103,7 +103,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			By("Getting BGPPeer (name2) before it is created")
 			_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPPeer(" + name2 + ") with error:"))
 
 			By("Listing all the BGPPeers, expecting a single result with name1/spec1")
 			outList, outError := c.BGPPeers().List(ctx, options.ListOptions{})
@@ -224,7 +224,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 				time.Sleep(2 * time.Second)
 				_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPPeer(" + name2 + ") with error:"))
 
 				By("Creating BGPPeer name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.BGPPeers().Create(ctx, &apiv3.BGPPeer{
@@ -238,7 +238,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 				time.Sleep(2 * time.Second)
 				_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPPeer(" + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -251,7 +251,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			By("Attempting to deleting BGPPeer (name2) again")
 			_, outError = c.BGPPeers().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPPeer(" + name2 + ") with error:"))
 
 			By("Listing all BGPPeers and expecting no items")
 			outList, outError = c.BGPPeers().List(ctx, options.ListOptions{})
@@ -261,7 +261,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 			By("Getting BGPPeer (name2) and expecting an error")
 			_, outError = c.BGPPeers().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: BGPPeer(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: BGPPeer(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated BGPPeerSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/clusterinfo_e2e_test.go
+++ b/lib/clientv3/clusterinfo_e2e_test.go
@@ -223,7 +223,7 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: ClusterInformation(" + name + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: ClusterInformation(" + name + ") with error:"))
 
 			By("Attempting to creating a new ClusterInformation with name/spec1 and a non-empty ResourceVersion")
 			_, outError = c.ClusterInformation().Create(ctx, &apiv3.ClusterInformation{
@@ -236,7 +236,7 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 			By("Getting ClusterInformation (name) before it is created")
 			_, outError = c.ClusterInformation().Get(ctx, name, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: ClusterInformation(" + name + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: ClusterInformation(" + name + ") with error:"))
 
 			By("Attempting to create a new ClusterInformation with a non-default name and spec1")
 			_, outError = c.ClusterInformation().Create(ctx, &apiv3.ClusterInformation{

--- a/lib/clientv3/felixconfig_e2e_test.go
+++ b/lib/clientv3/felixconfig_e2e_test.go
@@ -70,7 +70,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: FelixConfiguration(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: FelixConfiguration(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new FelixConfiguration with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.FelixConfigurations().Create(ctx, &apiv3.FelixConfiguration{
@@ -108,7 +108,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 			By("Getting FelixConfiguration (name2) before it is created")
 			_, outError = c.FelixConfigurations().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: FelixConfiguration(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: FelixConfiguration(" + name2 + ") with error:"))
 
 			By("Listing all the FelixConfigurations, expecting a single result with name1/spec1")
 			outList, outError := c.FelixConfigurations().List(ctx, options.ListOptions{})
@@ -229,7 +229,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 				time.Sleep(2 * time.Second)
 				_, outError = c.FelixConfigurations().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: FelixConfiguration(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: FelixConfiguration(" + name2 + ") with error:"))
 
 				By("Creating FelixConfiguration name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.FelixConfigurations().Create(ctx, &apiv3.FelixConfiguration{
@@ -243,7 +243,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 				time.Sleep(2 * time.Second)
 				_, outError = c.FelixConfigurations().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: FelixConfiguration(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: FelixConfiguration(" + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -256,7 +256,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 			By("Attempting to deleting FelixConfiguration (name2) again")
 			_, outError = c.FelixConfigurations().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: FelixConfiguration(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: FelixConfiguration(" + name2 + ") with error:"))
 
 			By("Listing all FelixConfigurations and expecting no items")
 			outList, outError = c.FelixConfigurations().List(ctx, options.ListOptions{})
@@ -266,7 +266,7 @@ var _ = testutils.E2eDatastoreDescribe("FelixConfiguration tests", testutils.Dat
 			By("Getting FelixConfiguration (name2) and expecting an error")
 			_, outError = c.FelixConfigurations().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: FelixConfiguration(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: FelixConfiguration(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated FelixConfigurationSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/globalnetworkpolicy_e2e_test.go
+++ b/lib/clientv3/globalnetworkpolicy_e2e_test.go
@@ -86,7 +86,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkPolicy(default." + name1 + ") with error:"))
 
 			By("Attempting to creating a new GlobalNetworkPolicy with name1/spec1 and a non-empty ResourceVersion")
 			polToCreate := &apiv3.GlobalNetworkPolicy{
@@ -131,7 +131,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			By("Getting GlobalNetworkPolicy (name2) before it is created")
 			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkPolicy(default." + name2 + ") with error:"))
 
 			By("Listing all the GlobalNetworkPolicies, expecting a single result with name1/spec1")
 			outList, outError := c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
@@ -256,7 +256,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				time.Sleep(2 * time.Second)
 				_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkPolicy(default." + name2 + ") with error:"))
 
 				By("Creating GlobalNetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.GlobalNetworkPolicies().Create(ctx, &apiv3.GlobalNetworkPolicy{
@@ -270,7 +270,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 				time.Sleep(2 * time.Second)
 				_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkPolicy(default." + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -283,7 +283,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			By("Attempting to delete GlobalNetworkPolicy (name2) again")
 			_, outError = c.GlobalNetworkPolicies().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkPolicy(default." + name2 + ") with error:"))
 
 			By("Listing all GlobalNetworkPolicies and expecting no items")
 			outList, outError = c.GlobalNetworkPolicies().List(ctx, options.ListOptions{})
@@ -293,7 +293,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 			By("Getting GlobalNetworkPolicy (name2) and expecting an error")
 			_, outError = c.GlobalNetworkPolicies().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkPolicy(default." + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkPolicy(default." + name2 + ") with error:"))
 		},
 
 		// Pass two fully populated GlobalNetworkPolicySpecs and expect the series of operations to succeed.

--- a/lib/clientv3/globalnetworkset_e2e_test.go
+++ b/lib/clientv3/globalnetworkset_e2e_test.go
@@ -66,7 +66,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkSet(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkSet(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new GlobalNetworkSet with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.GlobalNetworkSets().Create(ctx, &apiv3.GlobalNetworkSet{
@@ -104,7 +104,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 			By("Getting GlobalNetworkSet (name2) before it is created")
 			_, outError = c.GlobalNetworkSets().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkSet(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkSet(" + name2 + ") with error:"))
 
 			By("Listing all the GlobalNetworkSets, expecting a single result with name1/spec1")
 			outList, outError := c.GlobalNetworkSets().List(ctx, options.ListOptions{})
@@ -225,7 +225,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 				time.Sleep(2 * time.Second)
 				_, outError = c.GlobalNetworkSets().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkSet(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkSet(" + name2 + ") with error:"))
 
 				By("Creating GlobalNetworkSet name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.GlobalNetworkSets().Create(ctx, &apiv3.GlobalNetworkSet{
@@ -239,7 +239,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 				time.Sleep(2 * time.Second)
 				_, outError = c.GlobalNetworkSets().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkSet(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkSet(" + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -257,7 +257,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 			By("Getting GlobalNetworkSet (name2) and expecting an error")
 			_, outError = c.GlobalNetworkSets().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: GlobalNetworkSet(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: GlobalNetworkSet(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated GlobalNetworkSetSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/hostendpoint_e2e_test.go
+++ b/lib/clientv3/hostendpoint_e2e_test.go
@@ -82,7 +82,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: HostEndpoint(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new HostEndpoint with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.HostEndpoints().Create(ctx, &apiv3.HostEndpoint{
@@ -120,7 +120,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			By("Getting HostEndpoint (name2) before it is created")
 			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: HostEndpoint(" + name2 + ") with error:"))
 
 			By("Listing all the HostEndpoints, expecting a single result with name1/spec1")
 			outList, outError := c.HostEndpoints().List(ctx, options.ListOptions{})
@@ -234,7 +234,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			time.Sleep(2 * time.Second)
 			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: HostEndpoint(" + name2 + ") with error:"))
 
 			By("Creating HostEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.HostEndpoints().Create(ctx, &apiv3.HostEndpoint{
@@ -248,12 +248,12 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			time.Sleep(2 * time.Second)
 			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: HostEndpoint(" + name2 + ") with error:"))
 
 			By("Attempting to deleting HostEndpoint (name2) again")
 			_, outError = c.HostEndpoints().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: HostEndpoint(" + name2 + ") with error:"))
 
 			By("Listing all HostEndpoints and expecting no items")
 			outList, outError = c.HostEndpoints().List(ctx, options.ListOptions{})
@@ -263,7 +263,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 			By("Getting HostEndpoint (name2) and expecting an error")
 			_, outError = c.HostEndpoints().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: HostEndpoint(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: HostEndpoint(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated HostEndpointSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -86,7 +86,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new IPPool with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.IPPools().Create(ctx, &apiv3.IPPool{
@@ -127,7 +127,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			By("Getting IPPool (name2) before it is created")
 			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name2 + ") with error:"))
 
 			By("Listing all the IPPools, expecting a single result with name1/spec1")
 			outList, outError := c.IPPools().List(ctx, options.ListOptions{})
@@ -253,7 +253,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 				time.Sleep(2 * time.Second)
 				_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name2 + ") with error:"))
 
 				By("Creating IPPool name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.IPPools().Create(ctx, &apiv3.IPPool{
@@ -267,7 +267,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 				time.Sleep(2 * time.Second)
 				_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -282,7 +282,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			By("Attempting to deleting IPPool (name2) again")
 			_, outError = c.IPPools().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name2 + ") with error:"))
 
 			By("Listing all IPPools and expecting no items")
 			outList, outError = c.IPPools().List(ctx, options.ListOptions{})
@@ -292,7 +292,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			By("Getting IPPool (name2) and expecting an error")
 			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: IPPool(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated IPPoolSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/networkpolicy_e2e_test.go
+++ b/lib/clientv3/networkpolicy_e2e_test.go
@@ -90,7 +90,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace1 + "/default." + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: NetworkPolicy(" + namespace1 + "/default." + name1 + ") with error:"))
 
 			By("Attempting to creating a new NetworkPolicy with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.NetworkPolicies().Create(ctx, &apiv3.NetworkPolicy{
@@ -129,7 +129,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Getting NetworkPolicy (name2) before it is created")
 			_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ") with error:"))
 
 			By("Listing all the NetworkPolicies in namespace1, expecting a single result with name1/spec1")
 			outList, outError := c.NetworkPolicies().List(ctx, options.ListOptions{Namespace: namespace1})
@@ -257,7 +257,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 				time.Sleep(2 * time.Second)
 				_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ") with error:"))
 
 				By("Creating NetworkPolicy name2 with a 2s TTL and waiting for the entry to be deleted")
 				_, outError = c.NetworkPolicies().Create(ctx, &apiv3.NetworkPolicy{
@@ -271,7 +271,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 				time.Sleep(2 * time.Second)
 				_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 				Expect(outError).To(HaveOccurred())
-				Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ")"))
+				Expect(outError.Error()).To(ContainSubstring("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ") with error:"))
 			}
 
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
@@ -284,7 +284,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Attempting to delete NetworkPolicy (name2) again")
 			_, outError = c.NetworkPolicies().Delete(ctx, namespace2, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ") with error:"))
 
 			By("Listing all NetworkPolicies and expecting no items")
 			outList, outError = c.NetworkPolicies().List(ctx, options.ListOptions{})
@@ -294,7 +294,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Getting NetworkPolicy (name2) and expecting an error")
 			_, outError = c.NetworkPolicies().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: NetworkPolicy(" + namespace2 + "/default." + name2 + ") with error:"))
 		},
 
 		// Pass two fully populated PolicySpecs and expect the series of operations to succeed.

--- a/lib/clientv3/node_e2e_test.go
+++ b/lib/clientv3/node_e2e_test.go
@@ -238,7 +238,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Node(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new Node with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.Nodes().Create(ctx, &apiv3.Node{
@@ -276,7 +276,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 			By("Getting Node (name2) before it is created")
 			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Node(" + name2 + ") with error:"))
 
 			By("Listing all the Nodes, expecting a single result with name1/spec1")
 			outList, outError := c.Nodes().List(ctx, options.ListOptions{})
@@ -390,7 +390,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 			time.Sleep(2 * time.Second)
 			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Node(" + name2 + ") with error:"))
 
 			By("Creating Node name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.Nodes().Create(ctx, &apiv3.Node{
@@ -404,12 +404,12 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 			time.Sleep(2 * time.Second)
 			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Node(" + name2 + ") with error:"))
 
 			By("Attempting to deleting Node (name2) again")
 			_, outError = c.Nodes().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Node(" + name2 + ") with error:"))
 
 			By("Listing all Nodes and expecting no items")
 			outList, outError = c.Nodes().List(ctx, options.ListOptions{})
@@ -419,7 +419,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests", testutils.DatastoreEtcdV3, 
 			By("Getting Node (name2) and expecting an error")
 			_, outError = c.Nodes().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Node(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Node(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated NodeSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/profile_e2e_test.go
+++ b/lib/clientv3/profile_e2e_test.go
@@ -64,7 +64,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Profile(" + name1 + ") with error:"))
 
 			By("Attempting to creating a new Profile with name1/spec1 and a non-empty ResourceVersion")
 			_, outError = c.Profiles().Create(ctx, &apiv3.Profile{
@@ -102,7 +102,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			By("Getting Profile (name2) before it is created")
 			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Profile(" + name2 + ") with error:"))
 
 			By("Listing all the Profiles, expecting a single result with name1/spec1")
 			outList, outError := c.Profiles().List(ctx, options.ListOptions{})
@@ -216,7 +216,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			time.Sleep(2 * time.Second)
 			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Profile(" + name2 + ") with error:"))
 
 			By("Creating Profile name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.Profiles().Create(ctx, &apiv3.Profile{
@@ -230,12 +230,12 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			time.Sleep(2 * time.Second)
 			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Profile(" + name2 + ") with error:"))
 
 			By("Attempting to deleting Profile (name2) again")
 			_, outError = c.Profiles().Delete(ctx, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Profile(" + name2 + ") with error:"))
 
 			By("Listing all Profiles and expecting no items")
 			outList, outError = c.Profiles().List(ctx, options.ListOptions{})
@@ -245,7 +245,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			By("Getting Profile (name2) and expecting an error")
 			_, outError = c.Profiles().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: Profile(" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: Profile(" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated ProfileSpecs and expect the series of operations to succeed.

--- a/lib/clientv3/workloadendpoint_e2e_test.go
+++ b/lib/clientv3/workloadendpoint_e2e_test.go
@@ -107,12 +107,12 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 				Spec:       spec1_1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace1 + "/" + name1 + ") with error:"))
 
 			By("Attempting to get a WorkloadEndpoint before it is created")
 			_, outError = c.WorkloadEndpoints().Get(ctx, namespace1, name1, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace1 + "/" + name1 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace1 + "/" + name1 + ") with error:"))
 
 			By("Attempting to create a new WorkloadEndpoint with name1/spec1_1 and a non-empty ResourceVersion")
 			_, outError = c.WorkloadEndpoints().Create(ctx, &apiv3.WorkloadEndpoint{
@@ -157,7 +157,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			By("Getting WorkloadEndpoint (name2) before it is created")
 			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ") with error:"))
 
 			By("Listing all the WorkloadEndpoints in namespace1, expecting a single result with name1/spec1_1")
 			outList, outError := c.WorkloadEndpoints().List(ctx, options.ListOptions{Namespace: namespace1})
@@ -286,7 +286,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			time.Sleep(2 * time.Second)
 			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ") with error:"))
 
 			By("Creating WorkloadEndpoint name2 with a 2s TTL and waiting for the entry to be deleted")
 			_, outError = c.WorkloadEndpoints().Create(ctx, &apiv3.WorkloadEndpoint{
@@ -300,12 +300,12 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			time.Sleep(2 * time.Second)
 			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ") with error:"))
 
 			By("Attempting to deleting WorkloadEndpoint (name2) again")
 			_, outError = c.WorkloadEndpoints().Delete(ctx, namespace2, name2, options.DeleteOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ") with error:"))
 
 			By("Listing all WorkloadEndpoints and expecting no items")
 			outList, outError = c.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -315,7 +315,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 			By("Getting WorkloadEndpoint (name2) and expecting an error")
 			_, outError = c.WorkloadEndpoints().Get(ctx, namespace2, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
-			Expect(outError.Error()).To(Equal("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ")"))
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: WorkloadEndpoint(" + namespace2 + "/" + name2 + ") with error:"))
 		},
 
 		// Test 1: Pass two fully populated WorkloadEndpointSpecs and expect the series of operations to succeed.

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -36,7 +36,7 @@ type ErrorResourceDoesNotExist struct {
 }
 
 func (e ErrorResourceDoesNotExist) Error() string {
-	return fmt.Sprintf("resource does not exist: %v", e.Identifier)
+	return fmt.Sprintf("resource does not exist: %v with error: %v", e.Identifier, e.Err)
 }
 
 // Error indicating an operation is not supported.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add a more descriptive error message to the ErrorResourceDoesNotExist type.

For example, when attempting to apply a `WEP` with kdd. Error message used to be:

```bash
Failed to apply 'WorkloadEndpoint' resource: resource does not exist: WorkloadEndpoint(default/node0-k8s-wep--1-eth0)
```

This PR makes it more clear by adding the error:
```bash
Failed to apply 'WorkloadEndpoint' resource: resource does not exist: WorkloadEndpoint(default/node1-k8s-my--nginx--b1337a-eth0) with error: pods "my-nginx-b1337a" not found
```
Another example is attempting to create a resource in kdd when the CRD does not yet exist. The error message used to be:

```bash
Failed to create 'bgpPeer' resource: resource does not exist: BGPPeer(global, ip=10.2.0.1)

```

This PR makes it more clear by adding the error:
```bash
Failed to create 'BGPPeer' resource: resource does not exist: BGPPeer(some.name) with error: the server could not find the requested resource (post BGPPeers.crd.projectcalico.org)                                                                                           
```
fixes https://github.com/projectcalico/calicoctl/issues/1704
fixes https://github.com/projectcalico/calicoctl/issues/1827

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

Signed-off-by: derek mcquay <derek@tigera.io>
