### PR TITLE
Treat finished pods as having no IPs

### DIFF
--- a/lib/testutils/syncertester.go
+++ b/lib/testutils/syncertester.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -211,14 +211,16 @@ func (st *SyncerTester) ExpectData(kvp model.KVPair) {
 		value := func() interface{} {
 			return st.GetCacheValue(key)
 		}
-		Eventually(value, 6*time.Second, time.Millisecond).Should(Equal(kvp.Value))
-		Consistently(value).Should(Equal(kvp.Value), "KVPair data was incorrect")
+		EventuallyWithOffset(1, value, 6*time.Second, time.Millisecond).Should(Equal(kvp.Value),
+			fmt.Sprintf("Timed out waiting for %v to equal expected value", key))
+		ConsistentlyWithOffset(1, value).Should(Equal(kvp.Value), "KVPair data was incorrect")
 	} else {
 		kv := func() interface{} {
 			return st.GetCacheKVPair(key)
 		}
-		Eventually(kv, 6*time.Second, time.Millisecond).Should(Equal(kvp))
-		Consistently(kv).Should(Equal(kvp), "KVPair data (or revision) was incorrect")
+		EventuallyWithOffset(1, kv, 6*time.Second, time.Millisecond).Should(Equal(kvp),
+			fmt.Sprintf("Timed out waiting for %v to equal expected value @ rev %v", key, kvp.Revision))
+		ConsistentlyWithOffset(1, kv).Should(Equal(kvp), "KVPair data (or revision) was incorrect")
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Workload endpoints with no IP get filtered out int he syncer and result in a deletion to Felix.
- They are presented as is on the v3 get/list/watch API, resulting in correct API update type behaviour (although it's a bit odd to have a wep with no IP it's already possible so it feels less risky).

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
