### PR TITLE
Improve health reporting

### DIFF
--- a/lib/health/health.go
+++ b/lib/health/health.go
@@ -168,7 +168,7 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 	}
 
 	// Summary status has changed so update previous status and log.
-	if summary.Live != aggregator.lastReport.Live && summary.Ready != aggregator.lastReport.Ready {
+	if summary.Live != aggregator.lastReport.Live || summary.Ready != aggregator.lastReport.Ready {
 		aggregator.lastReport = summary
 		log.WithField("lastSummary", summary).Info("Overall health status changed")
 
@@ -176,13 +176,13 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 			log.WithFields(log.Fields{
 				"name":           name,
 				"reporter-state": aggregator.reporters[name],
-			}).Debug("Reporter failed liveness checks")
+			}).Warn("Reporter failed liveness checks")
 		}
 		for _, name := range failedReadinessChecks {
 			log.WithFields(log.Fields{
 				"name":           name,
 				"reporter-state": aggregator.reporters[name],
-			}).Debug("Reporter failed readiness checks")
+			}).Warn("Reporter failed readiness checks")
 		}
 	}
 	return summary

--- a/lib/health/health.go
+++ b/lib/health/health.go
@@ -141,15 +141,15 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 	for name, reporter := range aggregator.reporters {
 		// Reset Live to false if that reporter is registered to report liveness and hasn't
 		// recently said that it is live.
-		notReportedLive := !reporter.latest.Live || reporter.TimedOut()
-		if summary.Live && reporter.reports.Live && notReportedLive {
+		stillLive := reporter.latest.Live && !reporter.TimedOut()
+		if summary.Live && reporter.reports.Live && !stillLive {
 			summary.Live = false
 		}
 
 		// Reset Ready to false if that reporter is registered to report readiness and
 		// hasn't recently said that it is ready.
-		notReportedReady := !reporter.latest.Ready || reporter.TimedOut()
-		if summary.Ready && reporter.reports.Ready && notReportedReady {
+		stillReady := reporter.latest.Ready && !reporter.TimedOut()
+		if summary.Ready && reporter.reports.Ready && !stillReady {
 			summary.Ready = false
 		}
 
@@ -158,7 +158,7 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 			"reporter-state": reporter,
 		})
 
-		if reporter.reports.Live && notReportedLive || reporter.reports.Ready && notReportedReady {
+		if reporter.reports.Live && !stillLive || reporter.reports.Ready && !stillReady {
 			logFuncs = append(logFuncs, func() {
 				logEntry.Warn("Unhealthy reporter")
 			})

--- a/lib/health/health.go
+++ b/lib/health/health.go
@@ -154,12 +154,13 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 			summary.Ready = false
 		}
 
-		switch {
-		case reporter.reports.Live && !stillLive:
+		if reporter.reports.Live && !stillLive {
 			failedLivenessChecks = append(failedLivenessChecks, name)
-		case reporter.reports.Ready && !stillReady:
+		}
+		if reporter.reports.Ready && !stillReady {
 			failedReadinessChecks = append(failedReadinessChecks, name)
-		default:
+		}
+		if reporter.reports.Live && reporter.reports.Ready && stillLive && stillReady {
 			log.WithFields(log.Fields{
 				"name":           name,
 				"reporter-state": reporter,


### PR DESCRIPTION
## Description

Fixes https://github.com/projectcalico/libcalico-go/issues/973

The `HealthAggregator` now only logs the overall health report if it has changed and unhealthy reporters are logged at WARN.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Health aggregator now only logs if overall health status has changed. Details of unhealthy reporters are now logged.
```
