### PR TITLE
Wrap a mutex around ErrorTreshold

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -119,10 +119,10 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	It("should return WaitForDatastore on multiple consecutive watch errors", func() {
 		By("Sending errors to trigger a WaitForDatastore status update")
 
-		defaultThreshold := watchersyncer.ErrorThreshold
-		watchersyncer.ErrorThreshold = 6
+		defaultThreshold := watchersyncer.GetErrorThreshold()
+		watchersyncer.SetErrorThreshold(6)
 		defer func() {
-			watchersyncer.ErrorThreshold = defaultThreshold
+			watchersyncer.SetErrorThreshold(defaultThreshold)
 		}()
 
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
@@ -133,7 +133,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 
 		rs.clientWatchResponse(r1, genError)
 		rs.ExpectStatusUnchanged()
-		for i := 0; i < watchersyncer.ErrorThreshold-1; i++ {
+		n := watchersyncer.GetErrorThreshold()
+		for i := 0; i < n; i++ {
 			rs.clientListResponse(r1, genError)
 			rs.ExpectStatusUnchanged()
 		}
@@ -154,7 +155,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.clientWatchResponse(r1, nil)
 
 		// Watch is set but is now returning a generic WatchErrors
-		for i := 0; i < watchersyncer.ErrorThreshold; i++ {
+		n = watchersyncer.GetErrorThreshold()
+		for i := 0; i < n; i++ {
 			rs.sendEvent(r1, genWatchError)
 			rs.ExpectStatusUnchanged()
 		}
@@ -173,10 +175,10 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(500*time.Millisecond, 2000*time.Millisecond)
 
-		defaultThreshold := watchersyncer.ErrorThreshold
-		watchersyncer.ErrorThreshold = 3
+		defaultThreshold := watchersyncer.GetErrorThreshold()
+		watchersyncer.SetErrorThreshold(3)
 		defer func() {
-			watchersyncer.ErrorThreshold = defaultThreshold
+			watchersyncer.SetErrorThreshold(defaultThreshold)
 		}()
 
 		// All of the events should have been consumed within a time frame dictated by the
@@ -208,7 +210,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
 		rs.clientWatchResponse(r1, genError)
 
-		for i := 0; i < watchersyncer.ErrorThreshold; i++ {
+		n := watchersyncer.GetErrorThreshold()
+		for i := 0; i < n; i++ {
 			rs.clientListResponse(r1, genError)
 		}
 
@@ -272,10 +275,10 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should handle reconnection and syncing when the watcher sends a watch terminated error", func() {
-		defaultThreshold := watchersyncer.ErrorThreshold
-		watchersyncer.ErrorThreshold = 0
+		defaultThreshold := watchersyncer.GetErrorThreshold()
+		watchersyncer.SetErrorThreshold(0)
 		defer func() {
-			watchersyncer.ErrorThreshold = defaultThreshold
+			watchersyncer.SetErrorThreshold(defaultThreshold)
 		}()
 
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
@@ -305,10 +308,10 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should not return WaitForDatastore on multiple watch errors due to ClosedByRemote exceeding error threshold", func() {
-		defaultThreshold := watchersyncer.ErrorThreshold
-		watchersyncer.ErrorThreshold = 0
+		defaultThreshold := watchersyncer.GetErrorThreshold()
+		watchersyncer.SetErrorThreshold(0)
 		defer func() {
-			watchersyncer.ErrorThreshold = defaultThreshold
+			watchersyncer.SetErrorThreshold(defaultThreshold)
 		}()
 
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})

--- a/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/lib/backend/watchersyncer/watchersyncer_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.clientWatchResponse(r1, genError)
 		rs.ExpectStatusUnchanged()
 		n := watchersyncer.GetErrorThreshold()
-		for i := 0; i < n; i++ {
+		for i := 0; i < n-1; i++ {
 			rs.clientListResponse(r1, genError)
 			rs.ExpectStatusUnchanged()
 		}


### PR DESCRIPTION
This fixes one of the race conditions picked up by the `-race` option to `go test` and `ginkgo`, it's just a simple wrapper around the ErrorThreshold variable in the watchersyncer package.