### PR TITLE
release-v3.8 - Update go-yaml-wrapper so that we use go-yaml v2.25

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -159,10 +159,8 @@ imports:
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
   - json
-- name: github.com/projectcalico/go-yaml
-  version: 955bc3e451ef0c9df8b9113bf2e341139cdafab2
 - name: github.com/projectcalico/go-yaml-wrapper
-  version: 598e54215bee41a19677faa4f0c32acd2a87eb56
+  version: 090425220c545f6d179db17af395f5aac30b6926
 - name: github.com/prometheus/client_golang
   version: 5cec1d0429b02e4323e042eb04dafdb079ddf568
   subpackages:
@@ -303,7 +301,7 @@ imports:
 - name: gopkg.in/tomb.v1
   version: dd632973f1e7218eb1089048e0798ec9ae7dceb8
 - name: gopkg.in/yaml.v2
-  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+  version: f90ceb4f409096b60e2e9076b38b304b8246e5fa
 - name: k8s.io/api
   version: 7cf5895f2711098d7d9527db0a4a49fb0dff7de2
   subpackages:


### PR DESCRIPTION
## Description

The new pins:
- https://github.com/projectcalico/go-yaml-wrapper/commit/090425220c545f6d179db17af395f5aac30b6926
- https://github.com/go-yaml/yaml/commit/f90ceb4f409096b60e2e9076b38b304b8246e5fa

To minimize the impact of this update, I've just updated the `glide.lock` manually.

For the original PR that spawned this "cherry-pick" PR, see https://github.com/projectcalico/libcalico-go/pull/1162

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update to go-yaml v2.2.5
```
