### PR TITLE
Bug Fix: Stop using pointers for IPPools in IPAM

### DIFF
--- a/lib/clientv3/client.go
+++ b/lib/clientv3/client.go
@@ -142,19 +142,19 @@ type poolAccessor struct {
 	client *client
 }
 
-func (p poolAccessor) GetEnabledPools(ipVersion int) ([]*v3.IPPool, error) {
+func (p poolAccessor) GetEnabledPools(ipVersion int) ([]v3.IPPool, error) {
 	pools, err := p.client.IPPools().List(context.Background(), options.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	log.Debugf("Got list of all IPPools: %v", pools)
-	var enabled []*v3.IPPool
+	var enabled []v3.IPPool
 	for _, pool := range pools.Items {
 		if pool.Spec.Disabled {
 			continue
 		} else if _, cidr, err := net.ParseCIDR(pool.Spec.CIDR); err == nil && cidr.Version() == ipVersion {
 			log.Debugf("Adding pool (%s) to the enabled IPPool list", cidr.String())
-			enabled = append(enabled, &pool)
+			enabled = append(enabled, pool)
 		} else if err != nil {
 			log.Warnf("Failed to parse the IPPool: %s. Ignoring that IPPool", pool.Spec.CIDR)
 		} else {

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -199,7 +199,7 @@ func (c ipamClient) getBlockFromAffinity(ctx context.Context, aff *model.KVPair)
 // determinePools compares a list of requested pools with the enabled pools
 // and returns the intersect. If any requested pool does not exist, or is not enabled, an error is returned.
 // If no pools are requested, all enabled pools are returned.
-func (c ipamClient) determinePools(requestedPoolNets []net.IPNet, version int) ([]*v3.IPPool, error) {
+func (c ipamClient) determinePools(requestedPoolNets []net.IPNet, version int) ([]v3.IPPool, error) {
 	enabledPools, err := c.pools.GetEnabledPools(version)
 	if err != nil {
 		log.WithError(err).Errorf("Error reading configured pools")
@@ -210,7 +210,7 @@ func (c ipamClient) determinePools(requestedPoolNets []net.IPNet, version int) (
 	if len(requestedPoolNets) > 0 {
 		log.Debugf("requested IPPools: %v", requestedPoolNets)
 		// Build a map so we can lookup existing pools.
-		pm := map[string]*v3.IPPool{}
+		pm := map[string]v3.IPPool{}
 		for _, p := range enabledPools {
 			pm[p.Spec.CIDR] = p
 		}

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -36,7 +36,7 @@ type blockReaderWriter struct {
 	pools  PoolAccessorInterface
 }
 
-func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ver int, pools []*v3.IPPool) ([]cnet.IPNet, error) {
+func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ver int, pools []v3.IPPool) ([]cnet.IPNet, error) {
 	// Lookup all blocks by providing an empty BlockListOptions
 	// to the List operation.
 	opts := model.BlockAffinityListOptions{Host: host, IPVersion: ver}
@@ -84,7 +84,7 @@ func (rw blockReaderWriter) getAffineBlocks(ctx context.Context, host string, ve
 // should already be sanitized and only enclude existing, enabled pools. Note that the block may become claimed
 // between receiving the cidr from this function and attempting to claim the corresponding block as this function
 // does not reserve the returned IPNet.
-func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string, version int, pools []*v3.IPPool, config IPAMConfig) (*cnet.IPNet, error) {
+func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string, version int, pools []v3.IPPool, config IPAMConfig) (*cnet.IPNet, error) {
 	// If there are no pools, we cannot assign addresses.
 	if len(pools) == 0 {
 		return nil, errors.New("no configured Calico pools")
@@ -340,7 +340,7 @@ func (rw blockReaderWriter) getPoolForIP(ip cnet.IP) *v3.IPPool {
 		// Compare any enabled pools.
 		_, pool, err := cnet.ParseCIDR(p.Spec.CIDR)
 		if err == nil && pool.Contains(ip.IP) {
-			return p
+			return &p
 		}
 	}
 	return nil
@@ -380,7 +380,7 @@ func blockGenerator(pool *v3.IPPool, cidr cnet.IPNet) func() *cnet.IPNet {
 // Returns a generator that, when called, returns a random
 // block from the given pool.  When there are no blocks left,
 // the it returns nil.
-func randomBlockGenerator(ipPool *v3.IPPool, hostName string) func() *cnet.IPNet {
+func randomBlockGenerator(ipPool v3.IPPool, hostName string) func() *cnet.IPNet {
 	_, pool, err := cnet.ParseCIDR(ipPool.Spec.CIDR)
 	if err != nil {
 		log.Errorf("Error parsing CIDR: %s %v", ipPool.Spec.CIDR, err)

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -43,7 +43,7 @@ type ipPoolAccessor struct {
 	pools map[string]bool
 }
 
-func (i *ipPoolAccessor) GetEnabledPools(ipVersion int) ([]*v3.IPPool, error) {
+func (i *ipPoolAccessor) GetEnabledPools(ipVersion int) ([]v3.IPPool, error) {
 	sorted := make([]string, 0)
 	// Get a sorted list of enabled pool CIDR strings.
 	for p, e := range i.pools {
@@ -56,11 +56,11 @@ func (i *ipPoolAccessor) GetEnabledPools(ipVersion int) ([]*v3.IPPool, error) {
 	// Convert to IPNets and sort out the correct IP versions.  Sorting the results
 	// mimics more closely the behavior of etcd and allows the tests to be
 	// deterministic.
-	pools := make([]*v3.IPPool, 0)
+	pools := make([]v3.IPPool, 0)
 	for _, p := range sorted {
 		c := cnet.MustParseCIDR(p)
 		if c.Version() == ipVersion {
-			pool := &v3.IPPool{Spec: v3.IPPoolSpec{CIDR: p}}
+			pool := v3.IPPool{Spec: v3.IPPoolSpec{CIDR: p}}
 			if ipVersion == 4 {
 				pool.Spec.BlockSize = 26
 			} else {

--- a/lib/ipam/pools.go
+++ b/lib/ipam/pools.go
@@ -18,5 +18,5 @@ import "github.com/projectcalico/libcalico-go/lib/apis/v3"
 // Interface used to access the enabled IPPools.
 type PoolAccessorInterface interface {
 	// Returns a list of enabled pools sorted in alphanumeric name order.
-	GetEnabledPools(ipVersion int) ([]*v3.IPPool, error)
+	GetEnabledPools(ipVersion int) ([]v3.IPPool, error)
 }

--- a/lib/ipam/randomblock_test.go
+++ b/lib/ipam/randomblock_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Random Block Generator", func() {
 })
 
 func poolTest(cidr string, blockSize int) {
-	pools := []*v3.IPPool{{Spec: v3.IPPoolSpec{CIDR: cidr, BlockSize: blockSize}}}
+	pools := []v3.IPPool{{Spec: v3.IPPoolSpec{CIDR: cidr, BlockSize: blockSize}}}
 	host := "testHost"
 
 	_, pool, err := net.ParseCIDR(cidr)


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

Fix a bug hit when filtering a slice and storing the result in a slice
of pointers.
The pointer that was being stored was the iteraction variable instead of
to the original data value.

The fix is to switch the code to using values instead of pointers as it
makes it harder to make this sort of mistake.