### PR TITLE
Backporting 'IptablesNATOutgoingInterfaceFilter config param' changes on release v3.5

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -208,6 +208,8 @@ type FelixConfigurationSpec struct {
 	DebugDisableLogDropping         *bool            `json:"debugDisableLogDropping,omitempty"`
 	DebugSimulateCalcGraphHangAfter *metav1.Duration `json:"debugSimulateCalcGraphHangAfter,omitempty" configv1timescale:"seconds"`
 	DebugSimulateDataplaneHangAfter *metav1.Duration `json:"debugSimulateDataplaneHangAfter,omitempty" configv1timescale:"seconds"`
+
+	IptablesNATOutgoingInterfaceFilter string `json:"iptablesNATOutgoingInterfaceFilter,omitempty" validate:"omitempty,ifaceFilter"`
 }
 
 // ProtoPort is combination of protocol and port, both must be specified.

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,16 +70,17 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 54
+	numFelixConfigs := 56
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3
 	felixMappedNames := map[string]interface{}{
-		"RouteRefreshInterval":    nil,
-		"IptablesRefreshInterval": nil,
-		"IpsetsRefreshInterval":   nil,
-		"IpInIpEnabled":           nil,
-		"IpInIpMtu":               nil,
+		"RouteRefreshInterval":               nil,
+		"IptablesRefreshInterval":            nil,
+		"IpsetsRefreshInterval":              nil,
+		"IpInIpEnabled":                      nil,
+		"IpInIpMtu":                          nil,
+		"IptablesNATOutgoingInterfaceFilter": nil,
 	}
 
 	It("should handle conversion of node-specific delete with no additional configs", func() {
@@ -214,17 +215,19 @@ var _ = Describe("Test the generic configuration update processor and the concre
 			},
 		}
 		res.Spec.ExternalNodesCIDRList = &[]string{"1.1.1.1", "2.2.2.2"}
+		res.Spec.IptablesNATOutgoingInterfaceFilter = "cali-123"
 		expected := map[string]interface{}{
-			"RouteRefreshInterval":            "12.345",
-			"IptablesLockProbeIntervalMillis": "54.321",
-			"EndpointReportingDelaySecs":      "0",
-			"IpsetsRefreshInterval":           "0.1",
-			"InterfacePrefix":                 "califoobar",
-			"IpInIpEnabled":                   "false",
-			"IptablesMarkMask":                "1313",
-			"FailsafeInboundHostPorts":        "none",
-			"FailsafeOutboundHostPorts":       "tcp:1234,udp:22,tcp:65535",
-			"ExternalNodesCIDRList":           "1.1.1.1,2.2.2.2",
+			"RouteRefreshInterval":               "12.345",
+			"IptablesLockProbeIntervalMillis":    "54.321",
+			"EndpointReportingDelaySecs":         "0",
+			"IpsetsRefreshInterval":              "0.1",
+			"InterfacePrefix":                    "califoobar",
+			"IpInIpEnabled":                      "false",
+			"IptablesMarkMask":                   "1313",
+			"FailsafeInboundHostPorts":           "none",
+			"FailsafeOutboundHostPorts":          "tcp:1234,udp:22,tcp:65535",
+			"ExternalNodesCIDRList":              "1.1.1.1,2.2.2.2",
+			"IptablesNATOutgoingInterfaceFilter": "cali-123",
 		}
 		kvps, err := cc.Process(&model.KVPair{
 			Key:   perNodeFelixKey,

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 56
+	numFelixConfigs := 55
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -64,6 +64,7 @@ var (
 	globalNetworkPolicyNameRegex = regexp.MustCompile("^(" + nameLabelFmt + ")$")
 
 	interfaceRegex        = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,15}$")
+	ifaceFilterRegex      = regexp.MustCompile("^[a-zA-Z0-9:._+-]{1,15}$")
 	actionRegex           = regexp.MustCompile("^(Allow|Deny|Log|Pass)$")
 	protocolRegex         = regexp.MustCompile("^(TCP|UDP|ICMP|ICMPv6|SCTP|UDPLite)$")
 	ipipModeRegex         = regexp.MustCompile("^(Always|CrossSubnet|Never)$")
@@ -147,6 +148,7 @@ func init() {
 	registerFieldValidator("portName", validatePortName)
 	registerFieldValidator("mustBeNil", validateMustBeNil)
 	registerFieldValidator("mustBeFalse", validateMustBeFalse)
+	registerFieldValidator("ifaceFilter", validateIfaceFilter)
 
 	// Register network validators (i.e. validating a correctly masked CIDR).  Also
 	// accepts an IP address without a mask (assumes a full mask).
@@ -228,6 +230,12 @@ func validateInterface(v *validator.Validate, topStruct reflect.Value, currentSt
 	s := field.String()
 	log.Debugf("Validate interface: %s", s)
 	return s == "*" || interfaceRegex.MatchString(s)
+}
+
+func validateIfaceFilter(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {
+	s := field.String()
+	log.Debugf("Validate Interface Filter : %s", s)
+	return ifaceFilterRegex.MatchString(s)
 }
 
 func validateDatastoreType(v *validator.Validate, topStruct reflect.Value, currentStructOrField reflect.Value, field reflect.Value, fieldType reflect.Type, fieldKind reflect.Kind, param string) bool {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -519,6 +519,8 @@ func init() {
 		Entry("should accept a valid LogSeverityScreen value 'Warning'", api.FelixConfigurationSpec{LogSeverityScreen: "Warning"}, true),
 		Entry("should accept a valid LogSeverityFile value 'Debug'", api.FelixConfigurationSpec{LogSeverityFile: "Debug"}, true),
 		Entry("should accept a valid LogSeveritySys value 'Info'", api.FelixConfigurationSpec{LogSeveritySys: "Info"}, true),
+		Entry("should accept a valid IptablesNATOutgoingInterfaceFilter value 'cali-123'", api.FelixConfigurationSpec{IptablesNATOutgoingInterfaceFilter: "cali-123"}, true),
+		Entry("should reject an invalid IptablesNATOutgoingInterfaceFilter value 'cali@123'", api.FelixConfigurationSpec{IptablesNATOutgoingInterfaceFilter: "cali@123"}, false),
 
 		// (API) Protocol
 		Entry("should accept protocol TCP", protocolFromString("TCP"), true),


### PR DESCRIPTION
IptablesNATOutgoingInterfaceFilter config param added

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
