### PR TITLE
Reproduction of double-releaseIP bug

### DIFF
--- a/lib/client/ipam_block.go
+++ b/lib/client/ipam_block.go
@@ -156,9 +156,16 @@ func (b *allocationBlock) release(addresses []cnet.IP) ([]cnet.IP, map[string]in
 	delRefCounts := map[int]int{}
 	attrsToDelete := []int{}
 
+	// De-duplicate addresses to ensure reference counting is correcet
+	uniqueAddresses := make(map[string]struct{})
+	for _, ip := range addresses {
+		uniqueAddresses[ip.IP.String()] = struct{}{}
+	}
 	// Determine the ordinals that need to be released and the
 	// attributes that need to be cleaned up.
-	for _, ip := range addresses {
+	for ipStr, _ := range uniqueAddresses {
+		ip := cnet.MustParseIP(ipStr)
+
 		// Convert to an ordinal.
 		ordinal := ipToOrdinal(ip, *b)
 		if (ordinal < 0) || (ordinal > blockSize) {


### PR DESCRIPTION
## Description

Setup a scenario in which an IP is assigned, but it's ordinal appears twice in the AllocationBlock's Unallocated list making it possible to assign the IP twice.

Have branched of 2.6 release which affects my environment, but reading the 3.x code suggests this bug will still be present in newer releases too.

Proof-of-concept for #989 

## Todos
- [X] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

TBA