### PR TITLE
Allow exact match on namespace / serviceaccount name

### DIFF
--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -28,4 +28,8 @@ const (
 	AnnotationPodIP = "cni.projectcalico.org/podIP"
 	// AnnotationPodIPs is similar for the plural PodIPs field.
 	AnnotationPodIPs = "cni.projectcalico.org/podIPs"
+
+	// NameLabel is a label that can be used to match a serviceaccount or namespace
+	// name exactly.
+	NameLabel = "projectcalico.org/name"
 )

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -102,8 +102,9 @@ func (c Converter) NamespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, erro
 		UID:               ns.UID,
 	}
 	profile.Spec = apiv3.ProfileSpec{
-		Ingress: []apiv3.Rule{{Action: apiv3.Allow}},
-		Egress:  []apiv3.Rule{{Action: apiv3.Allow}},
+		Ingress:       []apiv3.Rule{{Action: apiv3.Allow}},
+		Egress:        []apiv3.Rule{{Action: apiv3.Allow}},
+		LabelsToApply: labels,
 	}
 
 	// Embed the profile in a KVPair.
@@ -785,6 +786,9 @@ func (c Converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 		Name:              name,
 		CreationTimestamp: sa.CreationTimestamp,
 		UID:               sa.UID,
+	}
+	profile.Spec = apiv3.ProfileSpec{
+		LabelsToApply: labels,
 	}
 
 	// Embed the profile in a KVPair.

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -787,9 +787,7 @@ func (c Converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 		CreationTimestamp: sa.CreationTimestamp,
 		UID:               sa.UID,
 	}
-	profile.Spec = apiv3.ProfileSpec{
-		LabelsToApply: labels,
-	}
+	profile.Spec.LabelsToApply = labels
 
 	// Embed the profile in a KVPair.
 	kvp := model.KVPair{

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -2442,6 +2442,7 @@ var _ = Describe("Test Namespace conversion", func() {
 
 		// Check labels.
 		labels := p.Value.(*apiv3.Profile).Spec.LabelsToApply
+		Expect(labels["pcns.projectcalico.org/name"]).To(Equal("default"))
 		Expect(labels["pcns.foo"]).To(Equal("bar"))
 		Expect(labels["pcns.roger"]).To(Equal("rabbit"))
 	})
@@ -2468,9 +2469,10 @@ var _ = Describe("Test Namespace conversion", func() {
 		Expect(Ingress[0]).To(Equal(apiv3.Rule{Action: apiv3.Allow}))
 		Expect(Egress[0]).To(Equal(apiv3.Rule{Action: apiv3.Allow}))
 
-		// Check labels.
+		// Check labels. It should only have one - the projectcalico.org/name label.
 		labels := p.Value.(*apiv3.Profile).Spec.LabelsToApply
-		Expect(len(labels)).To(Equal(0))
+		Expect(len(labels)).To(Equal(1))
+		Expect(labels["pcns.projectcalico.org/name"]).To(Equal("default"))
 	})
 
 	It("should ignore the network-policy Namespace annotation", func() {
@@ -2624,6 +2626,7 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 
 		// Check labels.
 		labels := p.Value.(*apiv3.Profile).Spec.LabelsToApply
+		Expect(labels["pcsa.projectcalico.org/name"]).To(Equal("sa-test"))
 		Expect(labels["pcsa.foo"]).To(Equal("bar"))
 		Expect(labels["pcsa.roger"]).To(Equal("rabbit"))
 	})
@@ -2660,9 +2663,10 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 		Expect(len(Ingress)).To(Equal(0))
 		Expect(len(Egress)).To(Equal(0))
 
-		// Check labels.
+		// Check labels. It should have only one - the projectcalico.org/name label.
 		labels := p.Value.(*apiv3.Profile).Spec.LabelsToApply
-		Expect(len(labels)).To(Equal(0))
+		Expect(len(labels)).To(Equal(1))
+		Expect(labels["pcsa.projectcalico.org/name"]).To(Equal("sa-test"))
 	})
 
 	It("should handle ServiceAccount resource versions", func() {


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->


So that rules can more easily select specific namespaces.

e.g.,

```
- namespaceSelector: projectcalico.org/name == 'kube-system'
  selector: k8s-app == 'kube-dns'
```

Or at the top-level:

```
serviceaccountSelector: projectcalico.org/name == 'my-app'
```


- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add projectcalico.org/name label for exact match on namespace and serviceaccount names
```