### PR TITLE
Reinstate host-local IPAM aggregation

### DIFF
--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -72,6 +72,10 @@ type KubeConfig struct {
 	K8sAPIToken              string `json:"k8sAPIToken" ignore:"true"`
 	K8sInsecureSkipTLSVerify bool   `json:"k8sInsecureSkipTLSVerify" envconfig:"K8S_INSECURE_SKIP_TLS_VERIFY" default:""`
 	K8sDisableNodePoll       bool   `json:"k8sDisableNodePoll" envconfig:"K8S_DISABLE_NODE_POLL" default:""`
+
+	// K8sUsePodCIDR controls whether or not IPAM blocks are generated based on Node.Spec.PodCIDR. Set this
+	// to true when using host-local IPAM, and set to false when using calico-ipam.
+	K8sUsePodCIDR bool `json:"usePodCIDR" envconfig:"USE_POD_CIDR" default:""`
 }
 
 // NewCalicoAPIConfig creates a new (zeroed) CalicoAPIConfig struct with the

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -32,7 +32,7 @@ import (
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -193,7 +193,7 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 		reflect.TypeOf(model.ResourceKey{}),
 		reflect.TypeOf(model.ResourceListOptions{}),
 		apiv3.KindNode,
-		resources.NewNodeClient(cs),
+		resources.NewNodeClient(cs, ca.K8sUsePodCIDR),
 	)
 	kubeClient.registerResourceClient(
 		reflect.TypeOf(model.ResourceKey{}),
@@ -213,30 +213,44 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 		apiv3.KindWorkloadEndpoint,
 		resources.NewWorkloadEndpointClient(cs),
 	)
-	kubeClient.registerResourceClient(
-		reflect.TypeOf(model.BlockAffinityKey{}),
-		reflect.TypeOf(model.BlockAffinityListOptions{}),
-		apiv3.KindBlockAffinity,
-		resources.NewBlockAffinityClient(cs, crdClientV1),
-	)
-	kubeClient.registerResourceClient(
-		reflect.TypeOf(model.BlockKey{}),
-		reflect.TypeOf(model.BlockListOptions{}),
-		apiv3.KindIPAMBlock,
-		resources.NewIPAMBlockClient(cs, crdClientV1),
-	)
-	kubeClient.registerResourceClient(
-		reflect.TypeOf(model.IPAMHandleKey{}),
-		reflect.TypeOf(model.IPAMHandleListOptions{}),
-		apiv3.KindIPAMHandle,
-		resources.NewIPAMHandleClient(cs, crdClientV1),
-	)
-	kubeClient.registerResourceClient(
-		reflect.TypeOf(model.IPAMConfigKey{}),
-		nil,
-		apiv3.KindIPAMConfig,
-		resources.NewIPAMConfigClient(cs, crdClientV1),
-	)
+
+	if ca.K8sUsePodCIDR {
+		// Using host-local IPAM. Use Kubernetes pod CIDRs to back IPAM.
+		log.Info("Using host-local IPAM")
+		kubeClient.registerResourceClient(
+			reflect.TypeOf(model.BlockAffinityKey{}),
+			reflect.TypeOf(model.BlockAffinityListOptions{}),
+			apiv3.KindBlockAffinity,
+			resources.NewPodCIDRBlockAffinityClient(cs),
+		)
+	} else {
+		// Using Calico IPAM - use CRDs to back IPAM resources.
+		log.Info("Using Calico IPAM")
+		kubeClient.registerResourceClient(
+			reflect.TypeOf(model.BlockAffinityKey{}),
+			reflect.TypeOf(model.BlockAffinityListOptions{}),
+			apiv3.KindBlockAffinity,
+			resources.NewBlockAffinityClient(cs, crdClientV1),
+		)
+		kubeClient.registerResourceClient(
+			reflect.TypeOf(model.BlockKey{}),
+			reflect.TypeOf(model.BlockListOptions{}),
+			apiv3.KindIPAMBlock,
+			resources.NewIPAMBlockClient(cs, crdClientV1),
+		)
+		kubeClient.registerResourceClient(
+			reflect.TypeOf(model.IPAMHandleKey{}),
+			reflect.TypeOf(model.IPAMHandleListOptions{}),
+			apiv3.KindIPAMHandle,
+			resources.NewIPAMHandleClient(cs, crdClientV1),
+		)
+		kubeClient.registerResourceClient(
+			reflect.TypeOf(model.IPAMConfigKey{}),
+			nil,
+			apiv3.KindIPAMConfig,
+			resources.NewIPAMConfigClient(cs, crdClientV1),
+		)
+	}
 
 	return kubeClient, nil
 }

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -316,7 +316,7 @@ func CreateClientAndSyncer(cfg apiconfig.KubeConfig) (*KubeClient, *cb, api.Sync
 		Lock:       &sync.Mutex{},
 		updateChan: updateChan,
 	}
-	syncer := felixsyncer.New(c, callback)
+	syncer := felixsyncer.New(c, caCfg, callback)
 	return c.(*KubeClient), &callback, syncer
 }
 

--- a/lib/backend/k8s/resources/ipam_block.go
+++ b/lib/backend/k8s/resources/ipam_block.go
@@ -61,9 +61,8 @@ func NewIPAMBlockClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResource
 
 // ipamBlockClient implements the api.Client interface for IPAMBlocks. It handles the translation between
 // v1 objects understood by the IPAM codebase in lib/ipam, and the CRDs which are used
-// to actually store the data in the Kubernetes API.
-// It uses a customK8sResourceClient under the covers to perform CRUD operations on
-// kubernetes CRDs.
+// to actually store the data in the Kubernetes API. It uses a customK8sResourceClient under
+// the covers to perform CRUD operations on kubernetes CRDs.
 type ipamBlockClient struct {
 	rc customK8sResourceClient
 }

--- a/lib/backend/k8s/resources/ipam_block_pod_cidr.go
+++ b/lib/backend/k8s/resources/ipam_block_pod_cidr.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+func NewPodCIDRBlockAffinityClient(c *kubernetes.Clientset) K8sResourceClient {
+	return &podCIDRBlockClient{
+		clientSet: c,
+	}
+}
+
+// podCIDRBlockClient implements the api.Client interface for block affinities using Kubernetes pod CIDR
+// allocations as the backing store. For use with host-local IPAM. For the Calico IPAM
+// implementation, see ipam_block.go.
+type podCIDRBlockClient struct {
+	clientSet *kubernetes.Clientset
+}
+
+func (c *podCIDRBlockClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Warn("Operation Create is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "Create",
+	}
+}
+
+func (c *podCIDRBlockClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Warn("Operation Update is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "Create",
+	}
+}
+
+func (c *podCIDRBlockClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Warn("Operation DeleteKVP is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "DeleteKVP",
+	}
+}
+
+func (c *podCIDRBlockClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
+	log.Warn("Operation Delete is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: key,
+		Operation:  "Delete",
+	}
+}
+
+func (c *podCIDRBlockClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	log.Warn("Operation Get is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: key,
+		Operation:  "Get",
+	}
+}
+
+func (c *podCIDRBlockClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+	log.Debug("Operation Watch is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: list,
+		Operation:  "Watch",
+	}
+}
+
+func (c *podCIDRBlockClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	log.Debug("Received List request on block affinities (using host-local IPAM)")
+	bl := list.(model.BlockAffinityListOptions)
+	kvpl := &model.KVPairList{
+		KVPairs:  []*model.KVPair{},
+		Revision: revision,
+	}
+
+	// If a host is specified, then do an exact lookup (ip version should not be expected in the query)
+	if bl.Host != "" && bl.IPVersion == 0 {
+		// Get the node settings, we use the nodes PodCIDR as the only node affinity block.
+		node, err := c.clientSet.CoreV1().Nodes().Get(bl.Host, metav1.GetOptions{ResourceVersion: revision})
+		if err != nil {
+			err = K8sErrorToCalico(err, list)
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+				return nil, err
+			}
+			return kvpl, nil
+		}
+
+		// Return no results if the pod CIDR is not assigned.
+		podcidr := node.Spec.PodCIDR
+		if len(podcidr) == 0 {
+			return kvpl, nil
+		}
+
+		_, cidr, err := cnet.ParseCIDR(podcidr)
+		if err != nil {
+			return nil, err
+		}
+		kvpl.Revision = node.ResourceVersion
+		kvpl.KVPairs = append(kvpl.KVPairs, &model.KVPair{
+			Key: model.BlockAffinityKey{
+				CIDR: *cidr,
+				Host: bl.Host,
+			},
+			Value:    &model.BlockAffinity{State: model.StateConfirmed},
+			Revision: node.ResourceVersion,
+		})
+
+		return kvpl, nil
+	}
+
+	// When host is not specified...
+	if bl.IPVersion == 0 {
+		// Get the node settings, we use the nodes PodCIDR as the only node affinity block.
+		nodeList, err := c.clientSet.CoreV1().Nodes().List(metav1.ListOptions{ResourceVersion: revision})
+		if err != nil {
+			err = K8sErrorToCalico(err, list)
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+				return nil, err
+			}
+			return kvpl, nil
+		}
+
+		kvpl.Revision = nodeList.ResourceVersion
+		for _, node := range nodeList.Items {
+			// Return no results if the pod CIDR is not assigned.
+			podcidr := node.Spec.PodCIDR
+			if len(podcidr) == 0 {
+				continue
+			}
+
+			_, cidr, err := cnet.ParseCIDR(podcidr)
+			if err != nil {
+				return nil, err
+			}
+			kvpl.KVPairs = append(kvpl.KVPairs, &model.KVPair{
+				Key: model.BlockAffinityKey{
+					CIDR: *cidr,
+					Host: node.Name,
+				},
+				Value:    &model.BlockAffinity{State: model.StateConfirmed},
+				Revision: node.ResourceVersion,
+			})
+		}
+		return kvpl, nil
+	}
+
+	// Currently querying the affinity block is only used by the BGP syncer *and* we always
+	// query for a specific Node, so for now fail List requests for all nodes.
+	log.Warn("Operation List (all nodes or all IP versions) is not supported on block affinities when using host-local IPAM")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: list,
+		Operation:  "List",
+	}
+}
+
+func (c *podCIDRBlockClient) EnsureInitialized() error {
+	return nil
+}

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
@@ -45,15 +46,17 @@ const (
 	nodeK8sLabelAnnotation               = "projectcalico.org/kube-labels"
 )
 
-func NewNodeClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewNodeClient(c *kubernetes.Clientset, usePodCIDR bool) K8sResourceClient {
 	return &nodeClient{
-		clientSet: c,
+		clientSet:  c,
+		usePodCIDR: usePodCIDR,
 	}
 }
 
 // Implements the api.Client interface for Nodes.
 type nodeClient struct {
-	clientSet *kubernetes.Clientset
+	clientSet  *kubernetes.Clientset
+	usePodCIDR bool
 }
 
 func (c *nodeClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -83,7 +86,7 @@ func (c *nodeClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPa
 		return nil, K8sErrorToCalico(err, kvp.Key)
 	}
 
-	newCalicoNode, err := K8sNodeToCalico(newNode)
+	newCalicoNode, err := K8sNodeToCalico(newNode, c.usePodCIDR)
 	if err != nil {
 		log.Errorf("Failed to parse returned Node after call to update %+v", newNode)
 		return nil, err
@@ -111,7 +114,7 @@ func (c *nodeClient) Get(ctx context.Context, key model.Key, revision string) (*
 		return nil, K8sErrorToCalico(err, key)
 	}
 
-	kvp, err := K8sNodeToCalico(node)
+	kvp, err := K8sNodeToCalico(node, c.usePodCIDR)
 	if err != nil {
 		log.WithError(err).Error("Couldn't convert k8s node.")
 		return nil, err
@@ -153,7 +156,7 @@ func (c *nodeClient) List(ctx context.Context, list model.ListInterface, revisio
 	}
 
 	for _, node := range nodes.Items {
-		kvp, err := K8sNodeToCalico(&node)
+		kvp, err := K8sNodeToCalico(&node, c.usePodCIDR)
 		if err != nil {
 			log.Errorf("Unable to convert k8s node to Calico node: node=%s: %v", node.Name, err)
 			continue
@@ -193,13 +196,13 @@ func (c *nodeClient) Watch(ctx context.Context, list model.ListInterface, revisi
 		if !ok {
 			return nil, errors.New("node conversion with incorrect k8s resource type")
 		}
-		return K8sNodeToCalico(k8sNode)
+		return K8sNodeToCalico(k8sNode, c.usePodCIDR)
 	}
 	return newK8sWatcherConverter(ctx, "Node", converter, k8sWatch), nil
 }
 
 // K8sNodeToCalico converts a Kubernetes format node, with Calico annotations, to a Calico Node.
-func K8sNodeToCalico(k8sNode *kapiv1.Node) (*model.KVPair, error) {
+func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, error) {
 	// Create a new CalicoNode resource and copy the settings across from the k8s Node.
 	calicoNode := apiv3.NewNode()
 	calicoNode.ObjectMeta.Name = k8sNode.Name
@@ -228,6 +231,15 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node) (*model.KVPair, error) {
 		}
 	}
 	bgpSpec.IPv4IPIPTunnelAddr = annotations[nodeBgpIpv4IPIPTunnelAddrAnnotation]
+
+	// If using host-local IPAM, assign an IPIP tunnel address statically.
+	if usePodCIDR && k8sNode.Spec.PodCIDR != "" {
+		// For back compatibility with v2.6.x, always generate a tunnel address if we have the pod CIDR.
+		bgpSpec.IPv4IPIPTunnelAddr, err = getIPIPTunnelAddress(k8sNode)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// Only set the BGP spec if it is not empty.
 	if !reflect.DeepEqual(*bgpSpec, apiv3.NodeBGPSpec{}) {
@@ -392,4 +404,25 @@ func restoreCalicoLabels(calicoNode *apiv3.Node) (*apiv3.Node, error) {
 	}
 
 	return calicoNode, nil
+}
+
+// getIPIPTunnelAddress calculates the IPv4 address to use for the IPIP tunnel based on the node's pod CIDR, for use
+// in conjunction with host-local IPAM backed by node.Spec.PodCIDR allocations.
+func getIPIPTunnelAddress(n *kapiv1.Node) (string, error) {
+	ip, _, err := net.ParseCIDR(n.Spec.PodCIDR)
+	if err != nil {
+		log.Warnf("Invalid pod CIDR for node: %s, %s", n.Name, n.Spec.PodCIDR)
+		return "", err
+	}
+
+	// We need to get the IP for the podCIDR and increment it to the
+	// first IP in the CIDR.
+	tunIp := ip.To4()
+	if tunIp == nil {
+		log.WithField("podCIDR", n.Spec.PodCIDR).Infof("Cannot pick an IPv4 tunnel address from the given CIDR")
+		return "", nil
+	}
+	tunIp[3]++
+
+	return tunIp.String(), nil
 }

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -55,7 +55,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			// Create a SyncerTester to receive the BGP syncer callback events and to allow us
 			// to assert state.
 			syncTester := testutils.NewSyncerTester()
-			syncer := felixsyncer.New(be, syncTester)
+			syncer := felixsyncer.New(be, config.Spec, syncTester)
 			syncer.Start()
 			expectedCacheSize := 0
 
@@ -381,7 +381,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			// We need to create a new syncTester and syncer.
 			current := syncTester.GetCacheEntries()
 			syncTester = testutils.NewSyncerTester()
-			syncer = felixsyncer.New(be, syncTester)
+			syncer = felixsyncer.New(be, config.Spec, syncTester)
 			syncer.Start()
 
 			// Verify the data is the same as the data from the previous cache.  We got the cache in the previous

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -38,23 +38,32 @@ import (
 
 var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
-	ctx := context.Background()
+	var ctx context.Context
+	var c clientv3.Interface
+	var be api.Client
+	var syncTester *testutils.SyncerTester
+	var err error
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		// Create a v3 client to drive data changes (luckily because this is the _test module,
+		// we don't get circular imports.
+		c, err = clientv3.New(config)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create the backend client to obtain a syncer interface.
+		be, err = backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		be.Clean()
+
+		// Create a SyncerTester to receive the BGP syncer callback events and to allow us
+		// to assert state.
+		syncTester = testutils.NewSyncerTester()
+
+	})
 
 	Describe("Felix syncer functionality", func() {
 		It("should receive the synced after return all current data", func() {
-			// Create a v3 client to drive data changes (luckily because this is the _test module,
-			// we don't get circular imports.
-			c, err := clientv3.New(config)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Create the backend client to obtain a syncer interface.
-			be, err := backend.NewClient(config)
-			Expect(err).NotTo(HaveOccurred())
-			be.Clean()
-
-			// Create a SyncerTester to receive the BGP syncer callback events and to allow us
-			// to assert state.
-			syncTester := testutils.NewSyncerTester()
 			syncer := felixsyncer.New(be, config.Spec, syncTester)
 			syncer.Start()
 			expectedCacheSize := 0
@@ -398,5 +407,42 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			}
 			syncTester.ExpectStatusUpdate(api.InSync)
 		})
+	})
+})
+
+var _ = testutils.E2eDatastoreDescribe("Felix syncer tests (KDD only)", testutils.DatastoreK8s, func(config apiconfig.CalicoAPIConfig) {
+	var be api.Client
+	var syncTester *testutils.SyncerTester
+	var err error
+
+	BeforeEach(func() {
+		// Create the backend client to obtain a syncer interface.
+		config.Spec.K8sUsePodCIDR = true
+		be, err = backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		be.Clean()
+
+		// Create a SyncerTester to receive the BGP syncer callback events and to allow us
+		// to assert state.
+		syncTester = testutils.NewSyncerTester()
+	})
+
+	It("should handle IPAM blocks properly for host-local IPAM", func() {
+		config.Spec.K8sUsePodCIDR = true
+		syncer := felixsyncer.New(be, config.Spec, syncTester)
+		syncer.Start()
+
+		// Verify we start a resync.
+		syncTester.ExpectStatusUpdate(api.WaitForDatastore)
+		syncTester.ExpectStatusUpdate(api.ResyncInProgress)
+
+		// Expect a felix config for the IPIP tunnel address, generated from the podCIDR.
+		syncTester.ExpectData(model.KVPair{
+			Key:   model.HostConfigKey{Hostname: "127.0.0.1", Name: "IpInIpTunnelAddr"},
+			Value: "10.10.10.1",
+		})
+
+		// Expect to be in-sync.
+		syncTester.ExpectStatusUpdate(api.InSync)
 	})
 })


### PR DESCRIPTION
We removed host-local IPAM aggregation in v3.6 when we switched KDD mode
over to use Calico IPAM. However, there are some scenarios where we may
still want to use host-local IPAM with BGP.

This PR reinstates the ability to use host-local IPAM with Calico BGP,
and get proper route aggregation.

To enable it, make sure you're using the KDD backend and set `USE_POD_CIDR=true`. 

This PR adds back support for IPIP mode but doesn't attempt to implement VXLAN support. 

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Reinstate BGP route aggregation when using host-local IPAM via config option USE_POD_CIDR
```