### PR TITLE
Fix service account to profile conversion

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -693,8 +693,14 @@ func (c Converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 		CreationTimestamp: sa.CreationTimestamp,
 		UID:               sa.UID,
 	}
-	profile.Spec = apiv3.ProfileSpec{
-		LabelsToApply: labels,
+
+	// Only set labels to apply when there are actually labels. This makes the
+	// result of this function consistent with the struct as loaded directly
+	// from etcd, which uses nil for the empty map.
+	if len(labels) != 0 {
+		profile.Spec.LabelsToApply = labels
+	} else {
+		profile.Spec.LabelsToApply = nil
 	}
 
 	// Embed the profile in a KVPair.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Service account kube-controller compares service account (stored as profile) object from cache with object from etcd datastore. If the two objects are different, kube-controller will update etcd datastore. Current conversion from k8s service account to a profile resource use an empty map if there is no labelToApply. However, etcd would store empty map to nil. Hence object from cache (empty map) is regarded as different with object read from etcd (nil map). 

Namespace object does not have this issue since its' conversion set label to nil if there is no labelToApply. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
