### PR TITLE
Fix default make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Shortcut targets
-default: build
+default: test
 
 ## Build binary
-all: build
+all: test
 
 ## Run the tests
 test: ut fv


### PR DESCRIPTION
In the Makefile, the `build` task doesn't exist, `test` seems like a reasonable default.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
