### PR TITLE
Send WaitForDatastore if there's a watch error

### DIFF
--- a/lib/backend/watchersyncer/watchersyncer.go
+++ b/lib/backend/watchersyncer/watchersyncer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -222,6 +222,13 @@ func (ws *watcherSyncer) processResult(updates []api.Update, result interface{})
 				updates = ws.sendUpdates(updates)
 				ws.sendStatusUpdate(api.InSync)
 			}
+		} else if r == api.WaitForDatastore {
+			// If we received a WaitForDatastore from a watcherCache and we're in-sync or re-syncing, send a status
+			// update signalling that we're not in-sync.
+			if ws.status == api.InSync || ws.status == api.ResyncInProgress {
+				ws.sendStatusUpdate(api.WaitForDatastore)
+			}
+			ws.numSynced--
 		}
 	}
 


### PR DESCRIPTION
## Description

This updates the syncer to be able to report `WaitForDatastore` if any of its `watcherCache`s are not in-sync. Previously, the `watcherSyncer` state only went from `WaitForDatastore` -> `ResyncInProgress` -> `InSync`. This PR adds another state change: `InSync` -> `WaitForDatastore`.

Fixes https://github.com/projectcalico/libcalico-go/issues/478

This depends on a change to confd to handle multiple `InSync` statuses: https://github.com/projectcalico/confd/pull/230

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve `calico/node` readiness probe reporting when watches on the datastore error out.
```
