### PR TITLE
Bug Fix: List IPPools not defaulting blocksize properly

### DIFF
--- a/lib/clientv3/ippool.go
+++ b/lib/clientv3/ippool.go
@@ -242,8 +242,8 @@ func (r ipPools) List(ctx context.Context, opts options.ListOptions) (*apiv3.IPP
 	}
 
 	// Default values when reading from backend.
-	for _, pool := range res.Items {
-		convertIpPoolFromStorage(&pool)
+	for i := range res.Items {
+		convertIpPoolFromStorage(&res.Items[i])
 	}
 
 	return res, nil

--- a/lib/clientv3/ippool_kdd_conversion_test.go
+++ b/lib/clientv3/ippool_kdd_conversion_test.go
@@ -44,6 +44,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 		CIDR:        "1.2.3.0/24",
 		NATOutgoing: true,
 		IPIPMode:    apiv3.IPIPModeCrossSubnet,
+		BlockSize:   26,
 	}
 	kvp1 := &model.KVPair{
 		Key: model.ResourceKey{
@@ -66,6 +67,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 					Enabled: true,
 					Mode:    ipip.CrossSubnet,
 				},
+				BlockSize: 26,
 			},
 		},
 	}
@@ -105,6 +107,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 		CIDR:        "1.1.1.0/24",
 		NATOutgoing: false,
 		IPIPMode:    apiv3.IPIPModeAlways,
+		BlockSize:   26,
 	}
 	kvp3 := &model.KVPair{
 		Key: model.ResourceKey{
@@ -125,6 +128,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 				IPIP: &apiv1.IPIPConfiguration{
 					Enabled: true,
 				},
+				BlockSize: 26,
 			},
 		},
 	}
@@ -133,6 +137,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 		CIDR:        "1.2.3.0/24",
 		NATOutgoing: true,
 		IPIPMode:    apiv3.IPIPModeAlways,
+		BlockSize:   26,
 	}
 	kvp5 := &model.KVPair{
 		Key: model.ResourceKey{
@@ -156,6 +161,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 				},
 				NATOutgoing:   true,
 				NATOutgoingV1: false,
+				BlockSize:     26,
 			},
 		},
 	}
@@ -164,6 +170,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 		CIDR:        "1.2.3.0/24",
 		NATOutgoing: true,
 		IPIPMode:    apiv3.IPIPModeCrossSubnet,
+		BlockSize:   26,
 	}
 	kvp6 := &model.KVPair{
 		Key: model.ResourceKey{
@@ -185,6 +192,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 				IPIP:          nil,
 				NATOutgoing:   false,
 				NATOutgoingV1: true,
+				BlockSize:     26,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

This affects upgrades from previous versions and was hit when trying to
allocate an IP (post upgrade) using CNI calico-ipam plugin.

I can't work out how to write an automated tests for this so I manually
tested it:

Against a blank etcd, I ran (using an old version pre-blocksize version
of calicoctl)
$ calicoctl apply -f ippool-noblock.yml
Successfully applied 1 'IPPool' resource(s)
$ ETCDCTL_API=3 etcdctl get /calico/resources/v3/projectcalico.org/ippools/my.ippool
/calico/resources/v3/projectcalico.org/ippools/my.ippool
{"kind":"IPPool","apiVersion":"projectcalico.org/v3","metadata":{"name":"my.ippool","uid":"575d6752-ce47-11e8-8a72-9cb6d089a923","creationTimestamp":"2018-10-12T17:50:43Z"},"spec":{"cidr":"192.168.0.0/24","ipipMode":"Never"}}

Then ran a CNI plugin without the fix, and then with the fix to verify
that it worked.
$ cat test.json | CNI_PATH=/tmp CNI_NETNS=/tmp CNI_IFNAME=eth0 CNI_COMMAND=ADD CNI_CONTAINERID=tom bin/amd64/calico-ipam
$ cat test.json
       │ File: test.json
   1   │ {
   2   │   "cniVersion": "0.2.0",
   3   │   "name": "net1",
   4   │   "type": "calico",
   5   │   "log_level": "DEBUG",
   6   │   "etcd_endpoints": "http://127.0.0.1:2379",
   7   │   "ipam": {
   8   │     "type": "calico-ipam",
   9   │     "subnet": "192.168.0.0/24"
  10   │   }
  11   │ }
  12   │

Without the fix I got:
{
    "code": 100,
    "msg": "failed to request 1 IPv4 addresses. IPAM allocated only 0"
}

With the fix I got:
{
    "cniVersion": "0.2.0",
    "ip4": {
        "ip": "192.168.0.192/32"
    },
    "dns": {}
}