### PR TITLE
Add etcd SRV discovery support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ test: ut fv
 #######################
 K8S_VERSION      ?= v1.14.1
 ETCD_VERSION     ?= v3.3.7
+COREDNS_VERSION  ?= 1.5.0
 GO_BUILD_VER     ?= v0.20
 CALICO_BUILD     ?= calico/go-build:$(GO_BUILD_VER)
 PACKAGE_NAME     ?= projectcalico/libcalico-go
@@ -159,9 +160,10 @@ ut: vendor
 
 .PHONY:fv
 ## Run functional tests against a real datastore in a container.
-fv: vendor run-etcd run-etcd-tls run-kubernetes-master
+fv: vendor run-etcd run-etcd-tls run-kubernetes-master run-coredns
 	-mkdir -p .go-pkg-cache
 	docker run --rm -t --privileged --net=host \
+		--dns 127.0.0.1 \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-v $(CURDIR):/go/src/github.com/$(PACKAGE_NAME):rw \
 		-v $(CURDIR)/.go-pkg-cache:/go-cache/:rw \
@@ -275,6 +277,19 @@ stop-kubernetes-master:
 ## Stop the etcd container (calico-etcd)
 stop-etcd:
 	-docker rm -f calico-etcd
+
+run-coredns: stop-coredns
+	docker run \
+		--detach \
+		--name coredns \
+		--net=host \
+		--rm \
+		-v $(shell pwd)/test/coredns:/etc/coredns \
+		-w /etc/coredns \
+		coredns/coredns:$(COREDNS_VERSION)
+
+stop-coredns:
+	-docker rm -f coredns
 
 ###############################################################################
 # CI

--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -49,12 +49,13 @@ type CalicoAPIConfigSpec struct {
 }
 
 type EtcdConfig struct {
-	EtcdEndpoints  string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
-	EtcdUsername   string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
-	EtcdPassword   string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
-	EtcdKeyFile    string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
-	EtcdCertFile   string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
-	EtcdCACertFile string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
+	EtcdEndpoints    string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
+	EtcdDiscoverySrv string `json:"etcdDiscoverySrv" envconfig:"ETCD_DISCOVERY_SRV"`
+	EtcdUsername     string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
+	EtcdPassword     string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
+	EtcdKeyFile      string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
+	EtcdCertFile     string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
+	EtcdCACertFile   string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
 
 	// These config file parameters are to support inline certificates, keys and CA / Trusted certificate.
 	// There are no corresponding environment variables to avoid accidental exposure.

--- a/lib/apis/v1/apiconfig.go
+++ b/lib/apis/v1/apiconfig.go
@@ -47,14 +47,15 @@ type CalicoAPIConfigSpec struct {
 }
 
 type EtcdConfig struct {
-	EtcdScheme     string `json:"etcdScheme" envconfig:"APIV1_ETCD_SCHEME" default:""`
-	EtcdAuthority  string `json:"etcdAuthority" envconfig:"APIV1_ETCD_AUTHORITY" default:""`
-	EtcdEndpoints  string `json:"etcdEndpoints" envconfig:"APIV1_ETCD_ENDPOINTS"`
-	EtcdUsername   string `json:"etcdUsername" envconfig:"APIV1_ETCD_USERNAME"`
-	EtcdPassword   string `json:"etcdPassword" envconfig:"APIV1_ETCD_PASSWORD"`
-	EtcdKeyFile    string `json:"etcdKeyFile" envconfig:"APIV1_ETCD_KEY_FILE"`
-	EtcdCertFile   string `json:"etcdCertFile" envconfig:"APIV1_ETCD_CERT_FILE"`
-	EtcdCACertFile string `json:"etcdCACertFile" envconfig:"APIV1_ETCD_CA_CERT_FILE"`
+	EtcdScheme       string `json:"etcdScheme" envconfig:"APIV1_ETCD_SCHEME" default:""`
+	EtcdAuthority    string `json:"etcdAuthority" envconfig:"APIV1_ETCD_AUTHORITY" default:""`
+	EtcdEndpoints    string `json:"etcdEndpoints" envconfig:"APIV1_ETCD_ENDPOINTS"`
+	EtcdDiscoverySrv string `json:"etcdDiscoverySrv" envconfig:"APIV1_ETCD_DISCOVERY_SRV"`
+	EtcdUsername     string `json:"etcdUsername" envconfig:"APIV1_ETCD_USERNAME"`
+	EtcdPassword     string `json:"etcdPassword" envconfig:"APIV1_ETCD_PASSWORD"`
+	EtcdKeyFile      string `json:"etcdKeyFile" envconfig:"APIV1_ETCD_KEY_FILE"`
+	EtcdCertFile     string `json:"etcdCertFile" envconfig:"APIV1_ETCD_CERT_FILE"`
+	EtcdCACertFile   string `json:"etcdCACertFile" envconfig:"APIV1_ETCD_CA_CERT_FILE"`
 }
 
 type KubeConfig struct {

--- a/lib/backend/etcdv3/etcdv3_test.go
+++ b/lib/backend/etcdv3/etcdv3_test.go
@@ -209,4 +209,19 @@ var _ = Describe("RulesAPIToBackend", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("[Datastore] should discover etcd via SRV records", func() {
+		_, err := etcdv3.NewEtcdV3Client(&apiconfig.EtcdConfig{
+			EtcdDiscoverySrv: "etcd.local",
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("[Datastore] should fail if SRV discovery finds no records", func() {
+		_, err := etcdv3.NewEtcdV3Client(&apiconfig.EtcdConfig{
+			EtcdDiscoverySrv: "fake.local",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("failed to discover etcd endpoints through SRV discovery")))
+	})
 })

--- a/lib/backend/etcdv3/etcdv3_test.go
+++ b/lib/backend/etcdv3/etcdv3_test.go
@@ -125,6 +125,14 @@ var _ = Describe("RulesAPIToBackend", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should raise an error if conflicting endpoint discovery configuration provided", func() {
+		_, err := etcdv3.NewEtcdV3Client(&apiconfig.EtcdConfig{
+			EtcdEndpoints:    "https://127.0.0.1:5007",
+			EtcdDiscoverySrv: "example.com",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("[Datastore] should raise an error for providing only inline Key and not Certificate", func() {
 		_, err := etcdv3.NewEtcdV3Client(&apiconfig.EtcdConfig{
 			EtcdCACert:    "",

--- a/test/coredns/Corefile
+++ b/test/coredns/Corefile
@@ -1,0 +1,7 @@
+etcd.local:53 {
+    bind 0.0.0.0
+    errors
+    root /etc/coredns/zones
+    file etcd.zone etcd.local
+    log
+}

--- a/test/coredns/zones/etcd.zone
+++ b/test/coredns/zones/etcd.zone
@@ -1,0 +1,14 @@
+$TTL    86400
+@   IN  SOA  etcdns.local. root.etcdns.local. (
+             100500     ; Serial
+             604800     ; Refresh
+              86400     ; Retry
+            2419200     ; Expire
+              86400 )   ; Negative Cache TTL
+    IN  NS  ns.etcdns.local.
+    IN  A   127.0.0.1
+
+ns IN A 127.0.0.1
+m1 IN A 127.0.0.1
+
+_etcd-client._tcp IN SRV 0 0 2379 m1.etcd.local.


### PR DESCRIPTION
## Description

Adds the configuration options to support specifying a domain name that
the etcd SRV discovery library will use to enumerate the current member
endpoints.

Not having this capability is becoming more inconvenient when running calico-node and the calico-kube-controllers via Kubernetes.

Another attempt at getting #388 updated and merged.

## Todos
- [X] Tests
- [ ] Documentation
- [X] Release note

## Release Note

```release-note
Adds [etcd DNS discovery](https://coreos.com/etcd/docs/latest/op-guide/clustering.html#dns-discovery) support for specifying datastore endpoint(s).
```
