### PR TITLE
Automated cherry pick of #1152: correct string trim func usage

### DIFF
--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -120,7 +120,7 @@ func (b *AllocationBlock) IsDeleted() bool {
 
 func (b *AllocationBlock) Host() string {
 	if b.Affinity != nil && strings.HasPrefix(*b.Affinity, "host:") {
-		return strings.TrimLeft(*b.Affinity, "host:")
+		return strings.TrimPrefix(*b.Affinity, "host:")
 	}
 	return ""
 }


### PR DESCRIPTION
Cherry pick of #1152 on release-v3.10.

#1152: correct string trim func usage


```release-note
Fix issue where IPAM block affinity was not properly calculated (@beautytiger)
```