### PR TITLE
Support for supplying NATOutgoingAddress to Felix

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -220,6 +220,11 @@ type FelixConfigurationSpec struct {
 	// network stack is used.
 	NATPortRange *numorstring.Port `json:"natPortRange,omitempty"`
 
+	// NATOutgoingAddress specifies an address to use when performing source NAT for traffic in a natOutgoing pool that
+	// is leaving the network. By default the address used is an address on the interface the traffic is leaving on
+	// (ie it uses the iptables MASQUERADE target)
+	NATOutgoingAddress string `json:"NATOutgoingAddress,omitempty"`
+
 	// ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes which may source tunnel traffic and have
 	// the tunneled traffic be accepted at calico nodes.
 	ExternalNodesCIDRList *[]string `json:"externalNodesList,omitempty"`

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 63
+	numFelixConfigs := 64
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -564,6 +564,14 @@ func validateFelixConfigSpec(structLevel validator.StructLevel) {
 				"OpenstackRegion", "", reason("must be a valid DNS label"), "")
 		}
 	}
+
+	if c.NATOutgoingAddress != "" {
+		parsedAddress := cnet.ParseIP(c.NATOutgoingAddress)
+		if parsedAddress == nil || parsedAddress.Version() != 4 {
+			structLevel.ReportError(reflect.ValueOf(c.NATOutgoingAddress),
+				"NATOutgoingAddress", "", reason("is not a valid IP address"), "")
+		}
+	}
 }
 
 func validateWorkloadEndpointSpec(structLevel validator.StructLevel) {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1733,6 +1733,18 @@ func init() {
 			&api.HTTPMatch{Methods: []string{"GET", "GET", "Foo"}},
 			false,
 		),
+		Entry("should not accept an invalid IP address",
+			api.FelixConfigurationSpec{NATOutgoingAddress: bad_ipv4_1}, false,
+		),
+		Entry("should not accept a masked IP",
+			api.FelixConfigurationSpec{NATOutgoingAddress: netv4_1}, false,
+		),
+		Entry("should not accept an IPV6 address",
+			api.FelixConfigurationSpec{NATOutgoingAddress: ipv6_1}, false,
+		),
+		Entry("should accept a valid IP address",
+			api.FelixConfigurationSpec{NATOutgoingAddress: ipv4_1}, true,
+		),
 	)
 }
 


### PR DESCRIPTION
## Description
This is a PR required for addressing https://github.com/projectcalico/calico/issues/2222. Addressing the issue also requires a change in Felix which I will link below. We chose to implement this by allowing users to specify the IP address being used rather than using the BGP address by default because it seemed more flexible. For our use case we are using the Kubernetes downward API to supply this address. I've tested this by setting/unsetting `FELIX_NATOUTGOINGADDRESS` in a calico node container using our modified felix. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
