### PR TITLE
Add profile ids to networkset

### DIFF
--- a/lib/backend/model/networkset.go
+++ b/lib/backend/model/networkset.go
@@ -88,6 +88,7 @@ func (options NetworkSetListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type NetworkSet struct {
-	Nets   []net.IPNet       `json:"nets,omitempty" validate:"omitempty,dive,cidr"`
-	Labels map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
+	Nets       []net.IPNet       `json:"nets,omitempty" validate:"omitempty,dive,cidr"`
+	Labels     map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
+	ProfileIDs []string          `json:"profile_ids,omitempty" validate:"omitempty,dive,name"`
 }

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -356,6 +356,9 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 					Nets: []net.IPNet{
 						*expNet,
 					},
+					ProfileIDs: []string{
+						"kns.namespace-1",
+					},
 				},
 				Revision: ns.ResourceVersion,
 			})

--- a/lib/backend/syncersv1/updateprocessors/networksetprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/networksetprocessor_test.go
@@ -64,6 +64,9 @@ var _ = Describe("Test the NetworkSet update processor", func() {
 				Labels: map[string]string{
 					apiv3.LabelNamespace: ns1,
 				},
+				ProfileIDs: []string{
+					"kns." + ns1,
+				},
 			},
 			Revision: "abcde",
 		}))
@@ -86,6 +89,9 @@ var _ = Describe("Test the NetworkSet update processor", func() {
 				Nets: []net.IPNet{*cidr1IPNet, *cidr2IPNet},
 				Labels: map[string]string{
 					apiv3.LabelNamespace: ns1,
+				},
+				ProfileIDs: []string{
+					"kns." + ns1,
 				},
 			},
 			Revision: "abcde",
@@ -125,6 +131,9 @@ var _ = Describe("Test the NetworkSet update processor", func() {
 				Nets: []net.IPNet{*cidr1IPNet},
 				Labels: map[string]string{
 					apiv3.LabelNamespace: ns1,
+				},
+				ProfileIDs: []string{
+					"kns." + ns1,
 				},
 			},
 			Revision: "abcde",


### PR DESCRIPTION
## Description
This adds profiles to network sets so that we can inherit namespace labels.

There will be corresponding change required for felix.

This is essentially a bug fix, so no docs change required.

## Todos
- [x] Tests
- n/a Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that namespaced network policies were not selected by namespaceSelectors 
```
