### PR TITLE
Fix watching of IPAM blocks

### DIFF
--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -369,32 +369,8 @@ func (c *etcdV3Client) List(ctx context.Context, l model.ListInterface, revision
 	logCxt := log.WithFields(log.Fields{"list-interface": l, "rev": revision})
 	logCxt.Debug("Processing List request")
 
-	// To list entries, we enumerate from the common root based on the supplied
-	// IDs, and then filter the results.
-	key := model.ListOptionsToDefaultPathRoot(l)
-
-	// -  If the final name segment of the name is itself a prefix, then just perform a prefix Get
-	//    using the constructed key.
-	// -  If the etcdKey is actually fully qualified, then perform an exact Get using the constructed
-	//    key.
-	// -  If the etcdKey is not fully qualified then it is a path prefix but the last segment is complete.
-	//    Append a terminating "/" and perform a prefix Get.  The terminating / for a prefix Get ensures
-	//    for a prefix of "/a" we only return "child entries" of "/a" such as "/a/x" and not siblings
-	//    such as "/ab".
-	ops := []clientv3.OpOption{}
-	if model.IsListOptionsLastSegmentPrefix(l) {
-		// The last segment is a prefix, perform a prefix Get without adding a segment
-		// delimiter.
-		logCxt.Debug("Performing a name-prefix query")
-		ops = append(ops, clientv3.WithPrefix())
-	} else if l.KeyFromDefaultPath(key) == nil {
-		// The etcdKey not a fully qualified etcdKey - it must be a prefix.
-		logCxt.Debug("Performing a parent-prefix query")
-		if !strings.HasSuffix(key, "/") {
-			key += "/"
-		}
-		ops = append(ops, clientv3.WithPrefix())
-	}
+	// To list entries, we enumerate from the common root based on the supplied IDs, and then filter the results.
+	key, ops := calculateListKeyAndOptions(logCxt, l)
 	logCxt = logCxt.WithField("etcdv3-etcdKey", key)
 
 	// We may also need to perform a get based on a particular revision.
@@ -426,6 +402,35 @@ func (c *etcdV3Client) List(ctx context.Context, l model.ListInterface, revision
 		KVPairs:  list,
 		Revision: strconv.FormatInt(resp.Header.Revision, 10),
 	}, nil
+}
+
+func calculateListKeyAndOptions(logCxt *log.Entry, l model.ListInterface) (string, []clientv3.OpOption) {
+	// -  If the final name segment of the name is itself a prefix, then just perform a prefix Get
+	//    using the constructed key.
+	// -  If the etcdKey is actually fully qualified, then perform an exact Get using the constructed
+	//    key.
+	// -  If the etcdKey is not fully qualified then it is a path prefix but the last segment is complete.
+	//    Append a terminating "/" and perform a prefix Get.  The terminating / for a prefix Get ensures
+	//    for a prefix of "/a" we only return "child entries" of "/a" such as "/a/x" and not siblings
+	//    such as "/ab".
+	key := model.ListOptionsToDefaultPathRoot(l)
+	var ops []clientv3.OpOption
+	if model.IsListOptionsLastSegmentPrefix(l) {
+		// The last segment is a prefix, perform a prefix Get without adding a segment
+		// delimiter.
+		logCxt.Debug("List options is a name prefix, don't add a / to the path")
+		ops = append(ops, clientv3.WithPrefix())
+	} else if !model.ListOptionsIsFullyQualified(l) {
+		// The etcdKey not a fully qualified etcdKey - it must be a prefix.
+		logCxt.Debug("List options is a parent prefix, ensure path ends in /")
+		if !strings.HasSuffix(key, "/") {
+			logCxt.Debug("Adding / to path")
+			key += "/"
+		}
+		ops = append(ops, clientv3.WithPrefix())
+	}
+
+	return key, ops
 }
 
 // EnsureInitialized makes sure that the etcd data is initialized for use by

--- a/lib/backend/etcdv3/watcher.go
+++ b/lib/backend/etcdv3/watcher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,17 +100,13 @@ func (wc *watcher) watchLoop() {
 	opts := []clientv3.OpOption{clientv3.WithRev(wc.initialRev + 1), clientv3.WithPrevKV()}
 
 	// If we are not watching a specific resource then this is a prefix watch.
-	key := model.ListOptionsToDefaultPathRoot(wc.list)
-	logCxt := log.WithFields(log.Fields{
-		"etcdv3-key": key,
-		"rev":        wc.initialRev,
+	logCxt := log.WithField("list", wc.list)
+	key, opts := calculateListKeyAndOptions(logCxt, wc.list)
+	logCxt = logCxt.WithFields(log.Fields{
+		"etcdv3-etcdKey": key,
+		"rev":            wc.initialRev,
 	})
 	logCxt.Debug("Starting etcdv3 watch")
-	if !model.ListOptionsIsFullyQualified(wc.list) {
-		logCxt.Debug("Performing prefix watch")
-		opts = append(opts, clientv3.WithPrefix())
-		key += "/"
-	}
 	wch := wc.client.etcdClient.Watch(wc.ctx, key, opts...)
 	for wres := range wch {
 		if wres.Err() != nil {

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ func ListOptionsToDefaultPathRoot(listOptions ListInterface) string {
 // ListOptionsIsFullyQualified returns true if the options actually specify a fully
 // qualified resource rather than a partial match.
 func ListOptionsIsFullyQualified(listOptions ListInterface) bool {
-	// Contruct the path prefix and then check to see if that actually corresponds to
+	// Construct the path prefix and then check to see if that actually corresponds to
 	// the path of a resource instance.
 	return listOptions.KeyFromDefaultPath(listOptions.defaultPathRoot()) != nil
 }

--- a/lib/testutils/syncertester.go
+++ b/lib/testutils/syncertester.go
@@ -198,7 +198,7 @@ func (st *SyncerTester) ExpectCacheSize(size int) {
 // revision number is not stable).
 func (st *SyncerTester) ExpectData(kvp model.KVPair) {
 	key, err := model.KeyToDefaultPath(kvp.Key)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to convert key to default path: %v", kvp.Key))
 
 	if kvp.Revision == "" {
 		value := func() interface{} {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

etcd's list and watch methods were using different logic for calculating the key.  The list routine was tolerant to a `/` at the end of the default path but the watch routine was not.  Make the logic common and handle an extra `/` in both cases.  Improve logging to log out the actual key that we watch on rather than the key that we're about to add a `/` to!

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
