### PR TITLE
provide a proper Revision when converting k8s to crd NetworkPolicies

### DIFF
--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -2249,6 +2249,16 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
 		})
+		It("supports resuming watch from previous revision", func() {
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, "")
+			Expect(err).NotTo(HaveOccurred())
+			event := ExpectAddedEvent(watch.ResultChan())
+			watch.Stop()
+
+			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, event.New.Revision)
+			Expect(err).NotTo(HaveOccurred())
+			watch.Stop()
+		})
 	})
 
 	Describe("watching NetworkPolicies (calico)", func() {

--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -340,7 +340,12 @@ func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterfac
 		if !ok {
 			return nil, errors.New("NetworkPolicy conversion with incorrect k8s resource type")
 		}
-		return c.K8sNetworkPolicyToCalico(np)
+
+		kvp, err := c.K8sNetworkPolicyToCalico(np)
+		if kvp != nil {
+			kvp.Revision = c.JoinNetworkPolicyRevisions("", kvp.Revision)
+		}
+		return kvp, err
 	}
 	k8sWatch := newK8sWatcherConverter(ctx, "NetworkPolicy (namespaced)", converter, k8sRawWatch)
 


### PR DESCRIPTION
## Description

This is a potential fix for https://github.com/projectcalico/typha/issues/335 . The gist of this bug report is that Typha fails to create a watch for a k8s NetworkPolicy because it fails to parse the Revision it finds in a `KVPair`:

```
Failed to create watcher
  ListRoot="/calico/resources/v3/projectcalico.org/networkpolicies"
  error=ResourceVersion is not valid: 346124214
```
The test I added is very much on the unit test side of things. I deployed it to one of our toy clusters, where it appears to work. I.e. it doesn't complain about failing to setup the watch anymore and the `List` from the full resync also disappears. The network policy is honored. I have not run the acceptance/integration testsuite locally because it fails for me even on master. The tests were done with Typha 3.7.5 and this patch applied.

As for the list of components, it's `NetworkPolicy` for sure and all its callers/users. Typha obviously, but so is everything using k8s NetworkPolicy conversion. I'm not familiar enough with the Calico codebase to come up with a list.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

The fix is an optimization in some sense, since the failure to parse the revision caused a full resync. The resync works, so the NetworkPolicies are applied. Not sure if that warrants a release note.

```release-note
fix Kubernetes NetworkPolicy conversion bug (caused unnecessary resyncs in e.g. Typha)
```