### PR TITLE
felixconfig: add sockmap config param

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -231,6 +231,9 @@ type FelixConfigurationSpec struct {
 
 	IptablesNATOutgoingInterfaceFilter string `json:"iptablesNATOutgoingInterfaceFilter,omitempty" validate:"omitempty,ifaceFilter"`
 
+	// SockmapEnabled enables experimental sockmap acceleration [Default: false]
+	SockmapEnabled *bool `json:"sockmapEnabled,omitempty" confignamev1:"SockmapEnabled"`
+
 	// XDPEnabled enables XDP acceleration for suitable untracked incoming deny rules. [Default: true]
 	XDPEnabled *bool `json:"xdpEnabled,omitempty" confignamev1:"XDPEnabled"`
 

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -724,6 +724,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.SockmapEnabled != nil {
+		in, out := &in.SockmapEnabled, &out.SockmapEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.XDPEnabled != nil {
 		in, out := &in.XDPEnabled, &out.XDPEnabled
 		*out = new(bool)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 63
+	numFelixConfigs := 64
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3


### PR DESCRIPTION
## Description
Add new sockmap fields to be used by Felix.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
