### PR TITLE
Allow the vxlan protocol filter to be set in the felix configuration

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -162,6 +162,9 @@ type FelixConfigurationSpec struct {
 	VXLANPort *int `json:"vxlanPort,omitempty"`
 	VXLANVNI  *int `json:"vxlanVNI,omitempty"`
 
+	// RouteProtocol specifies the protocol to use to mark routes managed by felix using the default interface.
+	RouteProtocol int `config:"int;0"`
+
 	// ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.
 	// Must be non-zero in OpenStack deployments. [Default: 30s]
 	ReportingInterval *metav1.Duration `json:"reportingInterval,omitempty" configv1timescale:"seconds" confignamev1:"ReportingIntervalSecs"`

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -277,7 +277,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			Expect(err).NotTo(HaveOccurred())
 			// The pool will add as single entry ( +1 ), plus will also create the default
 			// Felix config with IPIP enabled.
-			expectedCacheSize += 2
+			expectedCacheSize += 3
 			syncTester.ExpectCacheSize(expectedCacheSize)
 			syncTester.ExpectData(model.KVPair{
 				Key: model.IPPoolKey{CIDR: net.MustParseCIDR("192.124.0.0/21")},

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 68
+	numFelixConfigs := 69
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3
@@ -111,6 +111,8 @@ var _ = Describe("Test the generic configuration update processor and the concre
 			Value: apiv3.NewFelixConfiguration(),
 		})
 		Expect(err).NotTo(HaveOccurred())
+		expected := felixMappedNames
+		expected["RouteProtocol"] = "0"
 		// Explicitly pass in the "mapped" name values to check to ensure the names are mapped.
 		checkExpectedConfigs(
 			kvps,
@@ -127,12 +129,14 @@ var _ = Describe("Test the generic configuration update processor and the concre
 			Value: apiv3.NewFelixConfiguration(),
 		})
 		Expect(err).NotTo(HaveOccurred())
+		expected := felixMappedNames
+		expected["RouteProtocol"] = "0"
 		// Explicitly pass in the "mapped" name values to check to ensure the names are mapped.
 		checkExpectedConfigs(
 			kvps,
 			isGlobalFelixConfig,
 			numFelixConfigs,
-			felixMappedNames,
+			expected,
 		)
 	})
 
@@ -229,6 +233,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 			"FailsafeOutboundHostPorts":          "tcp:1234,udp:22,tcp:65535",
 			"ExternalNodesCIDRList":              "1.1.1.1,2.2.2.2",
 			"IptablesNATOutgoingInterfaceFilter": "cali-123",
+			"RouteProtocol":                      "0",
 		}
 		kvps, err := cc.Process(&model.KVPair{
 			Key:   perNodeFelixKey,


### PR DESCRIPTION
## Description
This allows the user to override the default protocol the vxlan manager uses in felix (protocol 80)
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
