### PR TITLE
Add watch kdd

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -300,6 +300,7 @@ func (c *KubeClient) Clean() error {
 		apiv3.KindFelixConfiguration,
 		apiv3.KindGlobalNetworkPolicy,
 		apiv3.KindGlobalNetworkSet,
+		apiv3.KindNetworkPolicy,
 		apiv3.KindNetworkSet,
 		apiv3.KindIPPool,
 		apiv3.KindHostEndpoint,


### PR DESCRIPTION
This PR adds support for named `Watch` for calico resources.

I'm open to suggestions on structure or style.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
