### PR TITLE
[v3.0] Treat finished pods as having no IPs (+1 other commit)

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -117,19 +117,16 @@ func (c Converter) NamespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, erro
 }
 
 // IsValidCalicoWorkloadEndpoint returns true if the pod should be shown as a workloadEndpoint
-// in the Calico API and false otherwise.  A Pod suitable for Calico should not be host
-// networked and should have been scheduled to a Node.
+// in the Calico API and false otherwise.  Note: since we completely ignore notifications for
+// invalid Pods, it is important that pods can only transition from not-valid to valid and not
+// the other way.  If they transition from valid to invalid, we'll fail to emit a deletion
+// event in the watcher.
 func (c Converter) IsValidCalicoWorkloadEndpoint(pod *kapiv1.Pod) bool {
 	if c.IsHostNetworked(pod) {
 		log.WithField("pod", pod.Name).Debug("Pod is host networked.")
 		return false
 	} else if !c.IsScheduled(pod) {
 		log.WithField("pod", pod.Name).Debug("Pod is not scheduled.")
-		return false
-	} else if c.IsFinished(pod) {
-		// Exclude finished pods.  When a pod finishes, the kubelet releases its IP so
-		// the IP in the pod status no-longer belongs to this endpoint.
-		log.WithField("pod", pod.Name).Debug("Pod has finished.")
 		return false
 	}
 	return true
@@ -222,11 +219,19 @@ func (c Converter) PodToWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error)
 		return nil, err
 	}
 
-	// An IP address may not yet be assigned (or may have been removed for a Pod deletion), so
-	// handle a missing IP gracefully.
 	ipNets, err := c.GetPodIPs(pod)
 	if err != nil {
+		// IP address was present but malformed in some way, handle as an explicit failure.
 		return nil, err
+	}
+
+	if c.IsFinished(pod) {
+		// Pod is finished but not yet deleted.  In this state the IP will have been freed and returned to the pool
+		// so we need to make sure we don't let the caller believe it still belongs to this endpoint.
+		// Pods with no IPs will get filtered out before they get to Felix in the watcher syncer cache layer.
+		// We can't pretend the workload endpoint is deleted _here_ because that would confuse users of the
+		// native v3 Watch() API.
+		ipNets = nil
 	}
 
 	// Generate the interface name based on workload.  This must match

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -319,6 +319,24 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should return a value for a missing pod IP", func() {
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "podA",
+				Namespace:       "default",
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+		}
+
+		kvp, err := c.PodToWorkloadEndpoint(&pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvp.Value).NotTo(BeNil())
+	})
+
 	It("should prioritise PodIP over the calico annotation for the IP", func() {
 		pod := kapiv1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -349,7 +367,7 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(ConsistOf("192.168.0.2/32"))
 	})
 
-	DescribeTable("IsValidCalicoWorkloadEndpoint reject/accept phase tests",
+	DescribeTable("PodToWorkloadEndpoint reject/accept phase tests",
 		func(podPhase kapiv1.PodPhase, expectedResult bool) {
 			pod := kapiv1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -369,7 +387,13 @@ var _ = Describe("Test Pod conversion", func() {
 					Phase: podPhase,
 				},
 			}
-			Expect(c.IsValidCalicoWorkloadEndpoint(&pod)).To(Equal(expectedResult))
+			kvp, err := c.PodToWorkloadEndpoint(&pod)
+			Expect(err).NotTo(HaveOccurred())
+			if expectedResult {
+				Expect(kvp.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(HaveLen(1))
+			} else {
+				Expect(kvp.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(HaveLen(0))
+			}
 		},
 		Entry("Pending", kapiv1.PodPending, true),
 		Entry("Running", kapiv1.PodRunning, true),

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import (
 
 	k8sapi "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -319,6 +320,41 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		go cb.ProcessUpdates()
 	})
 
+	AfterEach(func() {
+		// Clean up all Calico resources.
+		err := c.Clean()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Clean up any k8s network policy left over by the test.
+		nps := networkingv1.NetworkPolicyList{}
+		err = c.clientSet.NetworkingV1().RESTClient().
+			Get().
+			Resource("networkpolicies").
+			Timeout(10 * time.Second).
+			Do().Into(&nps)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, np := range nps.Items {
+			result := c.clientSet.NetworkingV1().RESTClient().
+				Delete().
+				Resource("networkpolicies").
+				Namespace(np.Namespace).
+				Name(np.Name).
+				Timeout(10 * time.Second).
+				Do()
+			Expect(result.Error()).NotTo(HaveOccurred())
+		}
+
+		// Clean up any pods left over by the test.
+		pods, err := c.clientSet.CoreV1().Pods("").List(metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, p := range pods.Items {
+			err = c.clientSet.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
 	It("should handle a Namespace with DefaultDeny (v1beta annotation for namespace isolation)", func() {
 		ns := k8sapi.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -329,12 +365,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				Labels: map[string]string{"label": "value"},
 			},
 		}
-
-		// Make sure we clean up.  Don't check for errors since we attempt
-		// to delete as part of the test below.
-		defer func() {
-			c.clientSet.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, &metav1.DeleteOptions{})
-		}()
 
 		By("Creating a namespace", func() {
 			_, err := c.clientSet.CoreV1().Namespaces().Create(&ns)
@@ -382,12 +412,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				Labels:      map[string]string{"label": "value"},
 			},
 		}
-
-		// Make sure we clean up after ourselves.  Don't check for errors since we attempt
-		// to delete as part of the test below.
-		defer func() {
-			c.clientSet.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, &metav1.DeleteOptions{})
-		}()
 
 		// Check to see if the create succeeded.
 		By("Creating a namespace", func() {
@@ -465,17 +489,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Body(&np).
 			Do()
 
-		// Make sure we clean up after ourselves.
-		defer func() {
-			res := c.clientSet.ExtensionsV1beta1().RESTClient().
-				Delete().
-				Resource("networkpolicies").
-				Namespace("default").
-				Name(np.ObjectMeta.Name).
-				Do()
-			Expect(res.Error()).NotTo(HaveOccurred())
-		}()
-
 		// Check to see if the create succeeded.
 		Expect(res.Error()).NotTo(HaveOccurred())
 
@@ -491,38 +504,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		}, "")
 		Expect(err).NotTo(HaveOccurred())
 	})
-
-	// Add a defer to wait for policies to clean up.
-	defer func() {
-		log.Warnf("[TEST] Waiting for policies to tear down")
-		It("should clean up all policies", func() {
-			nps := extensions.NetworkPolicyList{}
-			err := c.clientSet.ExtensionsV1beta1().RESTClient().
-				Get().
-				Resource("networkpolicies").
-				Namespace("default").
-				Timeout(10 * time.Second).
-				Do().Into(&nps)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Loop until no network policies exist.
-			for i := 0; i < 10; i++ {
-				if len(nps.Items) == 0 {
-					return
-				}
-				nps := extensions.NetworkPolicyList{}
-				err := c.clientSet.ExtensionsV1beta1().RESTClient().
-					Get().
-					Resource("networkpolicies").
-					Namespace("default").
-					Timeout(10 * time.Second).
-					Do().Into(&nps)
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(1 * time.Second)
-			}
-			panic(fmt.Sprintf("Failed to clean up policies: %+v", nps))
-		})
-	}()
 
 	It("should handle a CRUD of Global Network Policy", func() {
 		var kvpRes *model.KVPair
@@ -587,13 +568,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				Spec: calicoDisallowPolicyModelSpec,
 			},
 		}
-
-		// Make sure we clean up after ourselves.  We allow this to fail because
-		// part of our explicit testing below is to delete the resource.
-		defer func() {
-			gnpClient.Delete(ctx, kvp1a.Key, "")
-			gnpClient.Delete(ctx, kvp2a.Key, "")
-		}()
 
 		// Check our syncer has the correct GNP entries for the two
 		// System Network Protocols that this test manipulates.  Neither
@@ -782,13 +756,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		var kvpRes *model.KVPair
 		var err error
 
-		// Make sure we clean up after ourselves.  We allow this to fail because
-		// part of our explicit testing below is to delete the resource.
-		defer func() {
-			c.Delete(ctx, kvp1a.Key, "")
-			c.Delete(ctx, kvp2a.Key, "")
-		}()
-
 		By("Creating a BGP Peer", func() {
 			kvpRes, err = c.Create(ctx, kvp1a)
 			Expect(err).NotTo(HaveOccurred())
@@ -876,20 +843,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 	It("should handle a CRUD of Node BGP Peer", func() {
 		var kvp1a, kvp1b, kvp2a, kvp2b, kvpRes *model.KVPair
 		var nodename, peername1, peername2 string
-
-		// Make sure we clean up after ourselves.  We allow this to fail because
-		// part of our explicit testing below is to delete the resource.
-		defer func() {
-			log.Debug("Deleting Node BGP Peers")
-			if peers, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindBGPPeer}, ""); err == nil {
-				log.WithField("Peers", peers).Debug("Deleting resources")
-				for _, peer := range peers.KVPairs {
-					log.WithField("Key", peer.Key).Debug("Deleting resource")
-					peer.Revision = ""
-					_, _ = c.Delete(ctx, peer.Key, "")
-				}
-			}
-		}()
 
 		By("Listing all Nodes to find a suitable Node name", func() {
 			nodes, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindNode}, "")
@@ -1105,12 +1058,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		_, err := c.clientSet.CoreV1().Pods("default").Create(&pod)
 		wepName := "127.0.0.1-k8s-test--syncer--basic--pod-eth0"
 
-		// Make sure we clean up after ourselves.  This might fail if we reach the
-		// test below which deletes this pod, but that's OK.
-		defer func() {
-			log.Warnf("[TEST] Cleaning up test pod: %s", pod.ObjectMeta.Name)
-			_ = c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
-		}()
 		By("Creating a pod", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -1227,12 +1174,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		pod, err := c.clientSet.CoreV1().Pods("default").Create(pod)
 		wepName := "127.0.0.1-k8s-test--syncer--basic--pod-eth0"
 
-		// Make sure we clean up after ourselves.  This might fail if we reach the
-		// test below which deletes this pod, but that's OK.
-		defer func() {
-			log.Warnf("[TEST] Cleaning up test pod: %s", pod.ObjectMeta.Name)
-			_ = c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
-		}()
 		By("Creating a pod", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -1337,26 +1278,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 	})
 
-	// Add a defer to wait for all pods to clean up.
-	defer func() {
-		It("should clean up all pods", func() {
-			log.Warnf("[TEST] Waiting for pods to tear down")
-			pods, err := c.clientSet.CoreV1().Pods("default").List(metav1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Wait up to 60s for pod cleanup to occur.
-			for i := 0; i < 60; i++ {
-				if len(pods.Items) == 0 {
-					return
-				}
-				pods, err = c.clientSet.CoreV1().Pods("default").List(metav1.ListOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(1 * time.Second)
-			}
-			panic(fmt.Sprintf("Failed to clean up pods: %+v", pods))
-		})
-	}()
-
 	It("should error on unsupported List() calls", func() {
 		objs, err := c.List(ctx, model.BlockAffinityListOptions{}, "")
 		Expect(err).To(HaveOccurred())
@@ -1399,12 +1320,6 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		}
 		var updFC *model.KVPair
 		var err error
-
-		defer func() {
-			// Always make sure we tidy up after ourselves.  Ignore
-			// errors since the test itself should delete what it created.
-			_, _ = c.Delete(ctx, fc.Key, "")
-		}()
 
 		By("creating a new object", func() {
 			updFC, err = c.Create(ctx, fc)

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -17,8 +17,11 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/projectcalico/libcalico-go/lib/names"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -181,7 +184,7 @@ func (c cb) ExpectExists(updates []api.Update) {
 		log.Infof("[TEST] Expecting key: %v", update.Key)
 		matches := false
 
-		wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
+		_ = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
 			// Get the update.
 			c.Lock.Lock()
 			u, ok := c.State[update.Key.String()]
@@ -191,7 +194,7 @@ func (c cb) ExpectExists(updates []api.Update) {
 			// that the key exists and that it's the correct type.
 			matches = ok && update.UpdateType == u.UpdateType
 
-			log.Infof("[TEST] Key exists? %t matches? %t: %+v", ok, matches, u)
+			log.Infof("[TEST] Key exists? %t matches? %t: expected %v; actual %v", ok, matches, update.UpdateType, u.UpdateType)
 			if matches {
 				// Expected the update to be present, and it is.
 				return true, nil
@@ -213,7 +216,7 @@ func (c cb) ExpectDeleted(kvps []model.KVPair) {
 		log.Infof("[TEST] Not expecting key: %v", kvp.Key)
 		exists := true
 
-		wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
+		_ = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
 			// Get the update.
 			c.Lock.Lock()
 			update, ok := c.State[kvp.Key.String()]
@@ -1038,10 +1041,10 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 	})
 
-	It("should handle a basic Pod", func() {
-		pod := k8sapi.Pod{
+	createPodAndMarkAsRunning := func(name string) (*k8sapi.Pod, string) {
+		pod := &k8sapi.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-syncer-basic-pod",
+				Name:      name,
 				Namespace: "default",
 			},
 			Spec: k8sapi.PodSpec{
@@ -1055,21 +1058,17 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				},
 			},
 		}
-		_, err := c.clientSet.CoreV1().Pods("default").Create(&pod)
-		wepName := "127.0.0.1-k8s-test--syncer--basic--pod-eth0"
-
+		pod, err := c.clientSet.CoreV1().Pods("default").Create(pod)
 		By("Creating a pod", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		By("Assigning an IP", func() {
 			// Update the Pod to have an IP and be running.
 			pod.Status.PodIP = "192.168.1.1"
 			pod.Status.Phase = k8sapi.PodRunning
-			_, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(&pod)
+			pod, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(pod)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		By("Waiting for the pod to start", func() {
 			// Wait up to 120s for pod to start running.
 			log.Warnf("[TEST] Waiting for pod %s to start", pod.ObjectMeta.Name)
@@ -1087,6 +1086,21 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(p.Status.Phase).To(Equal(k8sapi.PodRunning))
 		})
 
+		wepids := names.WorkloadEndpointIdentifiers{
+			Node:         pod.Spec.NodeName,
+			Orchestrator: apiv3.OrchestratorKubernetes,
+			Endpoint:     "eth0",
+			Pod:          pod.Name,
+		}
+		wepName, err := wepids.CalculateWorkloadEndpointName(false)
+		Expect(err).NotTo(HaveOccurred())
+
+		return pod, wepName
+	}
+
+	It("should handle a basic Pod", func() {
+		pod, wepName := createPodAndMarkAsRunning("basic-pod")
+
 		By("Performing a List() operation", func() {
 			// Perform List and ensure it shows up in the Calico API.
 			weps, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindWorkloadEndpoint}, "")
@@ -1101,7 +1115,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(len(weps.KVPairs)).To(Equal(1))
 		})
 
-		By("Performing a Get() operation", func() {
+		By("Performing a Get() operation then updating the wep", func() {
 			// Perform a Get and ensure no error in the Calico API.
 			wep, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}, "")
 			Expect(err).NotTo(HaveOccurred())
@@ -1136,17 +1150,141 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			snapshotCallbacks.ExpectExists([]api.Update{
 				{KVPair: expectedKVP, UpdateType: api.UpdateTypeKVNew},
 			})
-
 		})
 
 		By("Deleting the Pod and expecting the wep to be deleted", func() {
 			var zero int64
 			policy := metav1.DeletePropagationBackground
-			err = c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{
+			err := c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{
 				GracePeriodSeconds: &zero,
 				PropagationPolicy:  &policy,
 			})
 			Expect(err).NotTo(HaveOccurred())
+			cb.ExpectDeleted([]model.KVPair{expectedKVP})
+		})
+	})
+
+	// There are several states that we consider "finished", run the test for each one.
+	for _, finishPhase := range []k8sapi.PodPhase{k8sapi.PodSucceeded, k8sapi.PodFailed} {
+		finishPhase := finishPhase
+		It(fmt.Sprintf("should treat a finished Pod (%v) as a deletion", finishPhase), func() {
+			pod, wepName := createPodAndMarkAsRunning("finished-pod-" + strings.ToLower(string(finishPhase)))
+			var err error
+
+			expectedKVP := model.KVPair{
+				Key: model.WorkloadEndpointKey{
+					Hostname:       "127.0.0.1",
+					OrchestratorID: "k8s",
+					WorkloadID:     fmt.Sprintf("default/%s", pod.ObjectMeta.Name),
+					EndpointID:     "eth0",
+				},
+			}
+
+			By("Expecting an update with type 'UpdateTypeKVNew' on the Syncer API", func() {
+				// The update processor filters out the initial update where the pod has no IP, then we get this
+				// notification when the IP is added.
+				cb.ExpectExists([]api.Update{
+					{KVPair: expectedKVP, UpdateType: api.UpdateTypeKVNew},
+				})
+			})
+
+			By("Checking the pod is visible before we mark it as finished", func() {
+				// Perform a Get and ensure no error in the Calico API.
+				wep, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(wep).NotTo(BeNil())
+
+				// Perform List and ensure it shows up in the Calico API.
+				weps, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindWorkloadEndpoint}, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(weps.KVPairs)).To(BeNumerically(">", 0))
+			})
+
+			By(fmt.Sprintf("Marking the Pod as finished (%v)", finishPhase), func() {
+				pod.Status.Phase = finishPhase
+				pod, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(pod)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Expecting an update with type 'KVDeleted' on the Syncer API", func() {
+				cb.ExpectDeleted([]model.KVPair{expectedKVP})
+			})
+
+			// Now go back from finished to running again.  This is likely impossible on a real Kubernetes system
+			// but it's helpful for testing out our UpdateType calculation logic.  I.e. since the last update was
+			// a "delete", we should now see a "new", rather than an "update".
+
+			By("Marking the Pod as running again", func() {
+				pod.Status.Phase = k8sapi.PodRunning
+				pod, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(pod)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Expecting an update that creates the wep again", func() {
+				cb.ExpectExists([]api.Update{
+					{KVPair: expectedKVP, UpdateType: api.UpdateTypeKVNew},
+				})
+			})
+
+			By("Checking the pod is gettable", func() {
+				// Perform a Get and ensure no error in the Calico API.
+				_, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}, "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Deleting the Pod and expecting the wep to be deleted", func() {
+				var zero int64
+				policy := metav1.DeletePropagationBackground
+				err := c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{
+					GracePeriodSeconds: &zero,
+					PropagationPolicy:  &policy,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				cb.ExpectDeleted([]model.KVPair{expectedKVP})
+			})
+		})
+	}
+
+	It("should treat a pod that loses its IP as a deletion", func() {
+		pod, wepName := createPodAndMarkAsRunning("pod-losing-ip")
+		var err error
+
+		expectedKVP := model.KVPair{
+			Key: model.WorkloadEndpointKey{
+				Hostname:       "127.0.0.1",
+				OrchestratorID: "k8s",
+				WorkloadID:     fmt.Sprintf("default/%s", pod.ObjectMeta.Name),
+				EndpointID:     "eth0",
+			},
+		}
+
+		By("Expecting an update with type 'UpdateTypeKVNew' on the Syncer API", func() {
+			// The update processor filters out the initial update where the pod has no IP, then we get this
+			// notification when the IP is added.
+			cb.ExpectExists([]api.Update{
+				{KVPair: expectedKVP, UpdateType: api.UpdateTypeKVNew},
+			})
+		})
+
+		By("Checking the pod is visible before we remove its IP", func() {
+			// Perform a Get and ensure no error in the Calico API.
+			wep, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wep).NotTo(BeNil())
+
+			// Perform List and ensure it shows up in the Calico API.
+			weps, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindWorkloadEndpoint}, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(weps.KVPairs)).To(BeNumerically(">", 0))
+		})
+
+		By("Removing its IP", func() {
+			pod.Status.PodIP = ""
+			pod, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("Expecting an update with type 'KVDeleted' on the Syncer API", func() {
 			cb.ExpectDeleted([]model.KVPair{expectedKVP})
 		})
 	})

--- a/lib/testutils/syncertester.go
+++ b/lib/testutils/syncertester.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -211,14 +211,16 @@ func (st *SyncerTester) ExpectData(kvp model.KVPair) {
 		value := func() interface{} {
 			return st.GetCacheValue(key)
 		}
-		Eventually(value, 6*time.Second, 500*time.Millisecond).Should(Equal(kvp.Value))
-		Consistently(value).Should(Equal(kvp.Value), "KVPair data was incorrect")
+		EventuallyWithOffset(1, value, 6*time.Second, time.Millisecond).Should(Equal(kvp.Value),
+			fmt.Sprintf("Timed out waiting for %v to equal expected value", key))
+		ConsistentlyWithOffset(1, value).Should(Equal(kvp.Value), "KVPair data was incorrect")
 	} else {
 		kv := func() interface{} {
 			return st.GetCacheKVPair(key)
 		}
-		Eventually(kv, 6*time.Second, 500*time.Millisecond).Should(Equal(kvp))
-		Consistently(kv).Should(Equal(kvp), "KVPair data (or revision) was incorrect")
+		EventuallyWithOffset(1, kv, 6*time.Second, time.Millisecond).Should(Equal(kvp),
+			fmt.Sprintf("Timed out waiting for %v to equal expected value @ rev %v", key, kvp.Revision))
+		ConsistentlyWithOffset(1, kv).Should(Equal(kvp), "KVPair data (or revision) was incorrect")
 	}
 }
 


### PR DESCRIPTION
Cherry pick the changes from #1047 and #813.
I found the need for #813 to make the tests to merge nicely without too much cleanup. 