### PR TITLE
Setting default to Never for VXLAN and IpIpMode

### DIFF
--- a/lib/apis/v3/ippool.go
+++ b/lib/apis/v3/ippool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,11 +45,11 @@ type IPPoolSpec struct {
 
 	// Contains configuration for VXLAN tunneling for this pool. If not specified,
 	// then this is defaulted to "Never" (i.e. VXLAN tunelling is disabled).
-	VXLANMode VXLANMode `json:"vxlanMode,omitempty" validate:"omitempty,vxlanMode"`
+	VXLANMode VXLANMode `json:"vxlanMode,omitempty" validate:"omitempty,vxlanMode" default:"Never"`
 
 	// Contains configuration for IPIP tunneling for this pool. If not specified,
 	// then this is defaulted to "Never" (i.e. IPIP tunelling is disabled).
-	IPIPMode IPIPMode `json:"ipipMode,omitempty" validate:"omitempty,ipIpMode"`
+	IPIPMode IPIPMode `json:"ipipMode,omitempty" validate:"omitempty,ipIpMode" default:"Never"`
 
 	// When nat-outgoing is true, packets sent from Calico networked containers in
 	// this pool to destinations outside of this pool will be masqueraded.


### PR DESCRIPTION
## Description
When applying an ip pool policy with IPV6 CIDR and no VXLAN mode selected via `calicoctl apply -f`
```
---
kind: IPPool
apiVersion: projectcalico.org/v3
metadata:
  name: ippool-2
spec:
  cidr: 2002::/64
  ipipMode: Never
  natOutgoing: true
```
Calicoctl crashes with `(VXLANMode other than 'Never' is not supported on an IPv6 IP pool)`

## Todos
- [ ] Tests