### PR TITLE
BGP Peer Spec: Add Remote Node ASN Field

### DIFF
--- a/lib/apis/v3/bgppeer.go
+++ b/lib/apis/v3/bgppeer.go
@@ -51,6 +51,9 @@ type BGPPeerSpec struct {
 	// Selector for the nodes that should have this peering.  When this is set, the Node
 	// field must be empty.
 	NodeSelector string `json:"nodeSelector,omitempty" validate:"omitempty,selector"`
+	// The AS Number that all remote nodes which have this peering will have. Takes precedence
+	// over the remote Node's spec.bgp.asNumber and the global default AS Number.
+	NodeASNumber numorstring.ASNumber `json:"omitempty,nodeAsNumber" validate:"omitempty"`
 	// Selector for the remote nodes to peer with.  When this is set, the PeerIP and
 	// ASNumber fields must be empty.  For each peering between the local node and
 	// selected remote nodes, we configure an IPv4 peering if both ends have

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1273,6 +1273,10 @@ func init() {
 			ASNumber:     as61234,
 			PeerSelector: "has(mylabel)",
 		}, false),
+		Entry("should accept BGPPeerSpec with both NodeASNumber and PeerSelector", api.BGPPeerSpec{
+			NodeASNumber: as61234,
+			PeerSelector: "has(mylabel)",
+		}, true),
 		Entry("should accept BGPPeerSpec with NodeSelector and PeerSelector", api.BGPPeerSpec{
 			NodeSelector: "has(mylabel)",
 			PeerSelector: "has(mylabel)",


### PR DESCRIPTION
## Description
Adds a `nodeAsNumber` field to the BGP Peer spec, which dictates the effective ASN of all remote nodes which have the peering. Currently, if we need all remote nodes in a given peering to have the same ASN we have to manually add the `projectcalico.org/ASNumber` annotation to each node. Adding this field to the spec makes achieving that configuration easy, and can be persisted with yaml in the same place as the other peering information.

This field will take precedence over the remote Node's `spec.bgp.asNumber` and the global default ASN.

If this change to the API is accepted, the relevant changes will be made to the `libcalico` backend and the Calico `confd` fork.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
```release-note
None required
```
