### PR TITLE
Ensure protocol is TCP is HTTP rule is given

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -72,6 +72,7 @@ var (
 	overlapsV6LinkLocal   = "IP pool range overlaps with IPv6 Link Local range fe80::/10"
 	protocolPortsMsg      = "rules that specify ports must set protocol to TCP or UDP"
 	protocolIcmpMsg       = "rules that specify ICMP fields must set protocol to ICMP"
+	protocolAndHTTPMsg    = "rules that specify HTTP fields must set protocol to TCP"
 
 	ipv4LinkLocalNet = net.IPNet{
 		IP:   net.ParseIP("169.254.0.0"),
@@ -756,6 +757,14 @@ func validateRule(structLevel validator.StructLevel) {
 		if len(rule.Destination.NotPorts) > 0 {
 			structLevel.ReportError(reflect.ValueOf(rule.Destination.NotPorts),
 				"Destination.NotPorts", "", reason(protocolPortsMsg), "")
+		}
+	}
+
+	// Check that HTTP must not use non-TCP protocols
+	if rule.HTTP != nil && rule.Protocol != nil {
+		tcp := numorstring.ProtocolFromString("TCP")
+		if *rule.Protocol != tcp {
+			structLevel.ReportError(reflect.ValueOf(rule.Protocol), "Protocol", "", reason(protocolAndHTTPMsg), "")
 		}
 	}
 

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -72,7 +72,7 @@ var (
 	overlapsV6LinkLocal   = "IP pool range overlaps with IPv6 Link Local range fe80::/10"
 	protocolPortsMsg      = "rules that specify ports must set protocol to TCP or UDP"
 	protocolIcmpMsg       = "rules that specify ICMP fields must set protocol to ICMP"
-	protocolAndHTTPMsg    = "rules that specify HTTP fields must set protocol to TCP"
+	protocolAndHTTPMsg    = "rules that specify HTTP fields must set protocol to TCP or empty"
 
 	ipv4LinkLocalNet = net.IPNet{
 		IP:   net.ParseIP("169.254.0.0"),

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -17,13 +17,13 @@ package v3_test
 import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/projectcalico/libcalico-go/lib/apis/v1"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
-	"github.com/projectcalico/libcalico-go/lib/validator/v3"
+	v3 "github.com/projectcalico/libcalico-go/lib/validator/v3"
 )
 
 func init() {
@@ -1158,6 +1158,23 @@ func init() {
 				Action: "Deny",
 				HTTP:   &api.HTTPMatch{Methods: []string{"GET"}},
 			}, false),
+		Entry("should reject non-TCP protocol with HTTP clause",
+			api.Rule{
+				Action:   "Allow",
+				Protocol: protocolFromString("UDP"),
+				HTTP:     &api.HTTPMatch{Methods: []string{"GET"}},
+			}, false),
+		Entry("should accept TCP protocol with HTTP clause",
+			api.Rule{
+				Action:   "Allow",
+				Protocol: protocolFromString("TCP"),
+				HTTP:     &api.HTTPMatch{Methods: []string{"GET"}},
+			}, true),
+		Entry("should accept missing protocol with HTTP clause",
+			api.Rule{
+				Action: "Allow",
+				HTTP:   &api.HTTPMatch{Methods: []string{"GET"}},
+			}, true),
 
 		// (API) BGPPeerSpec
 		Entry("should accept valid BGPPeerSpec", api.BGPPeerSpec{PeerIP: ipv4_1}, true),


### PR DESCRIPTION
## Description

This PR adds a check to make sure that combination of rules make sense together. Specifically, if an HTTP-level rule is given, the protocol has to be TCP.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Validate that protocol is set correctly if an HTTPMatch is specified in a NetworkPolicy
```
