### PR TITLE
Remove IgnoreLooseRPF

### DIFF
--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -46,8 +46,7 @@ type FelixConfigurationSpec struct {
 	UseInternalDataplaneDriver *bool  `json:"useInternalDataplaneDriver,omitempty"`
 	DataplaneDriver            string `json:"dataplaneDriver,omitempty"`
 
-	IPv6Support    *bool `json:"ipv6Support,omitempty" confignamev1:"Ipv6Support"`
-	IgnoreLooseRPF *bool `json:"ignoreLooseRPF,omitempty"`
+	IPv6Support *bool `json:"ipv6Support,omitempty" confignamev1:"Ipv6Support"`
 
 	// RouterefreshInterval is the period at which Felix re-checks the routes
 	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -513,11 +513,6 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.IgnoreLooseRPF != nil {
-		in, out := &in.IgnoreLooseRPF, &out.IgnoreLooseRPF
-		*out = new(bool)
-		**out = **in
-	}
 	if in.RouteRefreshInterval != nil {
 		in, out := &in.RouteRefreshInterval, &out.RouteRefreshInterval
 		*out = new(v1.Duration)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 70
+	numFelixConfigs := 69
 	numClusterConfigs := 4
 	numNodeClusterConfigs := 3
 	numBgpConfigs := 5

--- a/lib/clientv3/node_e2e_test.go
+++ b/lib/clientv3/node_e2e_test.go
@@ -290,11 +290,8 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.Datastor
 			Expect(err).ShouldNot(HaveOccurred())
 
 			nodeConfigName := fmt.Sprintf("node.%s", name1)
-			pTrue := true
 			felixConf := apiv3.FelixConfiguration{
-				Spec: apiv3.FelixConfigurationSpec{
-					IgnoreLooseRPF: &pTrue,
-				},
+				Spec: apiv3.FelixConfigurationSpec{},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeConfigName,
 				},


### PR DESCRIPTION
This removes `IgnoreLooseRPF` from Felix configuration. IgnoreLooseRPF exists because Felix requires strict RPF checking to be enabled. If "loose" RPF checking is enabled, Felix will not run unless IgnoreLooseRPF is also set.

With https://github.com/projectcalico/felix/pull/2189, we'll be removing the usage of the rp_filter sysctls and replacing all of that with an iptables rule. With that, we also won't need to check for loose RPF any more.

I'll need to add a docs PR to remove the mentions of IgnoreLooseRPF.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
IgnoreLooseRPF removed since it is no longer needed; RPF checking is done using iptables now
```
