### PR TITLE
Automated cherry pick of #1088: Update should set defaults before doing validation

### DIFF
--- a/lib/clientv3/ippool.go
+++ b/lib/clientv3/ippool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,9 +129,6 @@ func (r ipPools) Update(ctx context.Context, res *apiv3.IPPool, opts options.Set
 		resCopy := *res
 		res = &resCopy
 	}
-	if err := validator.Validate(res); err != nil {
-		return nil, err
-	}
 
 	// Get the existing settings, so that we can validate the CIDR and block size have not changed.
 	old, err := r.Get(ctx, res.Name, options.GetOptions{})
@@ -141,6 +138,10 @@ func (r ipPools) Update(ctx context.Context, res *apiv3.IPPool, opts options.Set
 
 	// Validate the IPPool updating the resource.
 	if err := r.validateAndSetDefaults(ctx, res, old); err != nil {
+		return nil, err
+	}
+
+	if err := validator.Validate(res); err != nil {
 		return nil, err
 	}
 

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018,2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -493,6 +493,14 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 	})
 
 	Describe("Verify handling of VXLAN mode", func() {
+
+		var missingVxlanPool = apiv3.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "ippool1"},
+			Spec: apiv3.IPPoolSpec{
+				CIDR: "192.168.0.0/16",
+			},
+		}
+
 		var err error
 		var c clientv3.Interface
 
@@ -512,6 +520,23 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			}
 			return cfg.Spec.VXLANEnabled, nil
 		}
+
+		It("should create/update an IPPool when VXLAN is missing", func() {
+			// create an ipppol with missing vxlan
+			ipPoolV1 := missingVxlanPool.DeepCopy()
+			ipPoolV2, err := c.IPPools().Create(ctx, ipPoolV1, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// update an ipppol with missing vxlan
+			ipPoolV2.Spec.VXLANMode = ""
+			_, err = c.IPPools().Update(ctx, ipPoolV2, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// delete the ipppol
+			_, err = c.IPPools().Delete(ctx, ipPoolV2.Name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
 
 		It("should enable VXLAN globally on an IPPool Create (VXLANModeAlways) if the global setting is not configured", func() {
 			By("Getting the current felix configuration - checking does not exist")


### PR DESCRIPTION
Cherry pick of #1088 on release-v3.7.

#1088: Update should set defaults before doing validation

```release-note
Fix for validation of resources on Update when defaults need to be set (@asincu)
```