### PR TITLE
fix: correct string trim func usage

### DIFF
--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -120,7 +120,7 @@ func (b *AllocationBlock) IsDeleted() bool {
 
 func (b *AllocationBlock) Host() string {
 	if b.Affinity != nil && strings.HasPrefix(*b.Affinity, "host:") {
-		return strings.TrimLeft(*b.Affinity, "host:")
+		return strings.TrimPrefix(*b.Affinity, "host:")
 	}
 	return ""
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
TrimLeft is char based, and TrimPrefix is word based, that's what we want here,
please see here: https://play.golang.org/p/i2idu52w9h0

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
