### PR TITLE
Switch libcalico-go to use calico fork of logrus

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -185,7 +185,8 @@ imports:
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: 1f80e3709dfafa8ca8727ba7eb392a11827ac8e2
+  repo: https://github.com/projectcalico/logrus
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/ugorji/go

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,9 +25,12 @@ import:
 # 1.1.0+ needed since our code expects the v4 uuid creation function to return a single value.
 - package: github.com/satori/go.uuid
   version: ^1.1.0
+# Use our fork, because v1.0.5 causes test breakages due to problems with our log formatting code,
+# but other deps require newer version because of the SetOutput function. Our fork backports
+# the missing stuff on top of v1.0.4.
 - package: github.com/sirupsen/logrus
-  # v1.0.5 causes test breakages due to problems with our log formatting code.
-  version: v1.0.4
+  repo: https://github.com/projectcalico/logrus
+  version: v1.0.4-calico
 - package: golang.org/x/net
   subpackages:
   - context


### PR DESCRIPTION
## Description
This is to fix a logging issue after bumping logrus to `v1.0.6`. Packr2
used by felix needed logrus with the `SetOutput` method, but the
fallout was that the messages now often have `<nil> <nil>` instead of
meaningful filename and line number. This only happens when used the
formatting version of log functions (like `Infof`).

The fork of logrus is based on `v1.0.4` with an extra commit adding
the `SetOutput` method to `Logger`.
