### PR TITLE
Allow affinity release to require empty blocks

### DIFF
--- a/lib/clientv3/node_e2e_test.go
+++ b/lib/clientv3/node_e2e_test.go
@@ -238,7 +238,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.Datastor
 			Expect(ips).Should(BeNil())
 
 			// Check that the host affinity pool was released.
-			err = c.IPAM().ReleaseAffinity(ctx, affBlock, name1)
+			err = c.IPAM().ReleaseAffinity(ctx, affBlock, name1, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			list, err := be.List(

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -60,13 +60,17 @@ type Interface interface {
 
 	// ReleaseAffinity releases affinity for all blocks within the given CIDR
 	// on the given host.  If an empty string is passed as the host, then the
-	// value returned by os.Hostname will be used.
-	ReleaseAffinity(ctx context.Context, cidr cnet.IPNet, host string) error
+	// value returned by os.Hostname will be used. If mustBeEmpty is true, then an error
+	// will be returned if any blocks within the CIDR are not empty - in this case, this
+	// function may release some but not all blocks within the given CIDR.
+	ReleaseAffinity(ctx context.Context, cidr cnet.IPNet, host string, mustBeEmpty bool) error
 
 	// ReleaseHostAffinities releases affinity for all blocks that are affine
 	// to the given host.  If an empty string is passed as the host, the value returned by
-	// os.Hostname will be used.
-	ReleaseHostAffinities(ctx context.Context, host string) error
+	// os.Hostname will be used. If mustBeEmpty is true, then an error
+	// will be returned if any blocks within the CIDR are not empty - in this case, this
+	// function may release some but not all blocks attached to this host.
+	ReleaseHostAffinities(ctx context.Context, host string, mustBeEmpty bool) error
 
 	// ReleasePoolAffinities releases affinity for all blocks within
 	// the specified pool across all hosts.

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -292,8 +292,8 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, host strin
 
 	// Don't release block affinity if we require it to be empty and it's not empty.
 	if requireEmpty && !b.empty() {
-		logCtx.Debug("Block must be empty but is not empty, refusing to remove affinity.")
-		return nil
+		logCtx.Info("Block must be empty but is not empty, refusing to remove affinity.")
+		return errBlockNotEmpty{Block: b}
 	}
 
 	// Mark the affinity as pending deletion.

--- a/lib/ipam/ipam_block_reader_writer_test.go
+++ b/lib/ipam/ipam_block_reader_writer_test.go
@@ -423,7 +423,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						defer GinkgoRecover()
 
 						testhost := "same-host"
-						err := ic.ReleaseAffinity(ctx, *net, testhost)
+						err := ic.ReleaseAffinity(ctx, *net, testhost, false)
 						if err != nil {
 							log.WithError(err).Errorf("Failed to release affinity for host %s", testhost)
 							testErr = err
@@ -845,7 +845,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			})
 
 			By("calling ReleaseAffinity", func() {
-				err := ic.ReleaseAffinity(ctx, *net, hostA)
+				err := ic.ReleaseAffinity(ctx, *net, hostA, false)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/lib/ipam/ipam_errors.go
+++ b/lib/ipam/ipam_errors.go
@@ -54,6 +54,16 @@ func (e errBlockClaimConflict) Error() string {
 	return fmt.Sprintf("%v already claimed", e.Block.CIDR)
 }
 
+// errBlockNotEmpty indicates that a given block has already
+// been claimed by another host.
+type errBlockNotEmpty struct {
+	Block allocationBlock
+}
+
+func (e errBlockNotEmpty) Error() string {
+	return fmt.Sprintf("block '%v' is not empty", e.Block.CIDR)
+}
+
 // errStaleAffinity indicates to the calling code that the given affinity
 // is not confirmed, and that the corresponding block belongs to another host.
 type errStaleAffinity string


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Allows IPAM users to ensure that block affinities are only released if 
the blocks are empty. This prevents blocks from being "orphaned" with one or more
remaining addresses.

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```