### PR TITLE
wip: add NodeSelector to IPPools and filter accordingly in ipam

### DIFF
--- a/lib/apis/v3/ippool.go
+++ b/lib/apis/v3/ippool.go
@@ -53,6 +53,9 @@ type IPPoolSpec struct {
 	// The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 112 for IPv6.
 	BlockSize int `json:"blockSize,omitempty"`
 
+	// Allows IPPool to allocate for a specific node by label selector.
+	NodeSelector string `json:"nodeSelector,omitempty" validate:"omitempty,selector"`
+
 	// Deprecated: this field is only used for APIv1 backwards compatibility.
 	// Setting this field is not allowed, this field is for internal use only.
 	IPIP *apiv1.IPIPConfiguration `json:"ipip,omitempty" validate:"omitempty,mustBeNil"`

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -241,9 +241,15 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 				By("Allocating an IP address on a different host and checking for no updates")
 				// The syncer only monitors affine blocks for one host, so IP allocations for a different
 				// host should not result in updates.
+				hostname := "not-this-host"
+				node, err = c.Nodes().Create(ctx, &apiv3.Node{ObjectMeta: metav1.ObjectMeta{Name: hostname}}, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				expectedCacheSize += 1
+				syncTester.ExpectCacheSize(expectedCacheSize)
+
 				ips2, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
 					Num4:     1,
-					Hostname: "not-this-host",
+					Hostname: hostname,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				syncTester.ExpectCacheSize(expectedCacheSize)

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -831,8 +831,13 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			}, options.SetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			// Create test node
+			host := "host-test"
+			_, err = c.Nodes().Create(ctx, &apiv3.Node{ObjectMeta: metav1.ObjectMeta{Name: host}}, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
 			// Allocate an IP so that a block is allocated
-			assigned, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1})
+			assigned, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1, Hostname: host})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(assigned).To(HaveLen(1))
 
@@ -898,8 +903,12 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			}, options.SetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			host := "host-test"
+			_, err = c.Nodes().Create(ctx, &apiv3.Node{ObjectMeta: metav1.ObjectMeta{Name: host}}, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
 			// Allocate an IP so that a block is allocated
-			assigned, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1})
+			assigned, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1, Hostname: host})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(assigned).To(HaveLen(1))
 
@@ -915,7 +924,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 
 			// Allocate an IP so that a block is allocated
 			pool2 := []cnet.IPNet{cnet.MustParseCIDR(p2.Spec.CIDR)}
-			assigned, _, err = c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{IPv4Pools: pool2, Num4: 1})
+			assigned, _, err = c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{IPv4Pools: pool2, Num4: 1, Hostname: host})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(assigned).To(HaveLen(1))
 

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -47,10 +47,11 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 		BlockSize: 26,
 	}
 	spec1_2 := apiv3.IPPoolSpec{
-		CIDR:        "1.2.3.0/24",
-		NATOutgoing: true,
-		IPIPMode:    apiv3.IPIPModeNever,
-		BlockSize:   26,
+		CIDR:         "1.2.3.0/24",
+		NATOutgoing:  true,
+		IPIPMode:     apiv3.IPIPModeNever,
+		BlockSize:    26,
+		NodeSelector: `foo == "bar"`,
 	}
 	spec2 := apiv3.IPPoolSpec{
 		CIDR:        "2001::/120",

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -235,8 +235,8 @@ func (c ipamClient) determinePools(requestedPoolNets []net.IPNet, version int, n
 				// No nodeSelector specified
 				enabledPools = append(enabledPools, pool)
 			} else if node, ok := nodeKV.Value.(*model.Node); !ok {
-				log.Warn("node is nil, passing...")
-				continue
+				log.Error("node is nil, refusing to determinePools...")
+				return nil, errors.New("node is nil")
 			} else if sel, err := selector.Parse(pool.Spec.NodeSelector); err != nil {
 				// Invalid selector syntax
 				log.WithError(err).WithField("selector", pool.Spec.NodeSelector).Error("failed to parse selector")
@@ -255,7 +255,7 @@ func (c ipamClient) autoAssign(ctx context.Context, num int, handleID *string, a
 	// Retrieve node for given hostname to use for ip pool node selection
 	node, err := c.client.Get(ctx, model.ResourceKey{Kind: v3.KindNode, Name: host}, "")
 	if err != nil {
-		log.WithError(err).WithField("host", host).Warn("failed to get node for host")
+		log.WithError(err).WithField("node", host).Error("failed to get node for host")
 		return nil, err
 	}
 

--- a/lib/ipam/ipam_block_reader_writer_test.go
+++ b/lib/ipam/ipam_block_reader_writer_test.go
@@ -179,15 +179,15 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 				wg := sync.WaitGroup{}
 				var testErr error
 
-				testhost := fmt.Sprintf("host-%d", j)
-				applyNode(bc, testhost, nil)
-				defer deleteNode(bc, testhost)
-
 				for i := 0; i < 32; i++ {
 					wg.Add(1)
 					j := i
 					go func() {
 						defer GinkgoRecover()
+
+						testhost := fmt.Sprintf("host-%d", j)
+						applyNode(bc, testhost, nil)
+						defer deleteNode(bc, testhost)
 
 						ips, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, 4, testhost, 0)
 						if err != nil {

--- a/lib/ipam/ipam_block_reader_writer_test.go
+++ b/lib/ipam/ipam_block_reader_writer_test.go
@@ -179,15 +179,15 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 				wg := sync.WaitGroup{}
 				var testErr error
 
+				testhost := fmt.Sprintf("host-%d", j)
+				applyNode(bc, testhost, nil)
+				defer deleteNode(bc, testhost)
+
 				for i := 0; i < 32; i++ {
 					wg.Add(1)
 					j := i
 					go func() {
 						defer GinkgoRecover()
-
-						testhost := fmt.Sprintf("host-%d", j)
-						applyNode(bc, testhost, nil)
-						defer deleteNode(bc, testhost)
 
 						ips, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, 4, testhost, 0)
 						if err != nil {
@@ -269,13 +269,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 				wg := sync.WaitGroup{}
 				var testErr error
 
+				testhost := "single-host"
+				applyNode(bc, testhost, nil)
 				for i := 0; i < 4; i++ {
 					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
 
-						testhost := "single-host"
-						applyNode(bc, testhost, nil)
 						ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, testhost, 0)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)

--- a/lib/ipam/ipam_block_reader_writer_test.go
+++ b/lib/ipam/ipam_block_reader_writer_test.go
@@ -152,6 +152,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 
 			hostA = "hostA"
 			hostB = "hostB"
+			applyNode(bc, hostA, nil)
+			applyNode(bc, hostB, nil)
 
 			pools = &ipPoolAccessor{pools: map[string]pool{"10.0.0.0/26": {enabled: true}}}
 
@@ -184,6 +186,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						defer GinkgoRecover()
 
 						testhost := fmt.Sprintf("host-%d", j)
+						applyNode(bc, testhost, nil)
+						defer deleteNode(bc, testhost)
+
 						ips, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, 4, testhost, 0)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)
@@ -270,6 +275,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						defer GinkgoRecover()
 
 						testhost := "single-host"
+						applyNode(bc, testhost, nil)
 						ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, testhost, 0)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -447,7 +447,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreEtcdV3, 
 			})
 			Expect(outErr).NotTo(HaveOccurred())
 
-			// Expect all the IPs to be in pool2.
+			// Expect all the IPs to be from pool1.
 			for _, a := range v4 {
 				Expect(pool1.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool1))
 			}

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -461,6 +461,22 @@ func init() {
 				Spec: api.IPPoolSpec{CIDR: netv4_3},
 			}, false,
 		),
+		Entry("should allow a valid nodeSelector",
+			api.IPPool{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "pool.name",
+				},
+				Spec: api.IPPoolSpec{CIDR: netv4_3, NodeSelector: `foo == "bar"`},
+			}, true,
+		),
+		Entry("should disallow a invalid nodeSelector",
+			api.IPPool{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "pool.name",
+				},
+				Spec: api.IPPoolSpec{CIDR: netv4_3, NodeSelector: "this is not valid selector syntax"},
+			}, false,
+		),
 
 		// (API) Interface.
 		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "Valid_Iface.0-9"}, true),


### PR DESCRIPTION
## Description
- adds the NodeSelector field to IPPools resource
- updates `ipamClient.determinePools` code to apply selector logic from IPPool NodeSelector on the Node labels

- needs feedback: 
```
node, err := c.client.Get(ctx, model.NodeKey{Hostname: host}, "")
```
doesn't seem to work with the following error:
```
2018-12-10 21:46:11.719 [DEBUG][81] etcdv3.go 306: Processing Get request model-etcdKey=Node(name=single-host) rev=""
2018-12-10 21:46:11.719 [ERROR][81] etcdv3.go 310: Unable to convert model.Key to an etcdv3 etcdKey model-etcdKey=Node(name=single-host) rev=""
2018-12-10 21:46:11.719 [ERROR][81] ipam.go 255: failed to get node for host error=Node is a composite type, so not handled with a single path host="single-host"
```

please advise @robbrockbank @caseydavenport 