### PR TITLE
Make the list of string comma delimited.

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor.go
@@ -240,6 +240,9 @@ func (c *configUpdateProcessor) processAddOrModified(kvp *model.KVPair) ([]*mode
 					default:
 						value = fmt.Sprintf("%v", vt.Seconds())
 					}
+				case []string:
+					// Make a list of strings comma delimited
+					value = strings.Join(vt, ",")
 				default:
 					value = fmt.Sprintf("%v", vt)
 				}

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -213,6 +213,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 				Port:     65535,
 			},
 		}
+		res.Spec.ExternalNodesCIDRList = &[]string{"1.1.1.1", "2.2.2.2"}
 		expected := map[string]interface{}{
 			"RouteRefreshInterval":            "12.345",
 			"IptablesLockProbeIntervalMillis": "54.321",
@@ -223,6 +224,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 			"IptablesMarkMask":                "1313",
 			"FailsafeInboundHostPorts":        "none",
 			"FailsafeOutboundHostPorts":       "tcp:1234,udp:22,tcp:65535",
+			"ExternalNodesCIDRList":           "1.1.1.1,2.2.2.2",
 		}
 		kvps, err := cc.Process(&model.KVPair{
 			Key:   perNodeFelixKey,


### PR DESCRIPTION
To make the list of strings easily to parse and human friendly, render it as a comma delimited list in the backend.

cc: @fasaxc 