### PR TITLE
add support for IPIP tunnel address on node in kdd mode

### DIFF
--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -1722,7 +1722,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			getNode, err := c.Get(ctx, kvp.Key.(model.ResourceKey), "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*getNode.Value.(*apiv3.Node).Spec.BGP.ASNumber).To(Equal(newAsn))
-			Expect(getNode.Value.(*apiv3.Node).Spec.BGP.IPv4IPIPTunnelAddr).To(Equal("10.10.10.1"))
+			Expect(getNode.Value.(*apiv3.Node).Spec.BGP.IPv4IPIPTunnelAddr).To(Equal(""))
 
 			// We do not support creating Nodes, we should see an error
 			// if the Node does not exist.
@@ -1749,7 +1749,8 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 					},
 					Spec: apiv3.NodeSpec{
 						BGP: &apiv3.NodeBGPSpec{
-							IPv4Address: ip,
+							IPv4Address:        ip,
+							IPv4IPIPTunnelAddr: "10.0.0.1",
 						},
 					},
 				},
@@ -1758,11 +1759,13 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(node.Value.(*apiv3.Node).Spec.BGP.ASNumber).To(BeNil())
+			Expect(node.Value.(*apiv3.Node).Spec.BGP.IPv4IPIPTunnelAddr).To(Equal("10.0.0.1"))
 
 			// Also check that Get() returns the changes
 			getNode, err := c.Get(ctx, kvp.Key.(model.ResourceKey), "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(getNode.Value.(*apiv3.Node).Spec.BGP.ASNumber).To(BeNil())
+			Expect(getNode.Value.(*apiv3.Node).Spec.BGP.IPv4IPIPTunnelAddr).To(Equal("10.0.0.1"))
 		})
 
 		By("Syncing HostIPs over the Syncer", func() {

--- a/lib/clientv3/node_e2e_test.go
+++ b/lib/clientv3/node_e2e_test.go
@@ -59,6 +59,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (kdd)", testutils.DatastoreK8
 		// Add a label and check it gets written.
 		By("Adding a label to the node")
 		node.Labels = map[string]string{"test-label": "foo"}
+		node.Spec.BGP = &apiv3.NodeBGPSpec{IPv4Address: "10.0.0.1"}
 		_, err = c.Nodes().Update(ctx, node, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Description
- adds a new annotation field for the Node resource to optionally store the IPIP tunnel address

## Todos
- [X] Tests
