### PR TITLE
Don't process floating IPs when there isn't yet a pod IP

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -233,7 +233,7 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 
 	// Pull out floating IP annotation
 	var floatingIPs []apiv3.IPNAT
-	if annotation, ok := pod.Annotations["cni.projectcalico.org/floatingIPs"]; ok {
+	if annotation, ok := pod.Annotations["cni.projectcalico.org/floatingIPs"]; ok && len(ipNets) > 0 {
 
 		// Parse Annotation data
 		var ips []string


### PR DESCRIPTION
Following #781, PodToWorkloadEndpoint will panic if there is a floating
IP annotation on the pod, but not yet a pod IP.  In that case,

- GetPodIPs returns nil, nil

- PodToWorkloadEndpoint's new floating IP code expects that there will
  always be at least one element in GetPodIPs's first return value, if
  the second return value is not an error.

The reasonable thing to do is to skip floating IP processing when there
isn't yet a pod IP.