### PR TITLE
BGPPeer invalid selector fix

### DIFF
--- a/lib/apis/v3/bgppeer.go
+++ b/lib/apis/v3/bgppeer.go
@@ -50,14 +50,14 @@ type BGPPeerSpec struct {
 	ASNumber numorstring.ASNumber `json:"asNumber"`
 	// Selector for the nodes that should have this peering.  When this is set, the Node
 	// field must be empty.
-	NodeSelector string `json:"nodeSelector,omitempty"`
+	NodeSelector string `json:"nodeSelector,omitempty" validate:"omitempty,selector"`
 	// Selector for the remote nodes to peer with.  When this is set, the PeerIP and
 	// ASNumber fields must be empty.  For each peering between the local node and
 	// selected remote nodes, we configure an IPv4 peering if both ends have
 	// NodeBGPSpec.IPv4Address specified, and an IPv6 peering if both ends have
 	// NodeBGPSpec.IPv6Address specified.  The remote AS number comes from the remote
 	// node’s NodeBGPSpec.ASNumber, or the global default if that is not set.
-	PeerSelector string `json:"peerSelector,omitempty"`
+	PeerSelector string `json:"peerSelector,omitempty" validate:"omitempty,selector"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1279,7 +1279,7 @@ func init() {
 		}, true),
 
 		Entry("should reject invalid BGPPeerSpec (selector)", api.BGPPeerSpec{
-			NodeSelector: "kubernetes.io/hostname: == 'casey-crc-kadm-node-4'"
+			NodeSelector: "kubernetes.io/hostname: == 'casey-crc-kadm-node-4'",
 			}, false),
 
 		// (API) NodeSpec

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1280,7 +1280,7 @@ func init() {
 
 		Entry("should reject invalid BGPPeerSpec (selector)", api.BGPPeerSpec{
 			NodeSelector: "kubernetes.io/hostname: == 'casey-crc-kadm-node-4'",
-			}, false),
+		}, false),
 
 		// (API) NodeSpec
 		Entry("should accept node with IPv4 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: netv4_1}}, true),

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1278,6 +1278,10 @@ func init() {
 			PeerSelector: "has(mylabel)",
 		}, true),
 
+		Entry("should reject invalid BGPPeerSpec (selector)", api.BGPPeerSpec{
+			NodeSelector: "kubernetes.io/hostname: == 'casey-crc-kadm-node-4'"
+			}, false),
+
 		// (API) NodeSpec
 		Entry("should accept node with IPv4 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv4Address: netv4_1}}, true),
 		Entry("should accept node with IPv6 BGP", api.NodeSpec{BGP: &api.NodeBGPSpec{IPv6Address: netv6_1}}, true),


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixed calicoctl side validation for selector attribute (nodeSelector, peerSelector) for BGPPeer resources.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Properly validate BGP peer selectors
```
