### PR TITLE
ipam GetAssignmentAttributes to return correct error code.

### DIFF
--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -21,7 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/libcalico-go/lib/apis/v3"
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/set"
 
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
@@ -1361,13 +1361,13 @@ func (c ipamClient) GetAssignmentAttributes(ctx context.Context, addr net.IP) (m
 	}
 	if pool == nil {
 		log.Errorf("Error reading pool for %s", addr.String())
-		return nil, errors.New(fmt.Sprintf("%s is not part of a configured pool", addr))
+		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: addr.String(), Err: errors.New("No valid IPPool")}
 	}
 	blockCIDR := getBlockCIDRForAddress(addr, pool)
 	obj, err := c.blockReaderWriter.queryBlock(ctx, blockCIDR, "")
 	if err != nil {
 		log.Errorf("Error reading block %s: %v", blockCIDR, err)
-		return nil, errors.New(fmt.Sprintf("%s is not assigned", addr))
+		return nil, err
 	}
 	block := allocationBlock{obj.Value.(*model.AllocationBlock)}
 	return block.attributesForIP(addr)

--- a/lib/ipam/ipam_block.go
+++ b/lib/ipam/ipam_block.go
@@ -22,10 +22,11 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/projectcalico/libcalico-go/lib/apis/v3"
 	log "github.com/sirupsen/logrus"
 
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -348,7 +349,8 @@ func (b allocationBlock) attributesForIP(ip cnet.IP) (map[string]string, error) 
 	// Check if allocated.
 	attrIndex := b.Allocations[ordinal]
 	if attrIndex == nil {
-		return nil, errors.New(fmt.Sprintf("IP %s is not currently assigned in block", ip))
+		log.Debugf("IP %s is not currently assigned in block", ip)
+		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: ip.String(), Err: errors.New("IP is unassigned")}
 	}
 	return b.Attributes[*attrIndex].AttrSecondary, nil
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We should return correct error code to query attributes for an IP. 
- Return `ErrorResourceDoesNotExist` if no valid ippool or no valid block or ip is unassigned.
- Return whatever datastore error status is.

This would allow caller to make right decisions based on error code. A use case could be checking a previously allocated tunnel address. See https://github.com/projectcalico/node/pull/254 
- Getting attributes for old tunnel address returns `ErrorResourceDoesNotExist`, we should assign a new tunnel address.
- Any other error from datastore, panic and allow calico-node restarts. 



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
