### PR TITLE
Add settings for route protocol and disabling external route removal

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -237,6 +237,13 @@ type FelixConfigurationSpec struct {
 	// leaving the kernel to choose the source address used.
 	DeviceRouteSourceAddress string `json:"deviceRouteSourceAddress,omitempty"`
 
+	// This defines the route protocol added to programmed device routes, by default this will be RTPROT_BOOT
+	// when left blank.
+	DeviceRouteProtocol *int `json:"deviceRouteProtocol,omitempty"`
+	// Whether or not to remove device routes that have not been programmed by Felix. Disabling this will allow external
+	// applications to also add device routes. This is enabled by default which means we will remove externally added routes.
+	RemoveExternalRoutes *bool `json:"removeExternalRoutes,omitempty"`
+
 	// ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes which may source tunnel traffic and have
 	// the tunneled traffic be accepted at calico nodes.
 	ExternalNodesCIDRList *[]string `json:"externalNodesList,omitempty"`

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -705,6 +705,16 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(numorstring.Port)
 		**out = **in
 	}
+	if in.DeviceRouteProtocol != nil {
+		in, out := &in.DeviceRouteProtocol, &out.DeviceRouteProtocol
+		*out = new(int)
+		**out = **in
+	}
+	if in.RemoveExternalRoutes != nil {
+		in, out := &in.RemoveExternalRoutes, &out.RemoveExternalRoutes
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ExternalNodesCIDRList != nil {
 		in, out := &in.ExternalNodesCIDRList, &out.ExternalNodesCIDRList
 		*out = new([]string)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 68
+	numFelixConfigs := 70
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 3


### PR DESCRIPTION
## Description
This adds two settings `DeviceRouteProtocol` and `RemoveExternalRoutes`.

`DeviceRouteProtocol` allows the user to specify the protocol (`proto` in `ip route`) to use on routes progreammed by Felix. This defaults to `RTPROT_BOOT` (https://elixir.bootlin.com/linux/v4.2/source/include/uapi/linux/rtnetlink.h#L225) which is currently used.

`RemoveExternalRoutes` allows the user to control whether or not Felix should remove routes installed by external applications. It will use the protocol specified in `DeviceRouteProtocol` to determine whether or not the route was added by external applications.

## Todos
- [ ] Tests
- [x] Documentation: projectcalico/calico#2800
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add Felix configuration option to ignore external routes on Calico-owned interfaces.
```

```release-note
Add Felix configuration option to set custom routing protocol on Calico-owned routes.
```
