### PR TITLE
Revised the doc. Default value for prometheus host: empty

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -184,7 +184,7 @@ type FelixConfigurationSpec struct {
 
 	// PrometheusMetricsEnabled enables the Prometheus metrics server in Felix if set to true. [Default: false]
 	PrometheusMetricsEnabled *bool `json:"prometheusMetricsEnabled,omitempty"`
-	// PrometheusMetricsHost is the host that the Prometheus metrics server should bind to. [Default: 0.0.0.0]
+	// PrometheusMetricsHost is the host that the Prometheus metrics server should bind to. [Default: empty]
 	PrometheusMetricsHost string `json:"prometheusMetricsHost,omitempty" validate:"omitempty,prometheusHost"`
 	// PrometheusMetricsPort is the TCP port that the Prometheus metrics server should bind to. [Default: 9091]
 	PrometheusMetricsPort *int `json:"prometheusMetricsPort,omitempty"`


### PR DESCRIPTION
It was pointed out to me by Erik that the default value should be empty, rather than 0.0.0.0. I rectified this in the documentation.
Related issues:
projectcalico/libcalico-go#1106
projectcalico/calico#2728
projectcalico/typha#284