### PR TITLE
encapsulate node selector logic to ippool resource

### DIFF
--- a/lib/apis/v3/ippool.go
+++ b/lib/apis/v3/ippool.go
@@ -66,9 +66,9 @@ type IPPoolSpec struct {
 	NATOutgoingV1 bool `json:"nat-outgoing,omitempty" validate:"omitempty,mustBeFalse"`
 }
 
-// DoesMatchNode determines whether or not the IPPool's nodeSelector
+// SelectsNode determines whether or not the IPPool's nodeSelector
 // matches the labels on the given node.
-func (pool IPPool) DoesMatchNode(n Node) (bool, error) {
+func (pool IPPool) SelectsNode(n Node) (bool, error) {
 	// No node selector means that the pool matches the node.
 	if len(pool.Spec.NodeSelector) == 0 {
 		return true, nil

--- a/lib/apis/v3/ippool.go
+++ b/lib/apis/v3/ippool.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
+	"github.com/projectcalico/libcalico-go/lib/selector"
 )
 
 const (
@@ -63,6 +64,22 @@ type IPPoolSpec struct {
 	// Deprecated: this field is only used for APIv1 backwards compatibility.
 	// Setting this field is not allowed, this field is for internal use only.
 	NATOutgoingV1 bool `json:"nat-outgoing,omitempty" validate:"omitempty,mustBeFalse"`
+}
+
+// DoesMatchNode determines whether or not the IPPool's nodeSelector
+// matches the labels on the given node.
+func (pool IPPool) DoesMatchNode(n Node) (bool, error) {
+	// No node selector means that the pool matches the node.
+	if len(pool.Spec.NodeSelector) == 0 {
+		return true, nil
+	}
+	// Check for valid selector syntax.
+	sel, err := selector.Parse(pool.Spec.NodeSelector)
+	if err != nil {
+		return false, err
+	}
+	// Return whether or not the selector matches.
+	return sel.Evaluate(n.Labels), nil
 }
 
 type IPIPMode string

--- a/lib/apis/v3/ippool_test.go
+++ b/lib/apis/v3/ippool_test.go
@@ -34,21 +34,21 @@ var _ = Describe("IPPoolSpec nodeSelector", func() {
 	It("should return true, nil for empty nodeSelector", func() {
 		pool.Spec = IPPoolSpec{NodeSelector: ""}
 
-		matches, err := pool.DoesMatchNode(node)
+		matches, err := pool.SelectsNode(node)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(matches).To(Equal(true))
 	})
 	It("should return false, err for invalid selector syntax", func() {
 		pool.Spec = IPPoolSpec{NodeSelector: "this is invalid selector syntax"}
 
-		matches, err := pool.DoesMatchNode(node)
+		matches, err := pool.SelectsNode(node)
 		Expect(err).To(HaveOccurred())
 		Expect(matches).To(Equal(false))
 	})
 	It("should return false, nil for mismatching labels", func() {
 		pool.Spec = IPPoolSpec{NodeSelector: `foo == "bar"`}
 
-		matches, err := pool.DoesMatchNode(node)
+		matches, err := pool.SelectsNode(node)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(matches).To(Equal(false))
 	})
@@ -56,7 +56,7 @@ var _ = Describe("IPPoolSpec nodeSelector", func() {
 		node.Labels = map[string]string{"foo": "bar"}
 		pool.Spec = IPPoolSpec{NodeSelector: `foo == "bar"`}
 
-		matches, err := pool.DoesMatchNode(node)
+		matches, err := pool.SelectsNode(node)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(matches).To(Equal(true))
 	})

--- a/lib/apis/v3/ippool_test.go
+++ b/lib/apis/v3/ippool_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3_test
+
+import (
+	. "github.com/projectcalico/libcalico-go/lib/apis/v3"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// These tests verify that the IPPool nodeSelector works as expected
+var _ = Describe("IPPoolSpec nodeSelector", func() {
+	var (
+		node Node
+		pool IPPool
+	)
+	BeforeEach(func() {
+		node = Node{}
+		pool = IPPool{}
+	})
+	It("should return true, nil for empty nodeSelector", func() {
+		pool.Spec = IPPoolSpec{NodeSelector: ""}
+
+		matches, err := pool.DoesMatchNode(node)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(matches).To(Equal(true))
+	})
+	It("should return false, err for invalid selector syntax", func() {
+		pool.Spec = IPPoolSpec{NodeSelector: "this is invalid selector syntax"}
+
+		matches, err := pool.DoesMatchNode(node)
+		Expect(err).To(HaveOccurred())
+		Expect(matches).To(Equal(false))
+	})
+	It("should return false, nil for mismatching labels", func() {
+		pool.Spec = IPPoolSpec{NodeSelector: `foo == "bar"`}
+
+		matches, err := pool.DoesMatchNode(node)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(matches).To(Equal(false))
+	})
+	It("should return true, nil for mismatching labels", func() {
+		node.Labels = map[string]string{"foo": "bar"}
+		pool.Spec = IPPoolSpec{NodeSelector: `foo == "bar"`}
+
+		matches, err := pool.DoesMatchNode(node)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(matches).To(Equal(true))
+	})
+})

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -250,7 +250,7 @@ func (c ipamClient) determinePools(requestedPoolNets []net.IPNet, version int, n
 	// selector.
 	matchingPools := []v3.IPPool{}
 	for _, pool := range enabledPools {
-		matches, err := pool.DoesMatchNode(node)
+		matches, err := pool.SelectsNode(node)
 		if err != nil {
 			log.WithError(err).WithField("pool", pool).Error("failed to determine if node matches pool")
 			return nil, err


### PR DESCRIPTION
## Description
Implements `DoesMatchNode` method on `IPPool` resource to modularize the node selection logic.

## Todos
- [x] Tests
- [x] Documentation
