### PR TITLE
Return CIDR instead of only IPs from calico IPAM.

### DIFF
--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -217,10 +217,15 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 			var blockAffinityKeyV1 model.BlockAffinityKey
 			if config.Spec.DatastoreType != apiconfig.Kubernetes {
 				By("Allocating an IP address and checking that we get an allocation block")
-				ips1, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+				ipV4Nets1, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
 					Num4:     1,
 					Hostname: "127.0.0.1",
 				})
+
+				var ips1 []net.IP
+				for _, ipnet := range ipV4Nets1 {
+					ips1 = append(ips1, net.IP{ipnet.IP})
+				}
 				Expect(err).NotTo(HaveOccurred())
 
 				// Allocating an IP will create an affinity block that we should be notified of.  Not sure
@@ -241,10 +246,16 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 				By("Allocating an IP address on a different host and checking for no updates")
 				// The syncer only monitors affine blocks for one host, so IP allocations for a different
 				// host should not result in updates.
-				ips2, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+				ipV4Nets2, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
 					Num4:     1,
 					Hostname: "not-this-host",
 				})
+
+				var ips2 []net.IP
+				for _, ipnet := range ipV4Nets2 {
+					ips2 = append(ips2, net.IP{ipnet.IP})
+				}
+
 				Expect(err).NotTo(HaveOccurred())
 				syncTester.ExpectCacheSize(expectedCacheSize)
 

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -832,7 +832,12 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			Expect(err).NotTo(HaveOccurred())
 
 			// Allocate an IP so that a block is allocated
-			assigned, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1})
+			assignedV4, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1})
+			var assigned []cnet.IP
+			for _, ipnet := range assignedV4 {
+				assigned = append(assigned, cnet.IP{ipnet.IP})
+			}
+
 			Expect(err).NotTo(HaveOccurred())
 			Expect(assigned).To(HaveLen(1))
 

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -31,10 +31,10 @@ type Interface interface {
 
 	// AutoAssign automatically assigns one or more IP addresses as specified by the
 	// provided AutoAssignArgs.  AutoAssign returns the list of the assigned IPv4 addresses,
-	// and the list of the assigned IPv6 addresses.
+	// and the list of the assigned IPv6 addresses in IPNet format.
 	//
 	// In case of error, returns the IPs allocated so far along with the error.
-	AutoAssign(ctx context.Context, args AutoAssignArgs) ([]cnet.IP, []cnet.IP, error)
+	AutoAssign(ctx context.Context, args AutoAssignArgs) ([]cnet.IPNet, []cnet.IPNet, error)
 
 	// ReleaseIPs releases any of the given IP addresses that are currently assigned,
 	// so that they are available to be used in another assignment.

--- a/lib/ipam/ipam_block.go
+++ b/lib/ipam/ipam_block.go
@@ -52,7 +52,7 @@ func newBlock(cidr cnet.IPNet) allocationBlock {
 }
 
 func (b *allocationBlock) autoAssign(
-	num int, handleID *string, host string, attrs map[string]string, affinityCheck bool) ([]cnet.IP, error) {
+	num int, handleID *string, host string, attrs map[string]string, affinityCheck bool) ([]cnet.IPNet, error) {
 
 	// Determine if we need to check for affinity.
 	checkAffinity := b.StrictAffinity || affinityCheck
@@ -76,11 +76,14 @@ func (b *allocationBlock) autoAssign(
 	}
 
 	// Create slice of IPs and perform the allocations.
-	ips := []cnet.IP{}
+	ips := []cnet.IPNet{}
+	_, mask, _ := cnet.ParseCIDR(b.CIDR.String())
 	for _, o := range ordinals {
 		attrIndex := b.findOrAddAttribute(handleID, attrs)
 		b.Allocations[o] = &attrIndex
-		ips = append(ips, incrementIP(cnet.IP{b.CIDR.IP}, big.NewInt(int64(o))))
+		ipNets := cnet.IPNet(*mask)
+		ipNets.IP = incrementIP(cnet.IP{b.CIDR.IP}, big.NewInt(int64(o))).IP
+		ips = append(ips, ipNets)
 	}
 
 	log.Debugf("Block %s returned ips: %v", b.CIDR.String(), ips)


### PR DESCRIPTION
This change is useful for rest of the apps to
know about the CIDR mask in addition to IP
address assigned

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
