### PR TITLE
Fix missing networksets list

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -394,6 +394,7 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 				&apiv3.NetworkPolicy{},
 				&apiv3.NetworkPolicyList{},
 				&apiv3.NetworkSet{},
+				&apiv3.NetworkSetList{},
 				&apiv3.HostEndpoint{},
 				&apiv3.HostEndpointList{},
 				&apiv3.BlockAffinity{},

--- a/lib/backend/k8s/resources/customresource.go
+++ b/lib/backend/k8s/resources/customresource.go
@@ -350,8 +350,14 @@ func (c *customK8sResourceClient) EnsureInitialized() error {
 
 func (c *customK8sResourceClient) listInterfaceToKey(l model.ListInterface) model.Key {
 	pl := l.(model.ResourceListOptions)
+	key := model.ResourceKey{Name: pl.Name, Kind: pl.Kind}
+
+	if c.namespaced && pl.Namespace != "" {
+		key.Namespace = pl.Namespace
+	}
+
 	if pl.Name != "" {
-		return model.ResourceKey{Name: pl.Name, Kind: pl.Kind}
+		return key
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Fixes the missing `NetworkSetList` crd registration in the KubeClient pointed out in https://github.com/projectcalico/libcalico-go/pull/1055#commitcomment-32712280
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
