### PR TITLE
Make the Prometheus host a configurable property

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -182,9 +182,11 @@ type FelixConfigurationSpec struct {
 	HealthHost    *string `json:"healthHost,omitempty"`
 	HealthPort    *int    `json:"healthPort,omitempty"`
 
-	// PrometheusMetricsEnabled enables the experimental Prometheus metrics server in Felix if set to true. [Default: false]
+	// PrometheusMetricsEnabled enables the Prometheus metrics server in Felix if set to true. [Default: false]
 	PrometheusMetricsEnabled *bool `json:"prometheusMetricsEnabled,omitempty"`
-	// PrometheusMetricsPort is the TCP port that the experimental Prometheus metrics server should bind to. [Default:9091]
+	// PrometheusMetricsHost is the host that the Prometheus metrics server should bind to. [Default: 0.0.0.0]
+	PrometheusMetricsHost string `json:"prometheusMetricsHost,omitempty" validate:"omitempty,prometheusHost"`
+	// PrometheusMetricsPort is the TCP port that the Prometheus metrics server should bind to. [Default: 9091]
 	PrometheusMetricsPort *int `json:"prometheusMetricsPort,omitempty"`
 	// PrometheusGoMetricsEnabled disables Go runtime metrics collection, which the Prometheus client does by default, when
 	// set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 66
+	numFelixConfigs := 67
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -57,6 +57,9 @@ var (
 	// GlobalNetworkPolicy names must be a simple DNS1123 label format (nameLabelFmt).
 	globalNetworkPolicyNameRegex = regexp.MustCompile("^(" + nameLabelFmt + ")$")
 
+	// Hostname  have to be valid ipv4, ipv6 or strings up to 64 characters.
+	prometheusHostRegexp = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,64}$`)
+
 	interfaceRegex        = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,15}$")
 	ifaceFilterRegex      = regexp.MustCompile("^[a-zA-Z0-9:._+-]{1,15}$")
 	actionRegex           = regexp.MustCompile("^(Allow|Deny|Log|Pass)$")
@@ -135,6 +138,7 @@ func init() {
 	registerFieldValidator("ifaceFilter", validateIfaceFilter)
 	registerFieldValidator("mac", validateMAC)
 	registerFieldValidator("iptablesBackend", validateIptablesBackend)
+	registerFieldValidator("prometheusHost", validatePrometheusHost)
 
 	// Register network validators (i.e. validating a correctly masked CIDR).  Also
 	// accepts an IP address without a mask (assumes a full mask).
@@ -233,6 +237,12 @@ func validateContainerID(fl validator.FieldLevel) bool {
 	s := fl.Field().String()
 	log.Debugf("Validate containerID: %s", s)
 	return containerIDRegex.MatchString(s)
+}
+
+func validatePrometheusHost(fl validator.FieldLevel) bool {
+	s := fl.Field().String()
+	log.Debugf("Validate prometheusHost: %s", s)
+	return prometheusHostRegexp.MatchString(s)
 }
 
 func validatePortName(fl validator.FieldLevel) bool {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1749,6 +1749,11 @@ func init() {
 		Entry("should accept a valid IP address",
 			api.FelixConfigurationSpec{NATOutgoingAddress: ipv4_1}, true,
 		),
+		Entry("should accept a valid prometheusMetricsHost value 'localhost'", api.FelixConfigurationSpec{PrometheusMetricsHost: "localhost"}, true),
+		Entry("should accept a valid prometheusMetricsHost value '10.0.0.1'", api.FelixConfigurationSpec{PrometheusMetricsHost: "10.0.0.1"}, true),
+		Entry("should accept a valid prometheusMetricsHost value 'fe80::ea7a:70fa:cf74:25d5'", api.FelixConfigurationSpec{PrometheusMetricsHost: "fe80::ea7a:70fa:cf74:25d5"}, true),
+		Entry("should reject an invalid prometheusMetricsHost value 'localhost#'", api.FelixConfigurationSpec{PrometheusMetricsHost: "localhost#"}, false),
+		Entry("should reject an invalid prometheusMetricsHost value '0: 1::1'", api.FelixConfigurationSpec{PrometheusMetricsHost: "0: 1::1"}, false),
 	)
 }
 


### PR DESCRIPTION
## Description
As per https://github.com/projectcalico/felix/issues/1948 we were asked if the Prometheus host could be made configurable.

This PR sets up some of the required configurations in order for that to be made possible.

## Todos
- [ ] Tests // Current unit tests will cover this addition
- [ ] Documentation // Will be handled in PR's outside of this repo
- [ ] Release note // Release note will be covered outside of this PR

```release-note
None required
```
