### PR TITLE
Write to pod status instead of pod

### DIFF
--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -101,7 +101,7 @@ func (c *WorkloadEndpointClient) patchPodIP(ctx context.Context, kvp *model.KVPa
 		log.WithError(err).Error("Failed to calculate Pod patch.")
 		return nil, err
 	}
-	pod, err := c.clientSet.CoreV1().Pods(ns).Patch(wepID.Pod, types.StrategicMergePatchType, patch)
+	pod, err := c.clientSet.CoreV1().Pods(ns).Patch(wepID.Pod, types.StrategicMergePatchType, patch, "status")
 	if err != nil {
 		return nil, K8sErrorToCalico(err, kvp.Key)
 	}


### PR DESCRIPTION
## Description
appends `"status"` as an arg to `Pod.Patch()` call on `WorkloadEndpointClient.patchPodIP` to ensure that the `PATCH` request is made to the `pods/status` sub-resource instead of `pod`

Addresses #888 

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note
```release-note
- #888 WorkloadEndpoints resource makes PATCH to pods/status instead of pods
```
