### PR TITLE
Fix api and apimachinery pin.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5c8124f9091c223a3be3c6c6a5b4c683f1d59290cda1ddc25371134d1d41f16f
-updated: 2018-07-03T12:41:24.276331117Z
+hash: a7fd53094b7101ee4c372a74930e193308f115abeafabbcaf520e4baf1bbb261
+updated: 2018-07-05T12:53:01.439969051Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -168,7 +168,7 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: a49355c7e3f8fe157a85be2f77e6e269a0f89602
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -406,7 +406,7 @@ imports:
   - util/jsonpath
   - util/retry
 - name: k8s.io/code-generator
-  version: 9de8e796a74d16d2a285165727d04c185ebca6dc
+  version: 7ead8f38b01cf8653249f5af80ce7b2c8aba12e2
 - name: k8s.io/gengo
   version: fdcf9f9480fdd5bf2b3c3df9bf4ecd22b25b87e2
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,15 +29,22 @@ import:
   version: ^2.2.6
   subpackages:
   - patricia
-# Versions of k8s.io/api and k8s/apimachinery are set by k8s.io/client-go
-- package: k8s.io/apimachinery
+# Version of k8s.io/api needs to be set to track the kubernetes 1.10.0 versions.
+# For package which dependent on libcalico-go e.g. typha, glide does not pick up 
+# client-go dependency for this package.
 - package: k8s.io/api
+  version: kubernetes-1.10.0
+# Version of k8s.io/apimachinery needs to be set to track the kubernetes 1.10.0 versions.
+# For some reason, glide does not pick up the client-go dependency for this package.
+- package: k8s.io/apimachinery
+  version: kubernetes-1.10.0
 - package: k8s.io/client-go
   version: v7.0.0
-# Version of k8s.io/code-generator set to commit id of release-1.10 branch
+# Version of k8s.io/code-generator needs to be set to track the kubernetes 1.10.0 versions.
 # Set it explicitly here because no obvious dependency info from k8s.io/client-go.
 - package: k8s.io/code-generator
-  version: 9de8e796a74d16d2a285165727d04c185ebca6dc
+  version: kubernetes-1.10.0
+# Version of k8s.io/gengo needs to be set current latest version.
 - package: k8s.io/gengo
   version: fdcf9f9480fdd5bf2b3c3df9bf4ecd22b25b87e2
 testImport:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
PR https://github.com/projectcalico/libcalico-go/pull/900 tried to leave k8s.io/api and k8s.io/apimachinery floating. For some reason, glide failed to pickup the correct dependency for api and apimachinery, when libcalico-go been imported by other package, e.g. typha. This PR set api and apimachinery version explicitly to work around this issue.
 
## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
