### PR TITLE
Cherry-pick Allow CrossSubnet value for IPPool resource's VXLANMode option into release-v3.8

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/ippoolprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/ippoolprocessor.go
@@ -69,6 +69,8 @@ func convertIPPoolV2ToV1(kvp *model.KVPair) (*model.KVPair, error) {
 	switch v3res.Spec.VXLANMode {
 	case apiv3.VXLANModeAlways:
 		vxlanMode = encap.Always
+	case apiv3.VXLANModeCrossSubnet:
+		vxlanMode = encap.CrossSubnet
 	default:
 		vxlanMode = encap.Undefined
 	}

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -62,7 +62,7 @@ var (
 	actionRegex           = regexp.MustCompile("^(Allow|Deny|Log|Pass)$")
 	protocolRegex         = regexp.MustCompile("^(TCP|UDP|ICMP|ICMPv6|SCTP|UDPLite)$")
 	ipipModeRegex         = regexp.MustCompile("^(Always|CrossSubnet|Never)$")
-	vxlanModeRegex        = regexp.MustCompile("^(Always|Never)$")
+	vxlanModeRegex        = regexp.MustCompile("^(Always|CrossSubnet|Never)$")
 	logLevelRegex         = regexp.MustCompile("^(Debug|Info|Warning|Error|Fatal)$")
 	datastoreType         = regexp.MustCompile("^(etcdv3|kubernetes)$")
 	dropAcceptReturnRegex = regexp.MustCompile("^(Drop|Accept|Return)$")
@@ -717,7 +717,7 @@ func validateIPPoolSpec(structLevel validator.StructLevel) {
 	}
 
 	// Cannot have both VXLAN and IPIP on the same IP pool.
-	if (pool.IPIPMode == api.IPIPModeAlways || pool.IPIPMode == api.IPIPModeCrossSubnet) && pool.VXLANMode == api.VXLANModeAlways {
+	if ipipModeEnabled(pool.IPIPMode) && vxLanModeEnabled(pool.VXLANMode) {
 		structLevel.ReportError(reflect.ValueOf(pool.IPIPMode),
 			"IPpool.IPIPMode", "", reason("IPIPMode and VXLANMode cannot both be enabled on the same IP pool"), "")
 	}
@@ -770,6 +770,14 @@ func validateIPPoolSpec(structLevel validator.StructLevel) {
 		structLevel.ReportError(reflect.ValueOf(pool.CIDR),
 			"IPpool.CIDR", "", reason(overlapsV6LinkLocal), "")
 	}
+}
+
+func vxLanModeEnabled(mode api.VXLANMode) bool {
+	return mode == api.VXLANModeAlways || mode == api.VXLANModeCrossSubnet
+}
+
+func ipipModeEnabled(mode api.IPIPMode) bool {
+	return mode == api.IPIPModeAlways || mode == api.IPIPModeCrossSubnet
 }
 
 func validateICMPFields(structLevel validator.StructLevel) {

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -828,6 +828,7 @@ func init() {
 		// (API) VXLANMode
 		Entry("should reject IPIP mode and VXLAN mode", api.IPPoolSpec{CIDR: "1.2.3.0/24", IPIPMode: "Always", VXLANMode: "Always"}, false),
 		Entry("should accept VXLAN mode Always", api.IPPoolSpec{CIDR: "1.2.3.0/24", VXLANMode: "Always"}, true),
+		Entry("should accept VXLAN mode CrossSubnet", api.IPPoolSpec{CIDR: "1.2.3.0/24", VXLANMode: api.VXLANModeCrossSubnet}, true),
 		Entry("should accept VXLAN mode Never ", api.IPPoolSpec{CIDR: "1.2.3.0/24", VXLANMode: "Never"}, true),
 		Entry("should reject VXLAN mode never", api.IPPoolSpec{CIDR: "1.2.3.0/24", VXLANMode: "never"}, false),
 		Entry("should reject VXLAN mode badVal", api.IPPoolSpec{CIDR: "1.2.3.0/24", VXLANMode: "badVal"}, false),


### PR DESCRIPTION
> This commit adds the CrossSubnet option to the IPool resource and updates the validator to allow for this option

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
