### PR TITLE
Fix etcdv3 watch event filtering

### DIFF
--- a/lib/backend/etcdv3/conversion.go
+++ b/lib/backend/etcdv3/conversion.go
@@ -44,7 +44,7 @@ func convertListResponse(ekv *mvccpb.KeyValue, l model.ListInterface) *model.KVP
 // convertWatchEvent converts an etcdv3 watch event to an api.WatchEvent, or nil if the
 // event did not correspond to an event that we are interested in.
 func convertWatchEvent(e *clientv3.Event, l model.ListInterface) (*api.WatchEvent, error) {
-	log.WithField("etcdv3-etcdKey", e.Kv.Key).Debug("Processing etcdv3 event")
+	log.WithField("etcdv3-etcdKey", string(e.Kv.Key)).Debug("Processing etcdv3 event")
 
 	var eventType api.WatchEventType
 	switch {
@@ -71,6 +71,9 @@ func convertWatchEvent(e *clientv3.Event, l model.ListInterface) (*api.WatchEven
 				return nil, err
 			}
 		}
+	} else {
+		log.WithField("key", string(e.Kv.Key)).Debug("key filtered")
+		return nil, nil
 	}
 
 	return &api.WatchEvent{

--- a/lib/clientv3/networkpolicy_e2e_test.go
+++ b/lib/clientv3/networkpolicy_e2e_test.go
@@ -423,7 +423,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 
 			// Only etcdv3 supports watching a specific instance of a resource.
 			if config.Spec.DatastoreType == apiconfig.EtcdV3 {
-				By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+				By("Starting a watcher from rev0 watching namespace1/name1 - this should get all events for name1")
 				w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{Namespace: namespace1, Name: name1, ResourceVersion: rev0})
 				Expect(err).NotTo(HaveOccurred())
 				testWatcher2_1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
@@ -439,6 +439,23 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 					},
 				})
 				testWatcher2_1.Stop()
+
+				By("Starting a watcher from rev0 watching name1 - this should get all events for name1")
+				w, err = c.NetworkPolicies().Watch(ctx, options.ListOptions{Name: name1, ResourceVersion: rev0})
+				Expect(err).NotTo(HaveOccurred())
+				testWatcher2_2 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+				defer testWatcher2_2.Stop()
+				testWatcher2_2.ExpectEvents(apiv3.KindNetworkPolicy, []watch.Event{
+					{
+						Type:   watch.Added,
+						Object: outRes1,
+					},
+					{
+						Type:     watch.Deleted,
+						Previous: outRes1,
+					},
+				})
+				testWatcher2_2.Stop()
 			}
 
 			By("Starting a watcher not specifying a rev - expect the current snapshot")

--- a/lib/testutils/resources.go
+++ b/lib/testutils/resources.go
@@ -256,13 +256,17 @@ func (t *testResourceWatcher) expectEvents(kind string, anyOrder bool, expectedE
 			} else {
 				actualObject = actualEvent.Object
 			}
-			log.Infof(
-				"Actual:   EventType:%s; Kind:%s; Name:%s; Namespace:%s",
-				actualEvent.Type,
-				actualObject.GetObjectKind().GroupVersionKind(),
-				actualObject.(v1.ObjectMetaAccessor).GetObjectMeta().GetName(),
-				actualObject.(v1.ObjectMetaAccessor).GetObjectMeta().GetNamespace(),
-			)
+			if actualObject != nil {
+				log.Infof(
+					"Actual:   EventType:%s; Kind:%s; Name:%s; Namespace:%s",
+					actualEvent.Type,
+					actualObject.GetObjectKind().GroupVersionKind(),
+					actualObject.(v1.ObjectMetaAccessor).GetObjectMeta().GetName(),
+					actualObject.(v1.ObjectMetaAccessor).GetObjectMeta().GetNamespace(),
+				)
+			} else {
+				log.Warnf("Actual:    EventType:%s, Object: <nil>; Error: %s", actualEvent.Type, actualEvent.Error)
+			}
 		} else {
 			log.Error("Actual:   Event missing")
 		}


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
I hit an issue while trying to add a namespaced object where watching a particular object would result in spurious watch Events set to the init value (ADDED with nil object and nil prevous object).  The reason is that calls to `convertWatchEvent` are supposed to return nil if the watch isn't of interest, but instead we return an un-filled WatchEvent.  This fixes that issue.

I think our testing only checks watching an object by namespace & name, not name only, and thus misses this case.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
