### PR TITLE
Revert "Allow SCTP ports on api v3"

### DIFF
--- a/lib/numorstring/protocol.go
+++ b/lib/numorstring/protocol.go
@@ -119,14 +119,14 @@ func (p Protocol) NumValue() (uint8, error) {
 }
 
 // SupportsProtocols returns whether this protocol supports ports.  This returns true if
-// the numerical or string version of the protocol indicates TCP (6), UDP (17), or SCTP (132).
+// the numerical or string verion of the protocol indicates TCP (6) or UDP (17).
 func (p Protocol) SupportsPorts() bool {
 	num, err := p.NumValue()
 	if err == nil {
-		return num == 6 || num == 17 || num == 132
+		return num == 6 || num == 17
 	} else {
 		switch p.StrVal {
-		case ProtocolTCP, ProtocolUDP, ProtocolTCPV1, ProtocolUDPV1, ProtocolSCTP:
+		case ProtocolTCP, ProtocolUDP, ProtocolTCPV1, ProtocolUDPV1:
 			return true
 		}
 		return false

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -811,7 +811,7 @@ func validateICMPFields(structLevel validator.StructLevel) {
 func validateRule(structLevel validator.StructLevel) {
 	rule := structLevel.Current().Interface().(api.Rule)
 
-	// If the protocol does not support ports check that the port values have not
+	// If the protocol is neither tcp (6) nor udp (17) check that the port values have not
 	// been specified.
 	if rule.Protocol == nil || !rule.Protocol.SupportsPorts() {
 		if len(rule.Source.Ports) > 0 {
@@ -929,12 +929,12 @@ func validateBGPPeerSpec(structLevel validator.StructLevel) {
 func validateEndpointPort(structLevel validator.StructLevel) {
 	port := structLevel.Current().Interface().(api.EndpointPort)
 
-	if !port.Protocol.SupportsPorts() {
+	if port.Protocol.String() != "TCP" && port.Protocol.String() != "UDP" {
 		structLevel.ReportError(
 			reflect.ValueOf(port.Protocol),
 			"EndpointPort.Protocol",
 			"",
-			reason("EndpointPort protocol does not support ports."),
+			reason("EndpointPort protocol must be 'TCP' or 'UDP'."),
 			"",
 		)
 	}
@@ -943,12 +943,12 @@ func validateEndpointPort(structLevel validator.StructLevel) {
 func validateProtoPort(structLevel validator.StructLevel) {
 	m := structLevel.Current().Interface().(api.ProtoPort)
 
-	if m.Protocol != "TCP" && m.Protocol != "UDP" && m.Protocol != "SCTP" {
+	if m.Protocol != "TCP" && m.Protocol != "UDP" {
 		structLevel.ReportError(
 			reflect.ValueOf(m.Protocol),
 			"ProtoPort.Protocol",
 			"",
-			reason("protocol must be 'TCP' or 'UDP' or 'SCTP'."),
+			reason("protocol must be 'TCP' or 'UDP'."),
 			"",
 		)
 	}

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -56,7 +56,6 @@ func init() {
 
 	protoTCP := numorstring.ProtocolFromString("TCP")
 	protoUDP := numorstring.ProtocolFromString("UDP")
-	protoSCTP := numorstring.ProtocolFromString("SCTP")
 	protoNumeric := numorstring.ProtocolFromInt(123)
 
 	as61234, _ := numorstring.ASNumberFromString("61234")
@@ -124,11 +123,6 @@ func init() {
 		Entry("should accept EndpointPort with udp protocol", api.EndpointPort{
 			Name:     "a-valid-port",
 			Protocol: protoUDP,
-			Port:     1234,
-		}, true),
-		Entry("should accept EndpointPort with sctp protocol", api.EndpointPort{
-			Name:     "a-valid-port",
-			Protocol: protoSCTP,
 			Port:     1234,
 		}, true),
 		Entry("should reject EndpointPort with empty name", api.EndpointPort{
@@ -397,7 +391,6 @@ func init() {
 		// (API) ProtoPort.
 		Entry("should accept ProtoPort.Protocol: UDP", api.ProtoPort{Protocol: "UDP", Port: 0}, true),
 		Entry("should accept ProtoPort.Protocol: TCP", api.ProtoPort{Protocol: "TCP", Port: 20}, true),
-		Entry("should accept ProtoPort.Protocol: SCTP", api.ProtoPort{Protocol: "SCTP", Port: 20}, true),
 		Entry("should reject random ProtoPort.Protocol", api.ProtoPort{Protocol: "jolly-UDP", Port: 0}, false),
 
 		// (API) Selectors.  Selectors themselves are thoroughly UT'd so only need to test simple
@@ -1056,14 +1049,14 @@ func init() {
 					NotPorts: []numorstring.Port{numorstring.SinglePort(1)},
 				},
 			}, false),
-		Entry("should allow Rule with dest ports and protocol type sctp",
+		Entry("should reject Rule with dest ports and protocol type tcp",
 			api.Rule{
 				Action:   "Allow",
 				Protocol: protocolFromString("SCTP"),
 				Destination: api.EntityRule{
 					Ports: []numorstring.Port{numorstring.SinglePort(1)},
 				},
-			}, true),
+			}, false),
 		Entry("should reject Rule with dest !ports and protocol type udp",
 			api.Rule{
 				Action:    "Allow",


### PR DESCRIPTION
Reverts projectcalico/libcalico-go#1179

Reverting this until we get the release-v3.11 branch cut; I forgot that the SCTP changes are for v3.12