### PR TITLE
Allow the blockSize to be configured for Calico IPAM

### DIFF
--- a/lib/apis/v3/ippool.go
+++ b/lib/apis/v3/ippool.go
@@ -50,6 +50,9 @@ type IPPoolSpec struct {
 	// When disabled is true, Calico IPAM will not assign addresses from this pool.
 	Disabled bool `json:"disabled,omitempty"`
 
+	// The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+	BlockSize int `json:"blockSize,omitempty"`
+
 	// Deprecated: this field is only used for APIv1 backwards compatibility.
 	// Setting this field is not allowed, this field is for internal use only.
 	IPIP *apiv1.IPIPConfiguration `json:"ipip,omitempty" validate:"omitempty,mustBeNil"`

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -22,15 +22,13 @@ import (
 	"reflect"
 
 	"github.com/kelseyhightower/envconfig"
-	yaml "github.com/projectcalico/go-yaml-wrapper"
+	"github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v1"
 	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/libcalico-go/lib/ipam"
-	"github.com/projectcalico/libcalico-go/lib/net"
 	validator "github.com/projectcalico/libcalico-go/lib/validator/v1"
 	log "github.com/sirupsen/logrus"
 )
@@ -99,31 +97,6 @@ func (c *Client) WorkloadEndpoints() WorkloadEndpointInterface {
 // BGPPeers returns an interface for managing BGP peer resources.
 func (c *Client) BGPPeers() BGPPeerInterface {
 	return newBGPPeers(c)
-}
-
-// IPAM returns an interface for managing IP address assignment and releasing.
-func (c *Client) IPAM() ipam.Interface {
-	return ipam.NewIPAMClient(c.Backend, poolAccessor{})
-}
-
-type poolAccessor struct {
-	client *Client
-}
-
-func (p poolAccessor) GetEnabledPools(ipVersion int) ([]net.IPNet, error) {
-	pools, err := p.client.IPPools().List(api.IPPoolMetadata{})
-	if err != nil {
-		return nil, err
-	}
-	enabled := []net.IPNet{}
-	for _, pool := range pools.Items {
-		if pool.Spec.Disabled {
-			continue
-		} else {
-			enabled = append(enabled, pool.Metadata.CIDR)
-		}
-	}
-	return enabled, nil
 }
 
 // Config returns an interface for managing system configuration..

--- a/lib/client/ippool.go
+++ b/lib/client/ippool.go
@@ -15,8 +15,6 @@
 package client
 
 import (
-	"context"
-
 	api "github.com/projectcalico/libcalico-go/lib/apis/v1"
 	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -91,13 +89,6 @@ func (h *ipPools) Delete(metadata api.IPPoolMetadata) error {
 		if _, err := h.Update(pool); err != nil {
 			return err
 		}
-	}
-
-	// Now release pool affinities.
-	log.Debugf("Releasing affinities for pool %s", metadata.CIDR)
-	err := h.c.IPAM().ReleasePoolAffinities(context.Background(), metadata.CIDR)
-	if err != nil {
-		return err
 	}
 
 	// And finally, delete the pool.

--- a/lib/clientv3/client.go
+++ b/lib/clientv3/client.go
@@ -142,19 +142,19 @@ type poolAccessor struct {
 	client *client
 }
 
-func (p poolAccessor) GetEnabledPools(ipVersion int) ([]net.IPNet, error) {
+func (p poolAccessor) GetEnabledPools(ipVersion int) ([]*v3.IPPool, error) {
 	pools, err := p.client.IPPools().List(context.Background(), options.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	log.Debugf("Got list of all IPPools: %v", pools)
-	enabled := []net.IPNet{}
+	var enabled []*v3.IPPool
 	for _, pool := range pools.Items {
 		if pool.Spec.Disabled {
 			continue
 		} else if _, cidr, err := net.ParseCIDR(pool.Spec.CIDR); err == nil && cidr.Version() == ipVersion {
 			log.Debugf("Adding pool (%s) to the enabled IPPool list", cidr.String())
-			enabled = append(enabled, *cidr)
+			enabled = append(enabled, &pool)
 		} else if err != nil {
 			log.Warnf("Failed to parse the IPPool: %s. Ignoring that IPPool", pool.Spec.CIDR)
 		} else {

--- a/lib/clientv3/common_test.go
+++ b/lib/clientv3/common_test.go
@@ -37,8 +37,9 @@ var _ = testutils.E2eDatastoreDescribe("Common resource tests", testutils.Datast
 			ctx := context.Background()
 			name1 := "ippool-1"
 			spec1 := apiv3.IPPoolSpec{
-				CIDR:     "1.2.3.0/24",
-				IPIPMode: apiv3.IPIPModeAlways,
+				CIDR:      "1.2.3.0/24",
+				IPIPMode:  apiv3.IPIPModeAlways,
+				BlockSize: 26,
 			}
 			c, err := clientv3.New(config)
 			Expect(err).NotTo(HaveOccurred())

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -40,22 +40,26 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 	name1 := "ippool-1"
 	name2 := "ippool-2"
 	spec1 := apiv3.IPPoolSpec{
-		CIDR:     "1.2.3.0/24",
-		IPIPMode: apiv3.IPIPModeAlways,
+		CIDR:      "1.2.3.0/24",
+		IPIPMode:  apiv3.IPIPModeAlways,
+		BlockSize: 26,
 	}
 	spec1_2 := apiv3.IPPoolSpec{
 		CIDR:        "1.2.3.0/24",
 		NATOutgoing: true,
 		IPIPMode:    apiv3.IPIPModeNever,
+		BlockSize:   26,
 	}
 	spec2 := apiv3.IPPoolSpec{
 		CIDR:        "2001::/120",
 		NATOutgoing: true,
 		IPIPMode:    apiv3.IPIPModeNever,
+		BlockSize:   122,
 	}
 	spec2_1 := apiv3.IPPoolSpec{
-		CIDR:     "2001::/120",
-		IPIPMode: apiv3.IPIPModeNever,
+		CIDR:      "2001::/120",
+		IPIPMode:  apiv3.IPIPModeNever,
+		BlockSize: 122,
 	}
 
 	It("should error when creating an IPPool with no name", func() {

--- a/lib/clientv3/ippool_kdd_conversion_test.go
+++ b/lib/clientv3/ippool_kdd_conversion_test.go
@@ -74,6 +74,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 		CIDR:        "2001::/120",
 		NATOutgoing: true,
 		IPIPMode:    apiv3.IPIPModeNever,
+		BlockSize:   122,
 	}
 	kvp2 := &model.KVPair{
 		Key: model.ResourceKey{
@@ -92,6 +93,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 				CIDR:        "2001::/120",
 				Disabled:    false,
 				NATOutgoing: true,
+				BlockSize:   122,
 				IPIP: &apiv1.IPIPConfiguration{
 					Enabled: false,
 				},

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net"
 
+	"github.com/projectcalico/libcalico-go/lib/apis/v3"
 	log "github.com/sirupsen/logrus"
 
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
@@ -35,10 +36,10 @@ type blockReaderWriter struct {
 	pools  PoolAccessorInterface
 }
 
-func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ver ipVersion, pools []cnet.IPNet) ([]cnet.IPNet, error) {
+func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ver int, pools []*v3.IPPool) ([]cnet.IPNet, error) {
 	// Lookup all blocks by providing an empty BlockListOptions
 	// to the List operation.
-	opts := model.BlockAffinityListOptions{Host: host, IPVersion: ver.Number}
+	opts := model.BlockAffinityListOptions{Host: host, IPVersion: ver}
 	datastoreObjs, err := rw.client.List(ctx, opts, "")
 	if err != nil {
 		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
@@ -63,7 +64,13 @@ func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ve
 			ids = append(ids, k.CIDR)
 		} else {
 			for _, pool := range pools {
-				if pool.Contains(k.CIDR.IPNet.IP) {
+				_, poolNet, err := cnet.ParseCIDR(pool.Spec.CIDR)
+				if err != nil {
+					log.Errorf("Error parsing CIDR: %s from pool: %s %v", pool.Spec.CIDR, pool.Name, err)
+					return nil, err
+				}
+
+				if poolNet.Contains(k.CIDR.IPNet.IP) {
 					ids = append(ids, k.CIDR)
 					break
 				}
@@ -77,7 +84,7 @@ func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ve
 // should already be sanitized and only enclude existing, enabled pools. Note that the block may become claimed
 // between receiving the cidr from this function and attempting to claim the corresponding block as this function
 // does not reserve the returned IPNet.
-func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string, version ipVersion, pools []cnet.IPNet, config IPAMConfig) (*cnet.IPNet, error) {
+func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string, version int, pools []*v3.IPPool, config IPAMConfig) (*cnet.IPNet, error) {
 	// If there are no pools, we cannot assign addresses.
 	if len(pools) == 0 {
 		return nil, errors.New("no configured Calico pools")
@@ -106,22 +113,6 @@ func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string,
 		}
 	}
 	return nil, noFreeBlocksError("No Free Blocks")
-}
-
-// isPoolInRequestedPools checks if the IP Pool that is passed in belongs to the list of IP Pools
-// that should be used for assigning IPs from.
-func isPoolInRequestedPools(pool cnet.IPNet, requestedPools []cnet.IPNet) bool {
-	if len(requestedPools) == 0 {
-		return true
-	}
-	// Compare the requested pools against the actual pool CIDR.  Note that we don't use deep equals
-	// because golang interchangeably seems to use 4-byte and 16-byte representations of IPv4 addresses.
-	for _, cidr := range requestedPools {
-		if pool.String() == cidr.String() {
-			return true
-		}
-	}
-	return false
 }
 
 // getPendingAffinity claims a pending affinity for the given host and subnet. The affinity can then
@@ -341,32 +332,44 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, host strin
 	return nil
 }
 
-// withinConfiguredPools returns true if the given IP is within a configured
-// Calico pool, and false otherwise.
-func (rw blockReaderWriter) withinConfiguredPools(ip cnet.IP) bool {
+// getPoolForIP returns the pool if the given IP is within a configured
+// Calico pool, and nil otherwise.
+func (rw blockReaderWriter) getPoolForIP(ip cnet.IP) *v3.IPPool {
 	enabledPools, _ := rw.pools.GetEnabledPools(ip.Version())
 	for _, p := range enabledPools {
 		// Compare any enabled pools.
-		if p.Contains(ip.IP) {
-			return true
+		_, pool, err := cnet.ParseCIDR(p.Spec.CIDR)
+		if err == nil && pool.Contains(ip.IP) {
+			return p
 		}
 	}
-	return false
+	return nil
 }
 
 // Generator to get list of block CIDRs which
-// fall within the given pool. Returns nil when no more
-// blocks can be generated.
-func blockGenerator(pool cnet.IPNet) func() *cnet.IPNet {
-	// Determine the IP type to use.
-	version := getIPVersion(cnet.IP{pool.IP})
-	ip := cnet.IP{pool.IP}
+// fall within the given cidr. The passed in pool
+// must contain the passed in block cidr.
+// Returns nil when no more blocks can be generated.
+func blockGenerator(pool *v3.IPPool, cidr cnet.IPNet) func() *cnet.IPNet {
+	ip := cnet.IP{IP: cidr.IP}
+
+	var blockMask net.IPMask
+	if ip.Version() == 4 {
+		blockMask = net.CIDRMask(pool.Spec.BlockSize, 32)
+	} else {
+		blockMask = net.CIDRMask(pool.Spec.BlockSize, 128)
+	}
+
+	ones, size := blockMask.Size()
+	blockSize := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(size-ones)), nil)
+
 	return func() *cnet.IPNet {
 		returnIP := ip
-		if pool.Contains(ip.IP) {
-			ipnet := net.IPNet{returnIP.IP, version.BlockPrefixMask}
-			cidr := cnet.IPNet{ipnet}
-			ip = incrementIP(ip, big.NewInt(blockSize))
+
+		if cidr.Contains(ip.IP) {
+			ipnet := net.IPNet{IP: returnIP.IP, Mask: blockMask}
+			cidr := cnet.IPNet{IPNet: ipnet}
+			ip = incrementIP(ip, blockSize)
 			return &cidr
 		} else {
 			return nil
@@ -377,18 +380,32 @@ func blockGenerator(pool cnet.IPNet) func() *cnet.IPNet {
 // Returns a generator that, when called, returns a random
 // block from the given pool.  When there are no blocks left,
 // the it returns nil.
-func randomBlockGenerator(pool cnet.IPNet, hostName string) func() *cnet.IPNet {
+func randomBlockGenerator(ipPool *v3.IPPool, hostName string) func() *cnet.IPNet {
+	_, pool, err := cnet.ParseCIDR(ipPool.Spec.CIDR)
+	if err != nil {
+		log.Errorf("Error parsing CIDR: %s %v", ipPool.Spec.CIDR, err)
+		return func() *cnet.IPNet { return nil }
+	}
 
 	// Determine the IP type to use.
-	version := getIPVersion(cnet.IP{pool.IP})
-	baseIP := cnet.IP{pool.IP}
+	baseIP := cnet.IP{IP: pool.IP}
+	version := getIPVersion(baseIP)
+	var blockMask net.IPMask
+	if version == 4 {
+		blockMask = net.CIDRMask(ipPool.Spec.BlockSize, 32)
+	} else {
+		blockMask = net.CIDRMask(ipPool.Spec.BlockSize, 128)
+	}
 
 	// Determine the number of blocks within this pool.
 	ones, size := pool.Mask.Size()
-	prefixLen := size - ones
-	numIP := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(prefixLen)), nil)
+	numIP := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(size-ones)), nil)
+
+	ones, size = blockMask.Size()
+	blockSize := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(size-ones)), nil)
+
 	numBlocks := new(big.Int)
-	numBlocks.Div(numIP, big.NewInt(blockSize))
+	numBlocks.Div(numIP, blockSize)
 
 	// Create a random number generator seed based on the hostname.
 	// This is to avoid assigning multiple blocks when multiple
@@ -414,8 +431,9 @@ func randomBlockGenerator(pool cnet.IPNet, hostName string) func() *cnet.IPNet {
 	return func() *cnet.IPNet {
 		// The `big.NewInt(0)` part creates a temp variable and assigns the result of multiplication of `i` and `big.NewInt(blockSize)`
 		// Note: we are not using `i.Mul()` because that will assign the result of the multiplication to `i`, which will cause unexpected issues
-		ip := incrementIP(baseIP, big.NewInt(0).Mul(i, big.NewInt(blockSize)))
-		ipnet := net.IPNet{ip.IP, version.BlockPrefixMask}
+		ip := incrementIP(baseIP, big.NewInt(0).Mul(i, blockSize))
+
+		ipnet := net.IPNet{ip.IP, blockMask}
 
 		numDiff.Sub(numBlocks, i)
 
@@ -439,4 +457,28 @@ func randomBlockGenerator(pool cnet.IPNet, hostName string) func() *cnet.IPNet {
 		// Return the block from this pool that corresponds with the index.
 		return &cnet.IPNet{ipnet}
 	}
+}
+
+// Find the block for a given IP (without needing a pool)
+func (rw blockReaderWriter) getBlockForIP(ctx context.Context, ip cnet.IP) (*cnet.IPNet, error) {
+	// Lookup all blocks by providing an empty BlockListOptions to the List operation.
+	opts := model.BlockListOptions{IPVersion: ip.Version()}
+	datastoreObjs, err := rw.client.List(ctx, opts, "")
+	if err != nil {
+		log.Errorf("Error getting affine blocks: %v", err)
+		return nil, err
+	}
+
+	// Iterate through and extract the block CIDRs.
+	for _, o := range datastoreObjs.KVPairs {
+		k := o.Key.(model.BlockKey)
+		if k.CIDR.IPNet.Contains(ip.IP) {
+			log.Debugf("Found IP %s in block %s", ip.String(), k.String())
+			return &k.CIDR, nil
+		}
+	}
+
+	// No blocks found.
+	log.Debugf("IP %s could not be found in any blocks", ip.String())
+	return nil, nil
 }

--- a/lib/ipam/ipam_block_reader_writer_test.go
+++ b/lib/ipam/ipam_block_reader_writer_test.go
@@ -184,7 +184,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						defer GinkgoRecover()
 
 						testhost := fmt.Sprintf("host-%d", j)
-						ips, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, ipv4, testhost)
+						ips, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, 4, testhost)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)
 							testErr = err
@@ -270,7 +270,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						defer GinkgoRecover()
 
 						testhost := "single-host"
-						ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, ipv4, testhost)
+						ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, testhost)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)
 							testErr = err
@@ -659,7 +659,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			}
 
 			By("attempting to claim the block on multiple hosts at the same time", func() {
-				ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, ipv4, hostA)
+				ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, hostA)
 
 				// Shouldn't return an error.
 				Expect(err).NotTo(HaveOccurred())
@@ -689,7 +689,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			})
 
 			By("attempting to claim another address", func() {
-				ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, ipv4, hostA)
+				ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, hostA)
 
 				// Shouldn't return an error.
 				Expect(err).NotTo(HaveOccurred())

--- a/lib/ipam/pools.go
+++ b/lib/ipam/pools.go
@@ -13,10 +13,10 @@
 // limitations under the License.
 package ipam
 
-import cnet "github.com/projectcalico/libcalico-go/lib/net"
+import "github.com/projectcalico/libcalico-go/lib/apis/v3"
 
 // Interface used to access the enabled IPPools.
 type PoolAccessorInterface interface {
 	// Returns a list of enabled pools sorted in alphanumeric name order.
-	GetEnabledPools(ipVersion int) ([]cnet.IPNet, error)
+	GetEnabledPools(ipVersion int) ([]*v3.IPPool, error)
 }

--- a/lib/validator/v3/doc.go
+++ b/lib/validator/v3/doc.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
-Package validator implements common field and structure validation that is
+Package v3 implements common field and structure validation that is
 used to validate the API structures supplied on the client interface, and
 is also used internally to validate the information stored in the backend
 datastore.

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"strings"
 
-	validator "gopkg.in/go-playground/validator.v8"
+	"gopkg.in/go-playground/validator.v8"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,8 +72,6 @@ var (
 	dropAcceptReturnRegex = regexp.MustCompile("^(Drop|Accept|Return)$")
 	acceptReturnRegex     = regexp.MustCompile("^(Accept|Return)$")
 	reasonString          = "Reason: "
-	poolSmallIPv4         = "IP pool size is too small (min /26) for use with Calico IPAM"
-	poolSmallIPv6         = "IP pool size is too small (min /122) for use with Calico IPAM"
 	poolUnstictCIDR       = "IP pool CIDR is not strictly masked"
 	overlapsV4LinkLocal   = "IP pool range overlaps with IPv4 Link Local range 169.254.0.0/16"
 	overlapsV6LinkLocal   = "IP pool range overlaps with IPv6 Link Local range fe80::/10"
@@ -468,7 +466,7 @@ func validateHTTPPaths(paths []api.HTTPPath) error {
 
 func validateHTTPRule(v *validator.Validate, structLevel *validator.StructLevel) {
 	h := structLevel.CurrentStruct.Interface().(api.HTTPMatch)
-	log.Debug("Validate HTTP Rule: %v", h)
+	log.Debugf("Validate HTTP Rule: %v", h)
 	if err := validateHTTPMethods(h.Methods); err != nil {
 		structLevel.ReportError(reflect.ValueOf(h.Methods), "Methods", "", reason(err.Error()))
 	}
@@ -680,19 +678,23 @@ func validateIPPoolSpec(v *validator.Validate, structLevel *validator.StructLeve
 			"IPpool.IPIPMode", "", reason("IPIPMode other than 'Never' is not supported on an IPv6 IP pool"))
 	}
 
+	// Default the blockSize
+	if pool.BlockSize == 0 {
+		if ipAddr.Version() == 4 {
+			pool.BlockSize = 26
+		} else {
+			pool.BlockSize = 122
+		}
+	}
+
 	// The Calico IPAM places restrictions on the minimum IP pool size.  If
 	// the ippool is enabled, check that the pool is at least the minimum size.
 	if !pool.Disabled {
-		ones, bits := cidr.Mask.Size()
-		log.Debugf("Pool CIDR: %s, num bits: %d", cidr.String(), bits-ones)
-		if bits-ones < 6 {
-			if cidr.Version() == 4 {
-				structLevel.ReportError(reflect.ValueOf(pool.CIDR),
-					"IPpool.CIDR", "", reason(poolSmallIPv4))
-			} else {
-				structLevel.ReportError(reflect.ValueOf(pool.CIDR),
-					"IPpool.CIDR", "", reason(poolSmallIPv6))
-			}
+		ones, _ := cidr.Mask.Size()
+		log.Debugf("Pool CIDR: %s, mask: %d, blockSize: %d", cidr.String(), ones, pool.BlockSize)
+		if ones > pool.BlockSize {
+			structLevel.ReportError(reflect.ValueOf(pool.CIDR),
+				"IPpool.CIDR", "", reason("IP pool size is too small for use with Calico IPAM. It must be equal to or greater than the block size."))
 		}
 	}
 


### PR DESCRIPTION
Allow the blockSize to be configured for Calico IPAM.
    
This removes the current fixed block size of /26 (for ipv4) or /122 (for IPv6).
The previous fixed values, now just become defaults.
    
The block size can be set per-pool, but once set it can't be changed.
```release-note
New Feature: Allow the blockSize to be configured for Calico IPAM.
```