### PR TITLE
Add FelixConfiguration for external nodes cidr list.

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -198,7 +198,11 @@ type FelixConfigurationSpec struct {
 
 	// NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
 	// network stack is used.
-	NATPortRange *numorstring.Port `json: natPortRange,omitempty`
+	NATPortRange *numorstring.Port `json:"natPortRange,omitempty"`
+
+	// ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes which may source tunnel traffic and have
+	// the tunneled traffic be accepted at calico nodes.
+	ExternalNodesCIDRList *[]string `json:"externalNodesList,omitempty"`
 
 	DebugMemoryProfilePath          string           `json:"debugMemoryProfilePath,omitempty"`
 	DebugDisableLogDropping         *bool            `json:"debugDisableLogDropping,omitempty"`

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -571,6 +571,15 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(numorstring.Port)
 		**out = **in
 	}
+	if in.ExternalNodesCIDRList != nil {
+		in, out := &in.ExternalNodesCIDRList, &out.ExternalNodesCIDRList
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
+	}
 	if in.DebugDisableLogDropping != nil {
 		in, out := &in.DebugDisableLogDropping, &out.DebugDisableLogDropping
 		*out = new(bool)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 53
+	numFelixConfigs := 54
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -545,6 +545,21 @@ func validateFelixConfigSpec(v *validator.Validate, structLevel *validator.Struc
 			}
 		}
 	}
+
+	// Validate that the externalNodesCIDRList is composed of valid cidr's.
+	if c.ExternalNodesCIDRList != nil {
+		for _, cidr := range *c.ExternalNodesCIDRList {
+			log.Debugf("Cidr is: %s", cidr)
+			ip, _, err := cnet.ParseCIDROrIP(cidr)
+			if err != nil {
+				structLevel.ReportError(reflect.ValueOf(cidr),
+					"ExternalNodesCIDRList", "", reason("has invalid CIDR(s)"))
+			} else if ip.Version() != 4 {
+				structLevel.ReportError(reflect.ValueOf(cidr),
+					"ExternalNodesCIDRList", "", reason("has invalid IPv6 CIDR"))
+			}
+		}
+	}
 }
 
 func validateWorkloadEndpointSpec(v *validator.Validate, structLevel *validator.StructLevel) {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -481,6 +481,10 @@ func init() {
 		Entry("should reject a named port KubeNodePortRanges value", api.FelixConfigurationSpec{KubeNodePortRanges: &[]numorstring.Port{
 			numorstring.NamedPort("testport"),
 		}}, false),
+		Entry("should accept a valid list of ExternalNodesCIDRList", api.FelixConfigurationSpec{ExternalNodesCIDRList: &[]string{"1.1.1.1", "1.1.1.2/32", "1.1.3.0/23"}},
+			true),
+		Entry("should reject an invalid list of ExternalNodesCIDRList", api.FelixConfigurationSpec{ExternalNodesCIDRList: &[]string{"foobar", "1.1.1.1"}}, false),
+		Entry("should reject IPv6 list of ExternalNodesCIDRList", api.FelixConfigurationSpec{ExternalNodesCIDRList: &[]string{"abcd::1", "abef::2/128"}}, false),
 
 		Entry("should reject an invalid LogSeverityScreen value 'badVal'", api.FelixConfigurationSpec{LogSeverityScreen: "badVal"}, false),
 		Entry("should reject an invalid LogSeverityFile value 'badVal'", api.FelixConfigurationSpec{LogSeverityFile: "badVal"}, false),


### PR DESCRIPTION
Add FelixConfiguration to set a list of CIDR's which may be used to originate tunneled traffic.