### PR TITLE
Revert "Allow underscore in containerID"

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -53,7 +53,7 @@ var (
 	// more restrictive naming requirements.
 	nameRegex = regexp.MustCompile("^" + nameSubdomainFmt + "$")
 
-	containerIDFmt   = "[a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?"
+	containerIDFmt   = "[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?"
 	containerIDRegex = regexp.MustCompile("^" + containerIDFmt + "$")
 
 	// NetworkPolicy names must either be a simple DNS1123 label format (nameLabelFmt), or

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -573,11 +573,6 @@ func init() {
 				InterfaceName: "cali012371237",
 				ContainerID:   "Cath01234-G",
 			}, true),
-		Entry("should accept workload endpoint with a non-leading underscore in the ContainerID",
-			api.WorkloadEndpointSpec{
-				InterfaceName: "cali012371237",
-				ContainerID:   "Cath01234_G",
-			}, true),
 		Entry("should reject workload endpoint with no config", api.WorkloadEndpointSpec{}, false),
 		Entry("should reject workload endpoint with IPv4 networks that contain >1 address",
 			api.WorkloadEndpointSpec{
@@ -610,11 +605,6 @@ func init() {
 			api.WorkloadEndpointSpec{
 				InterfaceName: "cali0134",
 				ContainerID:   "-abcdefg",
-			}, false),
-		Entry("should reject workload endpoint containerID that starts with an underscore",
-			api.WorkloadEndpointSpec{
-				InterfaceName: "cali0134",
-				ContainerID:   "_abcdefg",
 			}, false),
 		Entry("should reject workload endpoint containerID that ends with a dash",
 			api.WorkloadEndpointSpec{


### PR DESCRIPTION
Reverts projectcalico/libcalico-go#922