### PR TITLE
Send entire node in FelixNodeUpdateProcessor

### DIFF
--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -86,10 +86,12 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			syncTester.ExpectCacheSize(expectedCacheSize)
 			syncTester.ExpectStatusUpdate(api.ResyncInProgress)
 			syncTester.ExpectStatusUpdate(api.InSync)
+
 			// Kubernetes will have a profile for each of the namespaces that is configured.
 			// We expect:  default, kube-system, kube-public, namespace-1, namespace-2
 			if config.Spec.DatastoreType == apiconfig.Kubernetes {
-				expectedCacheSize += 6
+				//add one for the node resource
+				expectedCacheSize += 7
 				syncTester.ExpectData(model.KVPair{
 					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "kns.default"}},
 					Value: &model.ProfileRules{
@@ -243,7 +245,8 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 					Key:   model.HostConfigKey{Hostname: "127.0.0.1", Name: "VXLANTunnelMACAddr"},
 					Value: "66:cf:23:df:22:07",
 				})
-				expectedCacheSize += 4
+				//add one for the node resource
+				expectedCacheSize += 5
 			}
 
 			// The HostIP will be added for the IPv4 address

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -38,6 +38,7 @@ const (
 	isNodeBgpConfig
 
 	hostIPMarker = "*HOSTIP*"
+	nodeMarker   = "*NODEMARKER*"
 )
 
 var _ = Describe("Test the generic configuration update processor and the concrete implementations", func() {
@@ -657,6 +658,10 @@ func checkExpectedConfigs(kvps []*model.KVPair, dataType int, expectedNum int, e
 				Expect(node).To(Equal("mynode"))
 				name = hostIPMarker
 				logrus.Warnf("IP in key: %s", kvp.Value)
+			case model.ResourceKey:
+				node := kt.Name
+				Expect(node).To(Equal("mynode"))
+				name = nodeMarker
 			default:
 				Expect(kvp.Key).To(BeAssignableToTypeOf(model.HostConfigKey{}))
 			}

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,8 +49,10 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 	// just treat that as a delete on the underlying key and return the error alongside
 	// the updates.
 	var ipv4, ipv4Tunl, vxlanTunlIp, vxlanTunlMac interface{}
+	var node *apiv3.Node
+	var ok bool
 	if kvp.Value != nil {
-		node, ok := kvp.Value.(*apiv3.Node)
+		node, ok = kvp.Value.(*apiv3.Node)
 		if !ok {
 			return nil, errors.New("Incorrect value type - expecting resource of kind Node")
 		}
@@ -143,6 +145,14 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 				Name:     "VXLANTunnelMACAddr",
 			},
 			Value:    vxlanTunlMac,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.ResourceKey{
+				Name: name,
+				Kind: apiv3.KindNode,
+			},
+			Value:    node,
 			Revision: kvp.Revision,
 		},
 	}, err

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		Kind: apiv3.KindNode,
 		Name: "mynode",
 	}
-	numFelixConfigs := 4
+	numFelixConfigs := 5
 	up := updateprocessors.NewFelixNodeUpdateProcessor()
 
 	BeforeEach(func() {
@@ -46,6 +46,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		res.Name = "mynode"
 		expected := map[string]interface{}{
 			hostIPMarker:       nil,
+			nodeMarker:         res,
 			"IpInIpTunnelAddr": nil,
 		}
 		kvps, err := up.Process(&model.KVPair{
@@ -64,6 +65,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		res = apiv3.NewNode()
 		res.Name = "mynode"
 		res.Spec.BGP = &apiv3.NodeBGPSpec{}
+		expected[nodeMarker] = res
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
 			Value: res,
@@ -86,6 +88,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		ip := net.MustParseIP("1.2.3.4")
 		expected = map[string]interface{}{
 			hostIPMarker:       &ip,
+			nodeMarker:         res,
 			"IpInIpTunnelAddr": nil,
 		}
 		kvps, err = up.Process(&model.KVPair{
@@ -110,6 +113,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		ip = net.MustParseIP("100.200.100.200")
 		expected = map[string]interface{}{
 			hostIPMarker:       &ip,
+			nodeMarker:         res,
 			"IpInIpTunnelAddr": nil,
 		}
 		kvps, err = up.Process(&model.KVPair{
@@ -133,6 +137,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		}
 		expected = map[string]interface{}{
 			hostIPMarker:       nil,
+			nodeMarker:         res,
 			"IpInIpTunnelAddr": "192.100.100.100",
 		}
 		kvps, err = up.Process(&model.KVPair{
@@ -184,6 +189,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		Expect(err).To(HaveOccurred())
 		expected := map[string]interface{}{
 			hostIPMarker:       nil,
+			nodeMarker:         res,
 			"IpInIpTunnelAddr": "192.100.100.100",
 		}
 		checkExpectedConfigs(
@@ -208,6 +214,7 @@ var _ = Describe("Test the (Felix) Node update processor", func() {
 		ip := net.MustParseIP("1.2.3.4")
 		expected = map[string]interface{}{
 			hostIPMarker:       &ip,
+			nodeMarker:         res,
 			"IpInIpTunnelAddr": nil,
 		}
 		checkExpectedConfigs(


### PR DESCRIPTION
This adds the node under with the NodeKey key in the KV Process method in felixnodeprocessor. To be backwards compatible, this requires changing the return value for the String() function for the HostIPKey to return something different than the NodeKey's String() function, the added NodeKey would be ignored by the watcherCache

## Description
This commit is so we have the necessary node information, specifically the nodes subnet, when implementing the CrossSubnet option for VXLAN 
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
