### PR TITLE
Fix logutils filename calculation.

### DIFF
--- a/lib/logutils/benchmarks_test.go
+++ b/lib/logutils/benchmarks_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutils
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var result bool
+
+func BenchmarkShouldSkipFrame(b *testing.B) {
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = shouldSkipFrame(runtime.Frame{File: "/home/ubuntu/go/src/github.com/projectcalico/libcalico-go/lib/foo/bar.go"})
+	}
+	result = r
+}
+
+// These functions are here to make sure we have plenty of stack frames to load when we call runtime.Callers()
+
+func benchmarkCallers5(b *testing.B) {
+	benchmarkCallers4(b)
+}
+
+func benchmarkCallers4(b *testing.B) {
+	benchmarkCallers3(b)
+}
+
+func benchmarkCallers3(b *testing.B) {
+	benchmarkCallers2(b)
+}
+
+func benchmarkCallers2(b *testing.B) {
+	benchmarkCallers1(b)
+}
+
+func benchmarkCallers1(b *testing.B) {
+	benchmarkCallers(b)
+}
+
+var pcsResult []uintptr
+var skipResult int
+var entry *logrus.Entry
+var globalErr error
+
+func benchmarkCallers(b *testing.B) {
+	hook := &ContextHook{}
+	e := logrus.WithField("foo", "bar")
+	var err error
+
+	for n := 0; n < b.N; n++ {
+		err = hook.Fire(e)
+	}
+
+	entry = e
+	globalErr = err
+}
+
+func BenchmarkCallersSkip1(b *testing.B) {
+	benchmarkCallers5(b)
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Go v1.12 does more agressive inlining.
- This means that the skip value we passed to runtime.Callers()
  was often skipping too many frames.
- Reduce the skip to 1, which should be safe since Callers itself
  is marked as go:noinline and use runtime.CallersFrames() to
  deal with inlining.
- Benchmark and optimise ShouldSkipFrame to compensate for
  increased work done in parsing more frames.
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
