### PR TITLE
WIP: implement method to diff labels

### DIFF
--- a/lib/apis/v3/node.go
+++ b/lib/apis/v3/node.go
@@ -41,33 +41,17 @@ type Node struct {
 //   section against the receiver Node and applies them
 // returns a bool indicating whether or not a change was found
 func (n *Node) ApplyKddMeta(newMeta metav1.ObjectMeta) bool {
-	// HACK: real solution is to fix apis/v3.newNode method
-	if n.ObjectMeta.Annotations == nil {
-		n.ObjectMeta.Annotations = make(map[string]string)
-	}
 	if n.ObjectMeta.Labels == nil {
 		n.ObjectMeta.Labels = make(map[string]string)
 	}
 
-	// get input resourceVersion
-	oldKddV, exists := n.ObjectMeta.Annotations["kdd.resourceVersion"]
-
-	// new resourceVersion is older than stored resourceVersion
-	if exists && (oldKddV >= newMeta.ResourceVersion) {
-		return false
-	}
-
-	// set new resourceVersion
-	n.ObjectMeta.Annotations["kdd.resourceVersion"] = newMeta.ResourceVersion
-
 	// only override labels if does not exist or changed
 	changed := false
 	for labelKey, labelValue := range newMeta.Labels {
-		kddKey := "kdd." + labelKey
-		if oldLabelValue, exists := n.ObjectMeta.Labels[kddKey]; exists && (oldLabelValue == labelValue) {
+		if oldLabelValue, exists := n.ObjectMeta.Labels[labelKey]; exists && (oldLabelValue == labelValue) {
 			continue
 		}
-		n.ObjectMeta.Labels[kddKey] = labelValue
+		n.ObjectMeta.Labels[labelKey] = labelValue
 		changed = true
 	}
 	return changed


### PR DESCRIPTION
## Description
- `ApplyKddMeta` implements logic to determine whether or not labels from the input `ObjectMeta` into the `Node` object.
-- stores the input `ObjectMeta.ResourceVersion` as `Annotations["kdd.resourceVersion"]` in calico node
-- prefix all labels from the k8s Node with `kdd.`


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
```
todo
```
