### PR TITLE
Add contains/startswith/endswith selector  operators.

### DIFF
--- a/lib/selector/parser/parser.go
+++ b/lib/selector/parser/parser.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016, 2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -163,6 +163,27 @@ func parseOperation(tokens []tokenizer.Token) (sel node, remTokens []tokenizer.T
 		case tokenizer.TokNe:
 			if tokens[2].Kind == tokenizer.TokStringLiteral {
 				sel = &LabelNeValueNode{tokens[0].Value.(string), tokens[2].Value.(string)}
+				remTokens = tokens[3:]
+			} else {
+				err = errors.New("Expected string")
+			}
+		case tokenizer.TokContains:
+			if tokens[2].Kind == tokenizer.TokStringLiteral {
+				sel = &LabelContainsValueNode{tokens[0].Value.(string), tokens[2].Value.(string)}
+				remTokens = tokens[3:]
+			} else {
+				err = errors.New("Expected string")
+			}
+		case tokenizer.TokStartsWith:
+			if tokens[2].Kind == tokenizer.TokStringLiteral {
+				sel = &LabelStartsWithValueNode{tokens[0].Value.(string), tokens[2].Value.(string)}
+				remTokens = tokens[3:]
+			} else {
+				err = errors.New("Expected string")
+			}
+		case tokenizer.TokEndsWith:
+			if tokens[2].Kind == tokenizer.TokStringLiteral {
+				sel = &LabelEndsWithValueNode{tokens[0].Value.(string), tokens[2].Value.(string)}
 				remTokens = tokens[3:]
 			} else {
 				err = errors.New("Expected string")

--- a/lib/selector/tokenizer/tokenizer_test.go
+++ b/lib/selector/tokenizer/tokenizer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016, 2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,81 @@ var tokenTests = []struct {
 		{tokenizer.TokStringLiteral, "value"},
 		{tokenizer.TokEOF, nil},
 	}},
+	{`label contains "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokContains, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`contains contains "contains"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "contains"},
+		{tokenizer.TokContains, nil},
+		{tokenizer.TokStringLiteral, "contains"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`contains contains 'contains'`, []tokenizer.Token{
+		{tokenizer.TokLabel, "contains"},
+		{tokenizer.TokContains, nil},
+		{tokenizer.TokStringLiteral, "contains"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label contains"value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokContains, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label startswith "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokStartsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label endswith "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokEndsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label starts with "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokStartsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`startswith starts with "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "startswith"},
+		{tokenizer.TokStartsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label ends with "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokEndsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`endswith ends with "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "endswith"},
+		{tokenizer.TokEndsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label starts  with "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokStartsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label ends  with "value"`, []tokenizer.Token{
+		{tokenizer.TokLabel, "label"},
+		{tokenizer.TokEndsWith, nil},
+		{tokenizer.TokStringLiteral, "value"},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`label starts foo "value"`, nil},
+	{`label ends foo "value"`, nil},
+	{`label squiggles "value"`, nil},
 	{`a not in "bar" && !has(foo) || b in c`, []tokenizer.Token{
 		{tokenizer.TokLabel, "a"},
 		{tokenizer.TokNotIn, nil},
@@ -138,8 +213,15 @@ var _ = Describe("Token", func() {
 
 	for _, test := range tokenTests {
 		test := test // Take copy for closure
-		It(fmt.Sprintf("should tokenize %#v as %v", test.input, test.expected), func() {
-			Expect(tokenizer.Tokenize(test.input)).To(Equal(test.expected))
-		})
+		if test.expected == nil {
+			It(fmt.Sprintf("should return error for input %#v", test.input), func() {
+				_, err := tokenizer.Tokenize(test.input)
+				Expect(err).To(HaveOccurred())
+			})
+		} else {
+			It(fmt.Sprintf("should tokenize %#v as %v", test.input, test.expected), func() {
+				Expect(tokenizer.Tokenize(test.input)).To(Equal(test.expected))
+			})
+		}
 	}
 })


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add `contains`, `starts with` and `ends with` operators to selector syntax.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Selector syntax now supports operators for substring matching: "contains", "starts with" and "ends with".
```
