### PR TITLE
Update doc for InterfaceExclude param

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -104,10 +104,10 @@ type FelixConfigurationSpec struct {
 	// and our OpenStack integration sets the ‘tap’ value. [Default: cali]
 	InterfacePrefix string `json:"interfacePrefix,omitempty"`
 	// InterfaceExclude is a comma-separated list of interfaces that Felix should exclude when monitoring for host
-	// endpoints.  The default value ensures that Felix ignores Kubernetes' IPVS dummy interface, which is used 
-	// internally by kube-proxy. If you want to exclude multiple interface names using a single value, the list 
-	// supports regular expressions. For regular expressions you must wrap the value with '/'. For example 
-	// having values '/^kube/,veth1' will exclude all interfaces that begin with 'kube' and also the interface 
+	// endpoints. The default value ensures that Felix ignores Kubernetes' IPVS dummy interface, which is used
+	// internally by kube-proxy. If you want to exclude multiple interface names using a single value, the list
+	// supports regular expressions. For regular expressions you must wrap the value with '/'. For example
+	// having values '/^kube/,veth1' will exclude all interfaces that begin with 'kube' and also the interface
 	// 'veth1'. [Default: kube-ipvs0]
 	InterfaceExclude string `json:"interfaceExclude,omitempty"`
 

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -106,9 +106,10 @@ type FelixConfigurationSpec struct {
 	// InterfaceExclude is a comma-separated list of interfaces that Felix should exclude when monitoring for host
 	// endpoints.  The default value ensures that Felix ignores Kubernetes' IPVS dummy interface, which is used 
 	// internally by kube-proxy. If you want to exclude multiple interface names using a single value, the list 
-	// supports regular expressions, e.g. to exclude all interfaces that begin with `kube`, simply include an 
-	// entry `/^kube/`. [Default: kube-ipvs0]
-	InterfaceExclude string(regex) `json:"interfaceExclude,omitempty"`
+	// supports regular expressions. For regular expressions you must wrap the value with '/'. For example 
+	// having values '/^kube/,veth1' will exclude all interfaces that begin with 'kube' and also the interface 
+	// 'veth1'. [Default: kube-ipvs0]
+	InterfaceExclude string `json:"interfaceExclude,omitempty"`
 
 	// ChainInsertMode controls whether Felix hooks the kernel’s top-level iptables chains by inserting a rule
 	// at the top of the chain or by appending a rule at the bottom. insert is the safe default since it prevents

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -103,10 +103,12 @@ type FelixConfigurationSpec struct {
 	// configure this appropriately. For example our Kubernetes and Docker integrations set the ‘cali’ value,
 	// and our OpenStack integration sets the ‘tap’ value. [Default: cali]
 	InterfacePrefix string `json:"interfacePrefix,omitempty"`
-	// InterfaceExclude is a list of interfaces that Felix should exclude when monitoring for host
-	// endpoints.  The default value ensures that Felix ignores Kubernetes' IPVS dummy interface,
-	// which is used internally by kube-proxy.  [Default: kube-ipvs0]
-	InterfaceExclude string `json:"interfaceExclude,omitempty"`
+	// InterfaceExclude is a comma-separated list of interfaces that Felix should exclude when monitoring for host
+	// endpoints.  The default value ensures that Felix ignores Kubernetes' IPVS dummy interface, which is used 
+	// internally by kube-proxy. If you want to exclude multiple interface names using a single value, the list 
+	// supports regular expressions, e.g. to exclude all interfaces that begin with `kube`, simply include an 
+	// entry `/^kube/`. [Default: kube-ipvs0]
+	InterfaceExclude string(regex) `json:"interfaceExclude,omitempty"`
 
 	// ChainInsertMode controls whether Felix hooks the kernel’s top-level iptables chains by inserting a rule
 	// at the top of the chain or by appending a rule at the bottom. insert is the safe default since it prevents


### PR DESCRIPTION
Update doc for InterfaceExclude param regarding regexp support.

## Description
Please include:
- type of fix: documentation
- this PR updates the documentation for InterfaceExclude to handle regular expressions
- additional test coverage on `felix` repo  
- components affected: 
    - `felix`
- links to issues that this PR addresses: 
    - addresses [feature request #1945 on `felix` repo](https://github.com/projectcalico/felix/issues/1945)

## Todos
- [ ] ~~Tests~~
- [x] Documentation
- [x] Release note

## Release Note
Check for release note on [PR for `felix` repo](https://github.com/projectcalico/felix/pull/1980). 
