### PR TITLE
Makefile: Add a new target to check downstream projects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 build
+checkouts

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ junit.xml
 *.swp
 .generate_exes
 .generate_files
+checkouts

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ clean:
 	find . -name '*.coverprofile' -type f -delete
 	rm -rf vendor .go-pkg-cache
 	rm -rf $(BINDIR)
+	rm -rf checkouts
 
 .PHONY: clean-gen-files
 ## Convenience target for devs to remove generated files and related utilities
@@ -237,8 +238,27 @@ stop-etcd:
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean check-glide-warnings static-checks test
+ci: clean check-glide-warnings static-checks test build-libcalico-users
 
+# The list of repos that use libcalico (that support being tests in this way)
+LIBCALICO_REPOS=cni-plugin calicoctl typha kube-controllers
+
+# Checkout the repos into the "checkouts" directory
+DIRS := $(addprefix checkouts/,$(LIBCALICO_REPOS))
+$(DIRS):
+	@mkdir -p $(@D)
+	git clone -b master --single-branch git@github.com:projectcalico/$(@F).git $@
+
+## Build all projects that depend on libcalico-go using this version of libcalico-go
+build-libcalico-users: $(addsuffix -libcalico-build, $(DIRS))
+$(addsuffix -libcalico-build, $(DIRS)): %-libcalico-build: %
+	@export NEW_VER=$$(git rev-parse HEAD) ;\
+	cd $<; \
+	export OLD_VER=$$(grep --after 50 libcalico-go glide.yaml |grep --max-count=1 --only-matching --perl-regexp "version:\s*\K[\.0-9a-z]+") ;\
+	echo "Old: $$OLD_VER\nNew: $$NEW_VER";\
+	if [ $$NEW_VER != $$OLD_VER ]; then \
+		make clean; make update-libcalico build LIBCALICO_REPO=file:///libcalico-go LIBCALICO_VERSION=$$NEW_VER EXTRA_DOCKER_BIND="-v $(CURDIR):/libcalico-go";\
+	fi
 
 .PHONY: help
 ## Display this help text


### PR DESCRIPTION
Cheks out downstream projects, updates their glide pin and tries to
build them