### PR TITLE
Cleanup tests

### DIFF
--- a/lib/backend/etcd/etcd_suite_test.go
+++ b/lib/backend/etcd/etcd_suite_test.go
@@ -18,12 +18,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
-
 	"github.com/onsi/ginkgo/reporters"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"testing"
 )
 
 func TestEtcd(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../report/etcd_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Etcd Suite", []Reporter{junitReporter})

--- a/lib/backend/etcd/etcd_suite_test.go
+++ b/lib/backend/etcd/etcd_suite_test.go
@@ -18,9 +18,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"testing"
+
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
-	"testing"
 )
 
 func TestEtcd(t *testing.T) {

--- a/lib/backend/etcdv3/etcdv3_suite_test.go
+++ b/lib/backend/etcdv3/etcdv3_suite_test.go
@@ -21,9 +21,11 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 func TestEtcd(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../report/etcdv3_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "EtcdV3 Suite", []Reporter{junitReporter})

--- a/lib/backend/k8s/conversion/conversion_suite_test.go
+++ b/lib/backend/k8s/conversion/conversion_suite_test.go
@@ -17,6 +17,7 @@ package conversion_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 )
 
 func TestConversion(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../../report/conversion_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Conversion Suite", []Reporter{junitReporter})

--- a/lib/backend/k8s/k8s_suite_test.go
+++ b/lib/backend/k8s/k8s_suite_test.go
@@ -27,6 +27,6 @@ import (
 func TestModel(t *testing.T) {
 	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("../../../report/model_suite.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Model Suite", []Reporter{junitReporter})
+	junitReporter := reporters.NewJUnitReporter("../../../report/kdd_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "KDD Suite", []Reporter{junitReporter})
 }

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 
 	log "github.com/sirupsen/logrus"
 
@@ -295,7 +296,7 @@ func CreateClientAndSyncer(cfg apiconfig.KubeConfig) (*KubeClient, *cb, api.Sync
 	return c.(*KubeClient), &callback, syncer
 }
 
-var _ = Describe("Test Syncer API for Kubernetes backend", func() {
+var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend", testutils.DatastoreK8s, func(cfg apiconfig.CalicoAPIConfig) {
 	var (
 		c      *KubeClient
 		cb     *cb
@@ -1779,7 +1780,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 	})
 })
 
-var _ = Describe("Test Watch support", func() {
+var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.DatastoreK8s, func(cfg apiconfig.CalicoAPIConfig) {
 	var (
 		c   *KubeClient
 		ctx context.Context
@@ -1787,8 +1788,7 @@ var _ = Describe("Test Watch support", func() {
 
 	BeforeEach(func() {
 		// Create a client
-		cfg := apiconfig.CalicoAPIConfigSpec{KubeConfig: apiconfig.KubeConfig{K8sAPIEndpoint: "http://localhost:8080"}}
-		client, err := NewKubeClient(&cfg)
+		client, err := NewKubeClient(&cfg.Spec)
 		Expect(err).NotTo(HaveOccurred())
 		c = client.(*KubeClient)
 

--- a/lib/backend/model/model_suite_test.go
+++ b/lib/backend/model/model_suite_test.go
@@ -17,6 +17,7 @@ package model_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 )
 
 func TestModel(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../report/model_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Model Suite", []Reporter{junitReporter})

--- a/lib/client/client_suite_test.go
+++ b/lib/client/client_suite_test.go
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package backend_test
+package client
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-func TestBackend(t *testing.T) {
+func TestClient(t *testing.T) {
 	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("../../report/backend_suite.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Backend Suite", []Reporter{junitReporter})
+	junitReporter := reporters.NewJUnitReporter("../../report/client_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Client Suite", []Reporter{junitReporter})
 }

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -91,19 +91,19 @@ kind: notCalicoApiConfig
 
 	// Environments to test ETCD parameters
 	env1 := map[string]string{
-		"ETCD_ENDPOINTS":    "https://1.2.3.4:1234,https://10.20.30.40:1234",
-		"ETCD_USERNAME":     "bar",
-		"ETCD_PASSWORD":     "baz",
-		"ETCD_KEY_FILE":     "foo",
-		"ETCD_CERT_FILE":    "foobar",
-		"ETCD_CA_CERT_FILE": "foobarbaz",
+		"APIV1_ETCD_ENDPOINTS":    "https://1.2.3.4:1234,https://10.20.30.40:1234",
+		"APIV1_ETCD_USERNAME":     "bar",
+		"APIV1_ETCD_PASSWORD":     "baz",
+		"APIV1_ETCD_KEY_FILE":     "foo",
+		"APIV1_ETCD_CERT_FILE":    "foobar",
+		"APIV1_ETCD_CA_CERT_FILE": "foobarbaz",
 	}
 	cfg1env := api.NewCalicoAPIConfig()
 	cfg1env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
 		EtcdConfig: api.EtcdConfig{
-			EtcdScheme:     "http",
-			EtcdAuthority:  "127.0.0.1:2379",
+			EtcdScheme:     "",
+			EtcdAuthority:  "",
 			EtcdEndpoints:  "https://1.2.3.4:1234,https://10.20.30.40:1234",
 			EtcdUsername:   "bar",
 			EtcdPassword:   "baz",
@@ -115,20 +115,20 @@ kind: notCalicoApiConfig
 
 	// Environments to test k8s parameters
 	env2 := map[string]string{
-		"DATASTORE_TYPE":   string(api.Kubernetes),
-		"KUBECONFIG":       "filename",
-		"K8S_API_ENDPOINT": "bar1",
-		"K8S_CERT_FILE":    "baz1",
-		"K8S_KEY_FILE":     "foo1",
-		"K8S_CA_FILE":      "foobar1",
-		"K8S_API_TOKEN":    "foobarbaz1",
+		"APIV1_DATASTORE_TYPE":   string(api.Kubernetes),
+		"APIV1_KUBECONFIG":       "filename",
+		"APIV1_K8S_API_ENDPOINT": "bar1",
+		"APIV1_K8S_CERT_FILE":    "baz1",
+		"APIV1_K8S_KEY_FILE":     "foo1",
+		"APIV1_K8S_CA_FILE":      "foobar1",
+		"APIV1_K8S_API_TOKEN":    "foobarbaz1",
 	}
 	cfg2env := api.NewCalicoAPIConfig()
 	cfg2env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.Kubernetes,
 		EtcdConfig: api.EtcdConfig{
-			EtcdScheme:    "http",
-			EtcdAuthority: "127.0.0.1:2379",
+			EtcdScheme:    "",
+			EtcdAuthority: "",
 		},
 		KubeConfig: api.KubeConfig{
 			Kubeconfig:     "filename",
@@ -142,15 +142,15 @@ kind: notCalicoApiConfig
 
 	// Environments should work with CALICO_ prefix too.
 	env3 := map[string]string{
-		"CALICO_ETCD_AUTHORITY": "123.123.123.123:2344",
-		"CALICO_ETCD_USERNAME":  "userbar",
-		"CALICO_ETCD_PASSWORD":  "passbaz",
+		"CALICO_APIV1_ETCD_AUTHORITY": "123.123.123.123:2344",
+		"CALICO_APIV1_ETCD_USERNAME":  "userbar",
+		"CALICO_APIV1_ETCD_PASSWORD":  "passbaz",
 	}
 	cfg3env := api.NewCalicoAPIConfig()
 	cfg3env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.EtcdV2,
 		EtcdConfig: api.EtcdConfig{
-			EtcdScheme:    "http",
+			EtcdScheme:    "",
 			EtcdAuthority: "123.123.123.123:2344",
 			EtcdUsername:  "userbar",
 			EtcdPassword:  "passbaz",
@@ -159,16 +159,16 @@ kind: notCalicoApiConfig
 
 	// Environments to test k8s parameters (preferential naming)
 	env4 := map[string]string{
-		"DATASTORE_TYPE":    string(api.Kubernetes),
-		"KUBECONFIG":        "filename",
-		"CALICO_KUBECONFIG": "filename-preferred",
+		"APIV1_DATASTORE_TYPE":    string(api.Kubernetes),
+		"APIV1_KUBECONFIG":        "filename",
+		"CALICO_APIV1_KUBECONFIG": "filename-preferred",
 	}
 	cfg4env := api.NewCalicoAPIConfig()
 	cfg4env.Spec = api.CalicoAPIConfigSpec{
 		DatastoreType: api.Kubernetes,
 		EtcdConfig: api.EtcdConfig{
-			EtcdScheme:    "http",
-			EtcdAuthority: "127.0.0.1:2379",
+			EtcdScheme:    "",
+			EtcdAuthority: "",
 		},
 		KubeConfig: api.KubeConfig{
 			Kubeconfig: "filename-preferred",

--- a/lib/converter/converter_suite_test.go
+++ b/lib/converter/converter_suite_test.go
@@ -17,6 +17,7 @@ package converter_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 )
 
 func TestConverter(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../report/converter_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Converter Suite", []Reporter{junitReporter})

--- a/lib/errors/errors_suite_test.go
+++ b/lib/errors/errors_suite_test.go
@@ -21,9 +21,11 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
-func TestModel(t *testing.T) {
+func TestErrors(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../report/errors_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Errors Suite", []Reporter{junitReporter})

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -102,16 +102,16 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreEtcdV3, 
 	// Create a new backend client and an IPAM Client using the IP Pools Accessor.
 	// Tests that need to ensure a clean datastore should invoke Clean() on the datastore at the start of the
 	// tests.
-	bc, err := backend.NewClient(config)
-	if err != nil {
-		panic(err)
-	}
-	ic := NewIPAMClient(bc, ipPools)
+	var bc bapi.Client
+	var ic Interface
+	BeforeEach(func() {
+		var err error
+		bc, err = backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		ic = NewIPAMClient(bc, ipPools)
+	})
 
 	Context("Measuring allocation performance", func() {
-		bc.Clean()
-		deleteAllPools()
-
 		var pool20, pool32, pool26 []cnet.IPNet
 		// Create many pools
 		for i := 0; i < 100; i++ {

--- a/lib/logutils/logutils_suite_test.go
+++ b/lib/logutils/logutils_suite_test.go
@@ -15,13 +15,12 @@
 package logutils_test
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/onsi/ginkgo/reporters"
+	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 

--- a/lib/selector/parser/parser_test.go
+++ b/lib/selector/parser/parser_test.go
@@ -19,8 +19,6 @@ import (
 
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -284,7 +282,6 @@ var _ = Describe("Visitor", func() {
 			s.AcceptVisitor(visitor)
 
 			By("generating the correct output selector", func() {
-				log.Infof("[test] out: %s", s.String())
 				Expect(s.String()).To(Equal(outSelector))
 			})
 		},

--- a/lib/selector/selectors_suite_test.go
+++ b/lib/selector/selectors_suite_test.go
@@ -18,9 +18,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"testing"
+
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
-	"testing"
 )
 
 func TestSelectors(t *testing.T) {

--- a/lib/testutils/e2e_describe.go
+++ b/lib/testutils/e2e_describe.go
@@ -40,7 +40,7 @@ const (
 // that will be tested.
 func E2eDatastoreDescribe(description string, datastores DatastoreType, body func(config apiconfig.CalicoAPIConfig)) bool {
 	if datastores&DatastoreEtcdV3 != 0 {
-		Describe(fmt.Sprintf("%s (etcdv3 backend)", description),
+		Describe(fmt.Sprintf("%s [Datastore] (etcdv3 backend)", description),
 			func() {
 				body(apiconfig.CalicoAPIConfig{
 					Spec: apiconfig.CalicoAPIConfigSpec{
@@ -54,7 +54,7 @@ func E2eDatastoreDescribe(description string, datastores DatastoreType, body fun
 	}
 
 	if datastores&DatastoreK8s != 0 {
-		Describe(fmt.Sprintf("%s (kubernetes backend)", description),
+		Describe(fmt.Sprintf("%s [Datastore] (kubernetes backend)", description),
 			func() {
 				body(apiconfig.CalicoAPIConfig{
 					Spec: apiconfig.CalicoAPIConfigSpec{

--- a/lib/upgrade/converters/converter_suite_test.go
+++ b/lib/upgrade/converters/converter_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016,2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package selector_test
+package converters
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
-	"testing"
 )
 
-func TestSelectors(t *testing.T) {
+func TestClient(t *testing.T) {
 	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("../../report/selectors_suite.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Selectors Suite", []Reporter{junitReporter})
+	junitReporter := reporters.NewJUnitReporter("../../../report/converter_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "calico-upgrade converter pkg suite", []Reporter{junitReporter})
 }

--- a/lib/upgrade/converters/hostendpoint_test.go
+++ b/lib/upgrade/converters/hostendpoint_test.go
@@ -16,28 +16,22 @@ package converters
 
 import (
 	"fmt"
-	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
-	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var hepTable = []struct {
-	description string
-	v1API       unversioned.Resource
-	v1KVP       *model.KVPair
-	v3API       apiv3.HostEndpoint
-}{
-	{
-		description: "Valid basic v1 hep has data moved to right place",
-		v1API: &apiv1.HostEndpoint{
+var hepTable = []TableEntry{
+	Entry("Valid basic v1 hep has data moved to right place",
+		&apiv1.HostEndpoint{
 			Metadata: apiv1.HostEndpointMetadata{
 				Name: "my-hep",
 				Node: "my-node",
@@ -46,7 +40,7 @@ var hepTable = []struct {
 				InterfaceName: "eth3",
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.HostEndpointKey{
 				EndpointID: "my-hep",
 				Hostname:   "my-node",
@@ -55,7 +49,7 @@ var hepTable = []struct {
 				Name: "eth3",
 			},
 		},
-		v3API: apiv3.HostEndpoint{
+		apiv3.HostEndpoint{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "my-node.my-hep",
 			},
@@ -64,10 +58,9 @@ var hepTable = []struct {
 				Node:          "my-node",
 			},
 		},
-	},
-	{
-		description: "Valid filled v1 hep has data moved to right place",
-		v1API: &apiv1.HostEndpoint{
+	),
+	Entry("Valid filled v1 hep has data moved to right place",
+		&apiv1.HostEndpoint{
 			Metadata: apiv1.HostEndpointMetadata{
 				Name: "my-hep",
 				Node: "my-node",
@@ -91,7 +84,7 @@ var hepTable = []struct {
 				},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.HostEndpointKey{
 				EndpointID: "my-hep",
 				Hostname:   "my-node",
@@ -113,7 +106,7 @@ var hepTable = []struct {
 				ExpectedIPv6Addrs: []cnet.IP{cnet.MustParseIP("fe80::")},
 			},
 		},
-		v3API: apiv3.HostEndpoint{
+		apiv3.HostEndpoint{
 			ObjectMeta: v1.ObjectMeta{
 				Name: fmt.Sprintf("%s.%s", "my-node", "my-hep"),
 				Labels: map[string]string{
@@ -137,31 +130,116 @@ var hepTable = []struct {
 				},
 			},
 		},
+	),
+}
+
+var _ = DescribeTable("v1->v3 HostEndpoint conversion tests",
+	func(v1API *apiv1.HostEndpoint, v1KVP *model.KVPair, v3API apiv3.HostEndpoint) {
+		p := HostEndpoint{}
+
+		// Check v1API->v1KVP.
+		convertedKvp, err := p.APIV1ToBackendV1(v1API)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(convertedKvp.Key.(model.HostEndpointKey)).To(Equal(v1KVP.Key.(model.HostEndpointKey)))
+		Expect(convertedKvp.Value.(*model.HostEndpoint)).To(Equal(v1KVP.Value))
+
+		// Check v1KVP->v3API.
+		convertedv3, err := p.BackendV1ToAPIV3(v1KVP)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(convertedv3.(*apiv3.HostEndpoint).ObjectMeta).To(Equal(v3API.ObjectMeta))
+		Expect(convertedv3.(*apiv3.HostEndpoint).Spec).To(Equal(v3API.Spec))
 	},
-}
 
-func TestHEPDataIsMovedCorrectly(t *testing.T) {
-	for _, tdata := range hepTable {
-		t.Run(tdata.description, func(t *testing.T) {
-			RegisterTestingT(t)
+	// Add entries from table above.
+	hepTable...,
+)
 
-			p := HostEndpoint{}
+var _ = Describe("v1-v3 HostEndpoint conversion tests", func() {
+	It("correctly builds new name", func() {
+		a := basicHep()
+		a.Metadata.Node = "noD2{"
+		a.Metadata.Name = "H3P.N/me"
 
-			// Check v1API->v1KVP.
-			convertedKvp, err := p.APIV1ToBackendV1(tdata.v1API)
-			Expect(err).NotTo(HaveOccurred(), tdata.description)
+		b, err := convertHEPV1ToV3(a)
 
-			Expect(convertedKvp.Key.(model.HostEndpointKey)).To(Equal(tdata.v1KVP.Key.(model.HostEndpointKey)))
-			Expect(convertedKvp.Value.(*model.HostEndpoint)).To(Equal(tdata.v1KVP.Value))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(b.ObjectMeta.Name).To(Equal("nod2.h3p.n.me-7188e863"), "Should convert new name")
+	})
 
-			// Check v1KVP->v3API.
-			convertedv3, err := p.BackendV1ToAPIV3(tdata.v1KVP)
-			Expect(err).NotTo(HaveOccurred(), tdata.description)
-			Expect(convertedv3.(*apiv3.HostEndpoint).ObjectMeta).To(Equal(tdata.v3API.ObjectMeta), tdata.description)
-			Expect(convertedv3.(*apiv3.HostEndpoint).Spec).To(Equal(tdata.v3API.Spec), tdata.description)
-		})
-	}
-}
+	It("converts protocol names", func() {
+		a := basicHep()
+		a.Spec.Ports = []apiv1.EndpointPort{
+			{
+				Name:     "my-port",
+				Protocol: numorstring.ProtocolFromStringV1("tcp"),
+				Port:     5,
+			},
+		}
+
+		b, err := convertHEPV1ToV3(a)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(b.Spec.Ports)).To(Equal(1))
+		Expect(b.Spec.Ports[0].Protocol.StrVal).To(Equal("TCP"), "Should convert protocol name")
+	})
+
+	It("retains ports when only protocol is given", func() {
+		a := basicHep()
+		a.Spec.Ports = []apiv1.EndpointPort{
+			{
+				Protocol: numorstring.ProtocolFromStringV1("udp"),
+			},
+		}
+
+		b, err := convertHEPV1ToV3(a)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(b.Spec.Ports)).To(Equal(1))
+		Expect(b.Spec.Ports[0].Protocol.StrVal).To(Equal("UDP"))
+	})
+
+	It("retains ports when only port number is given", func() {
+		a := basicHep()
+		a.Spec.Ports = []apiv1.EndpointPort{
+			{
+				Port: 5,
+			},
+		}
+
+		b, err := convertHEPV1ToV3(a)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(b.Spec.Ports)).To(Equal(1))
+		Expect(b.Spec.Ports[0].Port).To(Equal(uint16(5)))
+	})
+
+	It("converts profile names", func() {
+		a := basicHep()
+		a.Spec.Profiles = []string{
+			"pRo/le",
+		}
+
+		b, err := convertHEPV1ToV3(a)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(b.Spec.Profiles)).To(Equal(1))
+		Expect(b.Spec.Profiles[0]).To(Equal("pro.le-b1554692"), "Should convert profile name")
+	})
+
+	It("converts profile names", func() {
+		a := basicHep()
+		a.Spec.Profiles = []string{
+			"k8s_ns.my-prof",
+		}
+
+		b, err := convertHEPV1ToV3(a)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(b.Spec.Profiles)).To(Equal(1))
+		Expect(b.Spec.Profiles[0]).To(Equal("kns.my-prof"), "Should convert profile name")
+	})
+})
 
 func basicHep() *apiv1.HostEndpoint {
 	return &apiv1.HostEndpoint{
@@ -189,96 +267,4 @@ func convertHEPV1ToV3(a *apiv1.HostEndpoint) (*apiv3.HostEndpoint, error) {
 	}
 
 	return c.(*apiv3.HostEndpoint), nil
-}
-
-func TestHEPDataIsConvertedCorrectly(t *testing.T) {
-	t.Run("correctly builds new name", func(t *testing.T) {
-		RegisterTestingT(t)
-		a := basicHep()
-		a.Metadata.Node = "noD2{"
-		a.Metadata.Name = "H3P.N/me"
-
-		b, err := convertHEPV1ToV3(a)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(b.ObjectMeta.Name).To(Equal("nod2.h3p.n.me-7188e863"), "Should convert new name")
-	})
-
-	t.Run("converts protocol names", func(t *testing.T) {
-		RegisterTestingT(t)
-		a := basicHep()
-		a.Spec.Ports = []apiv1.EndpointPort{
-			{
-				Name:     "my-port",
-				Protocol: numorstring.ProtocolFromStringV1("tcp"),
-				Port:     5,
-			},
-		}
-
-		b, err := convertHEPV1ToV3(a)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(b.Spec.Ports)).To(Equal(1))
-		Expect(b.Spec.Ports[0].Protocol.StrVal).To(Equal("TCP"), "Should convert protocol name")
-	})
-
-	t.Run("retains ports when only protocol is given", func(t *testing.T) {
-		RegisterTestingT(t)
-		a := basicHep()
-		a.Spec.Ports = []apiv1.EndpointPort{
-			{
-				Protocol: numorstring.ProtocolFromStringV1("udp"),
-			},
-		}
-
-		b, err := convertHEPV1ToV3(a)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(b.Spec.Ports)).To(Equal(1))
-		Expect(b.Spec.Ports[0].Protocol.StrVal).To(Equal("UDP"))
-	})
-
-	t.Run("retains ports when only port number is given", func(t *testing.T) {
-		RegisterTestingT(t)
-		a := basicHep()
-		a.Spec.Ports = []apiv1.EndpointPort{
-			{
-				Port: 5,
-			},
-		}
-
-		b, err := convertHEPV1ToV3(a)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(b.Spec.Ports)).To(Equal(1))
-		Expect(b.Spec.Ports[0].Port).To(Equal(uint16(5)))
-	})
-
-	t.Run("converts profile names", func(t *testing.T) {
-		RegisterTestingT(t)
-		a := basicHep()
-		a.Spec.Profiles = []string{
-			"pRo/le",
-		}
-
-		b, err := convertHEPV1ToV3(a)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(b.Spec.Profiles)).To(Equal(1))
-		Expect(b.Spec.Profiles[0]).To(Equal("pro.le-b1554692"), "Should convert profile name")
-	})
-
-	t.Run("converts profile names", func(t *testing.T) {
-		RegisterTestingT(t)
-		a := basicHep()
-		a.Spec.Profiles = []string{
-			"k8s_ns.my-prof",
-		}
-
-		b, err := convertHEPV1ToV3(a)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(b.Spec.Profiles)).To(Equal(1))
-		Expect(b.Spec.Profiles[0]).To(Equal("kns.my-prof"), "Should convert profile name")
-	})
 }

--- a/lib/upgrade/converters/ippool_test.go
+++ b/lib/upgrade/converters/ippool_test.go
@@ -15,28 +15,20 @@
 package converters
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
-	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/ipip"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var poolTable = []struct {
-	description string
-	v1API       unversioned.Resource
-	v1KVP       *model.KVPair
-	v3API       apiv3.IPPool
-}{
-	{
-		description: "fully populated IPv4 IPPool",
-		v1API: &apiv1.IPPool{
+var poolTable = []TableEntry{
+	Entry("fully populated IPv4 IPPool",
+		&apiv1.IPPool{
 			Metadata: apiv1.IPPoolMetadata{
 				CIDR: cnet.MustParseCIDR("10.0.0.1/24"),
 			},
@@ -49,7 +41,7 @@ var poolTable = []struct {
 				Disabled:    false,
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.IPPoolKey{
 				CIDR: cnet.MustParseCIDR("10.0.0.1/24"),
 			},
@@ -62,7 +54,7 @@ var poolTable = []struct {
 				IPAM:          true,
 			},
 		},
-		v3API: apiv3.IPPool{
+		apiv3.IPPool{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "10-0-0-1-24",
 			},
@@ -74,10 +66,9 @@ var poolTable = []struct {
 				BlockSize:   26,
 			},
 		},
-	},
-	{
-		description: "fully populated IPv6 IPPool",
-		v1API: &apiv1.IPPool{
+	),
+	Entry("fully populated IPv6 IPPool",
+		&apiv1.IPPool{
 			Metadata: apiv1.IPPoolMetadata{
 				CIDR: cnet.MustParseCIDR("2001::/120"),
 			},
@@ -90,7 +81,7 @@ var poolTable = []struct {
 				Disabled:    true,
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.IPPoolKey{
 				CIDR: cnet.MustParseCIDR("2001::/120"),
 			},
@@ -103,7 +94,7 @@ var poolTable = []struct {
 				IPAM:          false,
 			},
 		},
-		v3API: apiv3.IPPool{
+		apiv3.IPPool{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "2001---120",
 			},
@@ -115,10 +106,9 @@ var poolTable = []struct {
 				BlockSize:   122,
 			},
 		},
-	},
-	{
-		description: "IPv4 IPPool with IPIPMode blank, should be converted to IPIPMode Always",
-		v1API: &apiv1.IPPool{
+	),
+	Entry("IPv4 IPPool with IPIPMode blank, should be converted to IPIPMode Always",
+		&apiv1.IPPool{
 			Metadata: apiv1.IPPoolMetadata{
 				CIDR: cnet.MustParseCIDR("5.5.5.5/25"),
 			},
@@ -131,7 +121,7 @@ var poolTable = []struct {
 				Disabled:    true,
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.IPPoolKey{
 				CIDR: cnet.MustParseCIDR("5.5.5.5/25"),
 			},
@@ -144,7 +134,7 @@ var poolTable = []struct {
 				IPAM:          false,
 			},
 		},
-		v3API: apiv3.IPPool{
+		apiv3.IPPool{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "5-5-5-5-25",
 			},
@@ -156,10 +146,9 @@ var poolTable = []struct {
 				BlockSize:   26,
 			},
 		},
-	},
-	{
-		description: "IPv4 IPPool with IPIPMode unspecified, should be converted to IPIPMode Always",
-		v1API: &apiv1.IPPool{
+	),
+	Entry("IPv4 IPPool with IPIPMode unspecified, should be converted to IPIPMode Always",
+		&apiv1.IPPool{
 			Metadata: apiv1.IPPoolMetadata{
 				CIDR: cnet.MustParseCIDR("6.6.6.6/26"),
 			},
@@ -171,7 +160,7 @@ var poolTable = []struct {
 				Disabled:    true,
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.IPPoolKey{
 				CIDR: cnet.MustParseCIDR("6.6.6.6/26"),
 			},
@@ -182,7 +171,7 @@ var poolTable = []struct {
 				IPAM:       false,
 			},
 		},
-		v3API: apiv3.IPPool{
+		apiv3.IPPool{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "6-6-6-6-26",
 			},
@@ -194,10 +183,9 @@ var poolTable = []struct {
 				BlockSize:   26,
 			},
 		},
-	},
-	{
-		description: "partially populated IPv4 IPPool with IPIPMode set to cross-subnet",
-		v1API: &apiv1.IPPool{
+	),
+	Entry("partially populated IPv4 IPPool with IPIPMode set to cross-subnet",
+		&apiv1.IPPool{
 			Metadata: apiv1.IPPoolMetadata{
 				CIDR: cnet.MustParseCIDR("1.1.1.1/11"),
 			},
@@ -210,7 +198,7 @@ var poolTable = []struct {
 				Disabled:    true,
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.IPPoolKey{
 				CIDR: cnet.MustParseCIDR("1.1.1.1/11"),
 			},
@@ -223,7 +211,7 @@ var poolTable = []struct {
 				IPAM:          false,
 			},
 		},
-		v3API: apiv3.IPPool{
+		apiv3.IPPool{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "1-1-1-1-11",
 			},
@@ -235,28 +223,25 @@ var poolTable = []struct {
 				BlockSize:   26,
 			},
 		},
+	),
+}
+
+var _ = DescribeTable("v1->v3 IPPool conversion tests",
+	func(v1API *apiv1.IPPool, v1KVP *model.KVPair, v3API apiv3.IPPool) {
+		p := IPPool{}
+
+		// Test and assert v1 API to v1 backend logic.
+		v1KVPResult, err := p.APIV1ToBackendV1(v1API)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v1KVPResult.Key.(model.IPPoolKey).CIDR).To(Equal(v1KVP.Key.(model.IPPoolKey).CIDR))
+		Expect(v1KVPResult.Value.(*model.IPPool)).To(Equal(v1KVP.Value))
+
+		// Test and assert v1 backend to v3 API logic.
+		v3APIResult, err := p.BackendV1ToAPIV3(v1KVP)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v3APIResult.(*apiv3.IPPool).Name).To(Equal(v3API.Name))
+		Expect(v3APIResult.(*apiv3.IPPool).Spec).To(Equal(v3API.Spec))
 	},
-}
 
-func TestCanConvertV1ToV3IPPool(t *testing.T) {
-
-	for _, entry := range poolTable {
-		t.Run(entry.description, func(t *testing.T) {
-			RegisterTestingT(t)
-
-			p := IPPool{}
-
-			// Test and assert v1 API to v1 backend logic.
-			v1KVPResult, err := p.APIV1ToBackendV1(entry.v1API)
-			Expect(err).NotTo(HaveOccurred(), entry.description)
-			Expect(v1KVPResult.Key.(model.IPPoolKey).CIDR).To(Equal(entry.v1KVP.Key.(model.IPPoolKey).CIDR))
-			Expect(v1KVPResult.Value.(*model.IPPool)).To(Equal(entry.v1KVP.Value))
-
-			// Test and assert v1 backend to v3 API logic.
-			v3APIResult, err := p.BackendV1ToAPIV3(entry.v1KVP)
-			Expect(err).NotTo(HaveOccurred(), entry.description)
-			Expect(v3APIResult.(*apiv3.IPPool).Name).To(Equal(entry.v3API.Name), entry.description)
-			Expect(v3APIResult.(*apiv3.IPPool).Spec).To(Equal(entry.v3API.Spec), entry.description)
-		})
-	}
-}
+	poolTable...,
+)

--- a/lib/upgrade/converters/names_test.go
+++ b/lib/upgrade/converters/names_test.go
@@ -16,174 +16,152 @@ package converters
 
 import (
 	"net"
-	"testing"
 
 	"strings"
 
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var namesTable = []struct {
-	v1Name          string
-	v3Name          string
-	expectQualifier bool
-}{
-	{"abcdef", "abcdef", false},
-	{"Abcdef", "abcdef", true},
-	{"abc-def", "abc-def", false},
-	{"abc---def", "abc---def", false},
-	{"abc/def", "abc.def", true},
-	{"abc$$def", "abc-def", true},
-	{"abc$!$def", "abc-def", true},
-	{"abc..def", "abc.def", true},
-	{"abc...def", "abc.def", true},
-	{"abc.-def", "abc.def", true},
-	{"abc.-.def", "abc.def", true},
-	{"abc-.def", "abc.def", true},
-	{"abc-.-def", "abc.def", true},
-	{"aBcDe019", "abcde019", true},
-	{"abc$def", "abc-def", true},
-	{"-abc.def", "abc.def", true},
-	{"abc.def-", "abc.def", true},
-	{".abc.def", "abc.def", true},
-	{"abc.def.", "abc.def", true},
-	{"-.abc.def", "abc.def", true},
-	{"abc.def.-", "abc.def", true},
-	{"$ABC/DeF-123.-456!", "abc.def-123.456", true},
+var namesTable = []TableEntry{
+	Entry("Convert name abcdef", "abcdef", "abcdef", false),
+	Entry("Convert name Abcdef", "Abcdef", "abcdef", true),
+	Entry("Convert name abc-def", "abc-def", "abc-def", false),
+	Entry("Convert name abc---def", "abc---def", "abc---def", false),
+	Entry("Convert name abc/def", "abc/def", "abc.def", true),
+	Entry("Convert name abc$$def", "abc$$def", "abc-def", true),
+	Entry("Convert name abc$!$def", "abc$!$def", "abc-def", true),
+	Entry("Convert name abc..def", "abc..def", "abc.def", true),
+	Entry("Convert name abc...def", "abc...def", "abc.def", true),
+	Entry("Convert name abc.-def", "abc.-def", "abc.def", true),
+	Entry("Convert name abc.-.def", "abc.-.def", "abc.def", true),
+	Entry("Convert name abc-.def", "abc-.def", "abc.def", true),
+	Entry("Convert name abc-.-def", "abc-.-def", "abc.def", true),
+	Entry("Convert name aBcDe019", "aBcDe019", "abcde019", true),
+	Entry("Convert name abc$def", "abc$def", "abc-def", true),
+	Entry("Convert name -abc.def", "-abc.def", "abc.def", true),
+	Entry("Convert name abc.def-", "abc.def-", "abc.def", true),
+	Entry("Convert name .abc.def", ".abc.def", "abc.def", true),
+	Entry("Convert name abc.def.", "abc.def.", "abc.def", true),
+	Entry("Convert name -.abc.def", "-.abc.def", "abc.def", true),
+	Entry("Convert name abc.def.-", "abc.def.-", "abc.def", true),
+	Entry("Convert name $ABC/DeF-123.-456!", "$ABC/DeF-123.-456!", "abc.def-123.456", true),
 }
 
-func TestCanConvertV1ToV3Name(t *testing.T) {
-	for _, entry := range namesTable {
-		t.Run(entry.v1Name, func(t *testing.T) {
-			RegisterTestingT(t)
+var _ = DescribeTable("v1->v3 name conversion tests",
+	func(v1Name string, v3Name string, expectQualifier bool) {
+		// Get the converted name.
+		c1 := convertName(v1Name)
+		if !expectQualifier {
+			// No qualifier is expected, the names should match exactly.
+			Expect(c1).To(Equal(v3Name))
+		} else {
+			// A qualifier is expected, the first part of the name should match and the
+			// last 9 chars should be the qualifier.
+			Expect(c1[:len(c1)-9]).To(Equal(v3Name))
+			Expect(c1[len(c1)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
 
-			// Get the converted name.
-			c1 := convertName(entry.v1Name)
-			if !entry.expectQualifier {
-				// No qualifier is expected, the names should match exactly.
-				Expect(c1).To(Equal(entry.v3Name))
-			} else {
-				// A qualifier is expected, the first part of the name should match and the
-				// last 9 chars should be the qualifier.
-				Expect(c1[:len(c1)-9]).To(Equal(entry.v3Name))
-				Expect(c1[len(c1)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+			// Convert an upper case variant of the input.  The first part of the name should
+			// match and the last 9 chars should be the qualifier - however the two converted
+			// names should be different.
+			c2 := convertName(strings.ToUpper(v1Name))
+			Expect(c2[:len(c2)-9]).To(Equal(v3Name))
+			Expect(c2[len(c2)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+			Expect(c2).NotTo(Equal(c1))
+		}
+	},
 
-				// Convert an upper case variant of the input.  The first part of the name should
-				// match and the last 9 chars should be the qualifier - however the two converted
-				// names should be different.
-				c2 := convertName(strings.ToUpper(entry.v1Name))
-				Expect(c2[:len(c2)-9]).To(Equal(entry.v3Name))
-				Expect(c2[len(c2)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
-				Expect(c2).NotTo(Equal(c1))
-			}
-		})
-	}
+	namesTable...,
+)
+
+var namesNoDotsTable = []TableEntry{
+	Entry("Convert name abcdef", "abcdef", "abcdef", false),
+	Entry("Convert name Abcdef", "Abcdef", "abcdef", true),
+	Entry("Convert name abc-def", "abc-def", "abc-def", false),
+	Entry("Convert name abc---def", "abc---def", "abc---def", false),
+	Entry("Convert name abc/def", "abc/def", "abc-def", true),
+	Entry("Convert name abc..def", "abc..def", "abc-def", true),
+	Entry("Convert name abc...def", "abc...def", "abc-def", true),
+	Entry("Convert name abc.-def", "abc.-def", "abc-def", true),
+	Entry("Convert name abc.-.def", "abc.-.def", "abc-def", true),
+	Entry("Convert name abc-.def", "abc-.def", "abc-def", true),
+	Entry("Convert name abc-.-def", "abc-.-def", "abc-def", true),
+	Entry("Convert name aBcDe019", "aBcDe019", "abcde019", true),
+	Entry("Convert name abc$def", "abc$def", "abc-def", true),
+	Entry("Convert name -abc.def", "-abc.def", "abc-def", true),
+	Entry("Convert name abc.def-", "abc.def-", "abc-def", true),
+	Entry("Convert name .abc.def", ".abc.def", "abc-def", true),
+	Entry("Convert name abc.def.", "abc.def.", "abc-def", true),
+	Entry("Convert name -.abc.def", "-.abc.def", "abc-def", true),
+	Entry("Convert name abc.def.-", "abc.def.-", "abc-def", true),
+	Entry("Convert name $ABC/DeF-123.-456!", "$ABC/DeF-123.-456!", "abc-def-123-456", true),
 }
 
-var namesNoDotsTable = []struct {
-	v1Name          string
-	v3Name          string
-	expectQualifier bool
-}{
-	{"abcdef", "abcdef", false},
-	{"Abcdef", "abcdef", true},
-	{"abc-def", "abc-def", false},
-	{"abc---def", "abc---def", false},
-	{"abc/def", "abc-def", true},
-	{"abc..def", "abc-def", true},
-	{"abc...def", "abc-def", true},
-	{"abc.-def", "abc-def", true},
-	{"abc.-.def", "abc-def", true},
-	{"abc-.def", "abc-def", true},
-	{"abc-.-def", "abc-def", true},
-	{"aBcDe019", "abcde019", true},
-	{"abc$def", "abc-def", true},
-	{"-abc.def", "abc-def", true},
-	{"abc.def-", "abc-def", true},
-	{".abc.def", "abc-def", true},
-	{"abc.def.", "abc-def", true},
-	{"-.abc.def", "abc-def", true},
-	{"abc.def.-", "abc-def", true},
-	{"$ABC/DeF-123.-456!", "abc-def-123-456", true},
+var _ = DescribeTable("v1->v3 name conversion tests (no dots)",
+	func(v1Name, v3Name string, expectQualifier bool) {
+		// Get the converted name.
+		c1 := convertNameNoDots(v1Name)
+		if !expectQualifier {
+			// No qualifier is expected, the names should match exactly.
+			Expect(c1).To(Equal(v3Name))
+		} else {
+			// A qualifier is expected, the first part of the name should match and the
+			// last 9 chars should be the qualifier.
+			Expect(c1[:len(c1)-9]).To(Equal(v3Name))
+			Expect(c1[len(c1)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+
+			// Convert an upper case variant of the input.  The first part of the name should
+			// match and the last 9 chars should be the qualifier - however the two converted
+			// names should be different.
+			c2 := convertNameNoDots(strings.ToUpper(v1Name))
+			Expect(c2[:len(c2)-9]).To(Equal(v3Name))
+			Expect(c2[len(c2)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
+			Expect(c2).NotTo(Equal(c1))
+		}
+	},
+
+	namesNoDotsTable...,
+)
+
+var ipToNameTable = []TableEntry{
+	Entry("Parse IP 192.168.0.1", net.ParseIP("192.168.0.1"), "192-168-0-1"),
+	Entry("Parse IP Aa:Bb::", net.ParseIP("Aa:bb::"), "00aa-00bb-0000-0000-0000-0000-0000-0000"),
+	Entry("Parse IP 0Aa:bb::50", net.ParseIP("0Aa:bb::50"), "00aa-00bb-0000-0000-0000-0000-0000-0050"),
 }
 
-func TestCanConvertV1ToV3NameNoDots(t *testing.T) {
-	for _, entry := range namesNoDotsTable {
-		t.Run(entry.v1Name, func(t *testing.T) {
-			RegisterTestingT(t)
+var _ = DescribeTable("v1->v3 IP to name conversion tests",
+	func(ip net.IP, name string) {
+		Expect(convertIpToName(ip)).To(Equal(name), ip.String())
+	},
+	ipToNameTable...,
+)
 
-			// Get the converted name.
-			c1 := convertNameNoDots(entry.v1Name)
-			if !entry.expectQualifier {
-				// No qualifier is expected, the names should match exactly.
-				Expect(c1).To(Equal(entry.v3Name))
-			} else {
-				// A qualifier is expected, the first part of the name should match and the
-				// last 9 chars should be the qualifier.
-				Expect(c1[:len(c1)-9]).To(Equal(entry.v3Name))
-				Expect(c1[len(c1)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
-
-				// Convert an upper case variant of the input.  The first part of the name should
-				// match and the last 9 chars should be the qualifier - however the two converted
-				// names should be different.
-				c2 := convertNameNoDots(strings.ToUpper(entry.v1Name))
-				Expect(c2[:len(c2)-9]).To(Equal(entry.v3Name))
-				Expect(c2[len(c2)-9:]).To(MatchRegexp("[-][0-9a-f]{8}"))
-				Expect(c2).NotTo(Equal(c1))
-			}
-		})
-	}
+var nodeNamesTable = []TableEntry{
+	Entry("Convert abc-def", "abc-def", "abc-def"),
+	Entry("Convert abc---def", "abc---def", "abc---def"),
+	Entry("Convert abc/def", "abc/def", "abc.def"),
+	Entry("Convert abc$$def", "abc$$def", "abc-def"),
+	Entry("Convert abc$!$def", "abc$!$def", "abc-def"),
+	Entry("Convert abc..def", "abc..def", "abc.def"),
+	Entry("Convert abc...def", "abc...def", "abc.def"),
+	Entry("Convert abc.-def", "abc.-def", "abc.def"),
+	Entry("Convert abc.-.def", "abc.-.def", "abc.def"),
+	Entry("Convert abc-.def", "abc-.def", "abc.def"),
+	Entry("Convert abc-.-def", "abc-.-def", "abc.def"),
+	Entry("Convert aBcDe019", "aBcDe019", "abcde019"),
+	Entry("Convert abc$def", "abc$def", "abc-def"),
+	Entry("Convert -abc.def", "-abc.def", "abc.def"),
+	Entry("Convert abc.def-", "abc.def-", "abc.def"),
+	Entry("Convert .abc.def", ".abc.def", "abc.def"),
+	Entry("Convert abc.def.", "abc.def.", "abc.def"),
+	Entry("Convert -.abc.def", "-.abc.def", "abc.def"),
+	Entry("Convert abc.def.-", "abc.def.-", "abc.def"),
+	Entry("Convert $ABC/DEF-123.-456!", "$ABC/DEF-123.-456!", "abc.def-123.456"),
 }
 
-var ipToNameTable = []struct {
-	ip   net.IP
-	name string
-}{
-	{net.ParseIP("192.168.0.1"), "192-168-0-1"},
-	{net.ParseIP("Aa:bb::"), "00aa-00bb-0000-0000-0000-0000-0000-0000"},
-	{net.ParseIP("0Aa:bb::50"), "00aa-00bb-0000-0000-0000-0000-0000-0050"},
-}
-
-func TestCanConvertIpToName(t *testing.T) {
-	for _, entry := range ipToNameTable {
-		t.Run(entry.ip.String(), func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(convertIpToName(entry.ip)).To(Equal(entry.name), entry.ip.String())
-		})
-	}
-}
-
-var nodeNamesTable = []struct {
-	before string
-	after  string
-}{
-	{"abc-def", "abc-def"},
-	{"abc---def", "abc---def"},
-	{"abc/def", "abc.def"},
-	{"abc$$def", "abc-def"},
-	{"abc$!$def", "abc-def"},
-	{"abc..def", "abc.def"},
-	{"abc...def", "abc.def"},
-	{"abc.-def", "abc.def"},
-	{"abc.-.def", "abc.def"},
-	{"abc-.def", "abc.def"},
-	{"abc-.-def", "abc.def"},
-	{"aBcDe019", "abcde019"},
-	{"abc$def", "abc-def"},
-	{"-abc.def", "abc.def"},
-	{"abc.def-", "abc.def"},
-	{".abc.def", "abc.def"},
-	{"abc.def.", "abc.def"},
-	{"-.abc.def", "abc.def"},
-	{"abc.def.-", "abc.def"},
-	{"$ABC/DEF-123.-456!", "abc.def-123.456"},
-}
-
-func TestCanConvertV1ToV3NodeName(t *testing.T) {
-	for _, entry := range nodeNamesTable {
-		t.Run(entry.before, func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(ConvertNodeName(entry.before)).To(Equal(entry.after), entry.before)
-		})
-	}
-}
+var _ = DescribeTable("v1->v3 node name conversion tests",
+	func(before, after string) {
+		Expect(ConvertNodeName(before)).To(Equal(after), before)
+	},
+	nodeNamesTable...,
+)

--- a/lib/upgrade/converters/policy_test.go
+++ b/lib/upgrade/converters/policy_test.go
@@ -15,9 +15,9 @@
 package converters
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
@@ -28,15 +28,9 @@ import (
 
 var order1 = 1000.00
 var order2 = 999.99
-var policyTable = []struct {
-	description string
-	v1API       unversioned.Resource
-	v1KVP       *model.KVPair
-	v3API       apiv3.GlobalNetworkPolicy
-}{
-	{
-		description: "fully populated Policy",
-		v1API: &apiv1.Policy{
+var policyTable = []TableEntry{
+	Entry("fully populated Policy",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "nameyMcPolicyName",
 			},
@@ -50,7 +44,7 @@ var policyTable = []struct {
 				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "nameyMcPolicyName",
 			},
@@ -65,7 +59,7 @@ var policyTable = []struct {
 				Types:          []string{"ingress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "nameymcpolicyname-32df456f",
 			},
@@ -80,10 +74,9 @@ var policyTable = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
-	},
-	{
-		description: "policy name conversion",
-		v1API: &apiv1.Policy{
+	),
+	Entry("policy name conversion",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "MaKe.-.MaKe",
 			},
@@ -97,7 +90,7 @@ var policyTable = []struct {
 				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "MaKe.-.MaKe",
 			},
@@ -112,7 +105,7 @@ var policyTable = []struct {
 				Types:          []string{"ingress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "make-make-1b6971c8",
 			},
@@ -127,11 +120,9 @@ var policyTable = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
-	},
-	{
-		description: "policy with PreDNAT set to true " +
-			"should convert ApplyOnForward to true in v3 API",
-		v1API: &apiv1.Policy{
+	),
+	Entry("policy with PreDNAT set to true should convert ApplyOnForward to true in v3 API",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "RAWR",
 			},
@@ -142,7 +133,7 @@ var policyTable = []struct {
 				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "RAWR",
 			},
@@ -156,7 +147,7 @@ var policyTable = []struct {
 				Types:          []string{"ingress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "rawr-03d81e1d",
 			},
@@ -170,11 +161,10 @@ var policyTable = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
-	},
-	{
-		description: "policy with DoNotTrack set to true " +
-			"should convert ApplyOnForward to true in v3 API",
-		v1API: &apiv1.Policy{
+	),
+	Entry("policy with DoNotTrack set to true "+
+		"should convert ApplyOnForward to true in v3 API",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "RAWR",
 			},
@@ -185,7 +175,7 @@ var policyTable = []struct {
 				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "RAWR",
 			},
@@ -199,7 +189,7 @@ var policyTable = []struct {
 				Types:          []string{"ingress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "rawr-03d81e1d",
 			},
@@ -213,11 +203,9 @@ var policyTable = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
-	},
-	{
-		description: "policy with PreDNAT and DoNotTrack both " +
-			"set to false should NOT convert ApplyOnForward to true in v3 API",
-		v1API: &apiv1.Policy{
+	),
+	Entry("policy with PreDNAT and DoNotTrack both set to false should NOT convert ApplyOnForward to true in v3 API",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "meow",
 			},
@@ -229,7 +217,7 @@ var policyTable = []struct {
 				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "meow",
 			},
@@ -243,7 +231,7 @@ var policyTable = []struct {
 				Types:          []string{"ingress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "meow",
 			},
@@ -257,10 +245,9 @@ var policyTable = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
-	},
-	{
-		description: "policy with non-strictly masked CIDR should get converted to strictly masked CIDR in v3 API",
-		v1API: &apiv1.Policy{
+	),
+	Entry("policy with non-strictly masked CIDR should get converted to strictly masked CIDR in v3 API",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "MaKe.-.MaKe",
 			},
@@ -275,7 +262,7 @@ var policyTable = []struct {
 				Types:        []apiv1.PolicyType{apiv1.PolicyTypeIngress, apiv1.PolicyTypeEgress},
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "MaKe.-.MaKe",
 			},
@@ -291,7 +278,7 @@ var policyTable = []struct {
 				Types:          []string{"ingress", "egress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "make-make-1b6971c8",
 			},
@@ -307,10 +294,9 @@ var policyTable = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress, apiv3.PolicyTypeEgress},
 			},
 		},
-	},
-	{
-		description: "policy test3",
-		v1API: &apiv1.Policy{
+	),
+	Entry("policy test3",
+		&apiv1.Policy{
 			Metadata: apiv1.PolicyMetadata{
 				Name: "policy1",
 			},
@@ -328,7 +314,7 @@ var policyTable = []struct {
 				Selector: "type=='database'",
 			},
 		},
-		v1KVP: &model.KVPair{
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "policy1",
 			},
@@ -344,7 +330,7 @@ var policyTable = []struct {
 				Types:         []string{"ingress"},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "policy1",
 			},
@@ -362,40 +348,32 @@ var policyTable = []struct {
 				Types:    []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
+	),
+}
+
+var _ = DescribeTable("v1->v3 policy conversion tests",
+	func(v1API unversioned.Resource, v1KVP *model.KVPair, v3API apiv3.GlobalNetworkPolicy) {
+		p := Policy{}
+
+		// Test and assert v1 API to v1 backend logic.
+		v1KVPResult, err := p.APIV1ToBackendV1(v1API)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v1KVPResult.Key.(model.PolicyKey).Name).To(Equal(v1KVP.Key.(model.PolicyKey).Name))
+		Expect(v1KVPResult.Value.(*model.Policy)).To(Equal(v1KVP.Value))
+
+		// Test and assert v1 backend to v3 API logic.
+		v3APIResult, err := p.BackendV1ToAPIV3(v1KVP)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Name).To(Equal(v3API.Name))
+		Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Spec).To(Equal(v3API.Spec))
 	},
-}
 
-func TestCanConvertV1ToV3Policy(t *testing.T) {
+	policyTable...,
+)
 
-	for _, entry := range policyTable {
-		t.Run(entry.description, func(t *testing.T) {
-			RegisterTestingT(t)
-
-			p := Policy{}
-
-			// Test and assert v1 API to v1 backend logic.
-			v1KVPResult, err := p.APIV1ToBackendV1(entry.v1API)
-			Expect(err).NotTo(HaveOccurred(), entry.description)
-			Expect(v1KVPResult.Key.(model.PolicyKey).Name).To(Equal(entry.v1KVP.Key.(model.PolicyKey).Name))
-			Expect(v1KVPResult.Value.(*model.Policy)).To(Equal(entry.v1KVP.Value))
-
-			// Test and assert v1 backend to v3 API logic.
-			v3APIResult, err := p.BackendV1ToAPIV3(entry.v1KVP)
-			Expect(err).NotTo(HaveOccurred(), entry.description)
-			Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Name).To(Equal(entry.v3API.Name), entry.description)
-			Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Spec).To(Equal(entry.v3API.Spec), entry.description)
-		})
-	}
-}
-
-var policyTableBackend = []struct {
-	description string
-	v1KVP       *model.KVPair
-	v3API       apiv3.GlobalNetworkPolicy
-}{
-	{
-		description: "converting model with no Types with preDNAT to v3 API only has Ingress for Types",
-		v1KVP: &model.KVPair{
+var policyTableBackend = []TableEntry{
+	Entry("converting model with no Types with preDNAT to v3 API only has Ingress for Types",
+		&model.KVPair{
 			Key: model.PolicyKey{
 				Name: "somekey",
 			},
@@ -411,7 +389,7 @@ var policyTableBackend = []struct {
 				Types:          []string{},
 			},
 		},
-		v3API: apiv3.GlobalNetworkPolicy{
+		apiv3.GlobalNetworkPolicy{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "somekey",
 			},
@@ -427,22 +405,19 @@ var policyTableBackend = []struct {
 				Types:          []apiv3.PolicyType{apiv3.PolicyTypeIngress},
 			},
 		},
+	),
+}
+
+var _ = DescribeTable("v1->v3 policy conversion tests (backend)",
+	func(v1KVP *model.KVPair, v3API apiv3.GlobalNetworkPolicy) {
+		p := Policy{}
+
+		// Test and assert v1 backend to v3 API logic.
+		v3APIResult, err := p.BackendV1ToAPIV3(v1KVP)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Name).To(Equal(v3API.Name))
+		Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Spec).To(Equal(v3API.Spec))
 	},
-}
 
-func TestCanConvertKVModelToV3Policy(t *testing.T) {
-
-	for _, entry := range policyTableBackend {
-		t.Run(entry.description, func(t *testing.T) {
-			RegisterTestingT(t)
-
-			p := Policy{}
-
-			// Test and assert v1 backend to v3 API logic.
-			v3APIResult, err := p.BackendV1ToAPIV3(entry.v1KVP)
-			Expect(err).NotTo(HaveOccurred(), entry.description)
-			Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Name).To(Equal(entry.v3API.Name), entry.description)
-			Expect(v3APIResult.(*apiv3.GlobalNetworkPolicy).Spec).To(Equal(entry.v3API.Spec), entry.description)
-		})
-	}
-}
+	policyTableBackend...,
+)

--- a/lib/upgrade/converters/selectors_test.go
+++ b/lib/upgrade/converters/selectors_test.go
@@ -15,27 +15,21 @@
 package converters
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var table = []struct {
-	v1 string
-	v3 string
-}{
-	{"foo == 'bar'", "foo == 'bar'"},
-	{"calico/k8s_ns == 'default'", "projectcalico.org/namespace == 'default'"},
-	{"calico/k8s_ns in {'default'}", "projectcalico.org/namespace in {'default'}"},
-	{"has(calico/k8s_ns)", "has(projectcalico.org/namespace)"},
-	{"has(calico/k8s_ns) || foo == 'bar'", "has(projectcalico.org/namespace) || foo == 'bar'"},
+var selectorTable = []TableEntry{
+	Entry("foo == 'bar'", "foo == 'bar'", "foo == 'bar'"),
+	Entry("calico/k8s_ns == 'default'", "calico/k8s_ns == 'default'", "projectcalico.org/namespace == 'default'"),
+	Entry("calico/k8s_ns in {'default'}", "calico/k8s_ns in {'default'}", "projectcalico.org/namespace in {'default'}"),
+	Entry("has(calico/k8s_ns)", "has(calico/k8s_ns)", "has(projectcalico.org/namespace)"),
+	Entry("has(calico/k8s_ns) || foo == 'bar'", "has(calico/k8s_ns) || foo == 'bar'", "has(projectcalico.org/namespace) || foo == 'bar'"),
 }
 
-func TestCanConvertSelectors(t *testing.T) {
-	for _, entry := range table {
-		t.Run(entry.v1, func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(convertSelector(entry.v1)).To(Equal(entry.v3), entry.v1)
-		})
-	}
-}
+var _ = DescribeTable("v1->v3 selector conversion tests",
+	func(v1, v3 string) {
+		Expect(convertSelector(v1)).To(Equal(v3), v1)
+	},
+	selectorTable...,
+)

--- a/lib/upgrade/migrator/clients/v1/k8s/resources/resources_suite_test.go
+++ b/lib/upgrade/migrator/clients/v1/k8s/resources/resources_suite_test.go
@@ -17,6 +17,7 @@ package resources_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 
 	"testing"
 
@@ -24,7 +25,8 @@ import (
 )
 
 func TestModel(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../../../../../report/resources_suite.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Calico upgrade KDD v1 resources Suite", []Reporter{junitReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "calico-upgrade KDD v1 resources Suite", []Reporter{junitReporter})
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Had a couple of hours on a plane so thought I'd make some improvements here.

PR turned out quite a bit longer than I had hoped... but I think it has some good stuff in it.

- Split out tests which require a datastore into an "fv" target, so its easier to run a "fast" subset when developing.
- Standardize on Ginkgo - there were a few tests not using it.
- Fixup a number of suites which didn't have logging configured properly.
- Fix some copy/paste errors I spotted where report files had the same name across suites. 

`make ut` now takes about 20 seconds on my machine.
`make fv` still takes > 5min.

`make test` runs both `ut` and `fv`. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
