### PR TITLE
Remove CI doing make update-libcalico in other repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,27 +244,7 @@ stop-etcd:
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean check-glide-warnings static-checks test build-libcalico-users
-
-# The list of repos that use libcalico (that support being tests in this way)
-LIBCALICO_REPOS=cni-plugin calicoctl typha kube-controllers
-
-# Checkout the repos into the "checkouts" directory
-DIRS := $(addprefix checkouts/,$(LIBCALICO_REPOS))
-$(DIRS):
-	@mkdir -p $(@D)
-	git clone -b master --single-branch git@github.com:projectcalico/$(@F).git $@
-
-## Build all projects that depend on libcalico-go using this version of libcalico-go
-build-libcalico-users: $(addsuffix -libcalico-build, $(DIRS))
-$(addsuffix -libcalico-build, $(DIRS)): %-libcalico-build: %
-	@export NEW_VER=$$(git rev-parse HEAD) ;\
-	cd $<; \
-	export OLD_VER=$$(grep --after 50 libcalico-go glide.yaml |grep --max-count=1 --only-matching --perl-regexp "version:\s*\K[\.0-9a-z]+") ;\
-	echo "Old: $$OLD_VER\nNew: $$NEW_VER";\
-	if [ $$NEW_VER != $$OLD_VER ]; then \
-		make clean; make update-libcalico build LIBCALICO_REPO=file:///libcalico-go LIBCALICO_VERSION=$$NEW_VER EXTRA_DOCKER_BIND="-v $(CURDIR):/libcalico-go";\
-	fi
+ci: clean check-glide-warnings static-checks test
 
 .PHONY: help
 ## Display this help text


### PR DESCRIPTION
I think this was a useful exploration of how far our CI could go, but
indications now are that it was a bit too far, and is hurting us more
than it helps.

- It should be good enough for libcalico-go CI that it passes its own
  tests.

- In principle, if an update in libcalico-go causes a problem in a
  downstream repo, we can't automatically say if that is a problem here
  or in the other repo, so it doesn't make sense to fail libcalico-go's
  CI.  Actually it's normal that downstream repos may need code updates
  when they take a new rev of libcalico-go, because we intentionally do
  not try to maintain a compatible libcalico-go "API".

- When a glide issue requires a change in a downstream repo, we get into
  a weird situation where we have to _merge_ a change to the downstream
  repo in order to fix _this_ repo's CI, and there's no way of testing
  that that _will_ fix this repo's CI before pushing a change to the
  downstream repo.

- It causes a libcalico-go CI run to take much longer, which is bad for
  a component that is so central to us.

So let's remove this.  Then what will happen instead - when there is an
actual problem - is that the Semaphore-triggered automatic updates, on
each downstream repo, will report failure, and we just need to keep our
eyes open for that.
