### PR TITLE
Adding custom metadata to etcd's grpc calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	go.etcd.io/bbolt v1.3.3 // indirect
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/time v0.0.0-20170420181420-c06e80d9300e // indirect
+	google.golang.org/grpc v1.19.0
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -49,13 +49,14 @@ type CalicoAPIConfigSpec struct {
 }
 
 type EtcdConfig struct {
-	EtcdEndpoints    string `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
-	EtcdDiscoverySrv string `json:"etcdDiscoverySrv" envconfig:"ETCD_DISCOVERY_SRV"`
-	EtcdUsername     string `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
-	EtcdPassword     string `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
-	EtcdKeyFile      string `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
-	EtcdCertFile     string `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
-	EtcdCACertFile   string `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
+	EtcdEndpoints          string            `json:"etcdEndpoints" envconfig:"ETCD_ENDPOINTS"`
+	EtcdDiscoverySrv       string            `json:"etcdDiscoverySrv" envconfig:"ETCD_DISCOVERY_SRV"`
+	EtcdUsername           string            `json:"etcdUsername" envconfig:"ETCD_USERNAME"`
+	EtcdPassword           string            `json:"etcdPassword" envconfig:"ETCD_PASSWORD"`
+	EtcdKeyFile            string            `json:"etcdKeyFile" envconfig:"ETCD_KEY_FILE"`
+	EtcdCertFile           string            `json:"etcdCertFile" envconfig:"ETCD_CERT_FILE"`
+	EtcdCACertFile         string            `json:"etcdCACertFile" envconfig:"ETCD_CA_CERT_FILE"`
+	EtcdCustomGRPCMetadata map[string]string `json:"etcdCustomGRPCMetadata,omitempty" envconfig:"ETCD_CUSTOM_GRPC_METADATA" required:"false"`
 
 	// These config file parameters are to support inline certificates, keys and CA / Trusted certificate.
 	// There are no corresponding environment variables to avoid accidental exposure.


### PR DESCRIPTION
## Description

In our infrastructure we are running Calico that is accessing Etcd directly. We want to permit the users to manipulate the configuration of Calico using calicoctl from the "outside" of the cluster.

So far, between the external users and the cluster stands a sentinel proxy that authorizes all the calls made by the users when accessing the existing APIs. The authn and authz are built on top of JWT tokens. I considered integrating Calico's two existing security mechanisms first:
a) mutual TLS authentication
b) user:password authorization

Option a) was discarded due to the fact that it would require us to start issuing certificates to every user in parallel to issuing them JWT tokens. This was impractical and would introduce lots of complexity/new code.

Option b) leverages[ etcd's two-stage authn protocol](https://etcd.io/docs/v3.4.0/learning/design-auth-v3/) which is based on exchanging gRPC messages and a state machine.  The proxy would have to not only be gRPC-aware but also track the clients more closely and then perform the two-stage authentication with etcd on behalf of the clients. Considering that the proxy is based on Nginx+Lua, this would require considerable lua-foo on our side. 

I decided to approach the problem from a different angle using the gRPC metadata as a way to inject custom HTTP/2 headers. According to [the specification](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), the metadata is translated 1:1 to HTTP/2 headers which intermediate sentry proxies like ours can very easily intercept. The proxy can also produce gRPC messages in case of a denied access, which calicoctl handles just as if it was emited by etcd and produces clear error messages.

This PR implements this change by the means of gRPC interceptors which are passed to etcd client. The new parameter for the Calicoctl config is `etcdCustomGRPCMetadata` or env variable `ETCD_CUSTOM_GRPC_METADATA` and accepts a string map of strings. For example, a configuration passing custom "authorization" header would look like this:
```
apiVersion: projectcalico.org/v3
kind: CalicoAPIConfig
metadata:
spec:
  etcdEndpoints: https://etcd1:2379,https://etcd2:2379,https://etcd3:2379
  etcdKeyFile: /etc/calico/key.pem
  etcdCertFile: /etc/calico/cert.pem
  etcdCACertFile: /etc/calico/ca.pem
  etcdCustomGRPCMetadata:
    authorization: <some JWT token>
```

In our tooling, I wrap calicoctl in a wrapper that obtains JWT token the way our other libraries do and pass it to calicoctl through environment variable. 

In the case of k8s client, such a thing is not necessary as we could leverage e.g. the k8's `Bearer token` auth to achieve similar results. Unfortunately, k8s K/V backend has some scalability issues and requires Typha demon running which in turn would make our infrastructure way more complex than it should be.

The change is pretty simple and straightforward I believe. If the change is approved, let me know what kind of unittests you would like to have and where they should be written (I have noticed that clientv3 has no tests ATM) and any other things that are missing. I will be happy to provide them.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
