### PR TITLE
Fix revision numbers for NetworkPolicy watches

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -456,6 +456,7 @@ func (c Converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		Namespace:         np.Namespace,
 		CreationTimestamp: np.CreationTimestamp,
 		UID:               np.UID,
+		ResourceVersion:   np.ResourceVersion,
 	}
 	policy.Spec = apiv3.NetworkPolicySpec{
 		Order:    &order,

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -2463,11 +2463,12 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 				log.WithFields(log.Fields{
 					"revision": revision,
 					"key": l.KVPairs[i].Key.String()}).Info("[Test] starting watch")
-				_, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, revision)
+				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, revision)
 				Expect(err).ToNot(HaveOccurred())
 				// Since the items in the list aren't guaranteed to be in any specific order, we
 				// can't assert anything useful about what you should get out of this watch, so we
 				// just confirm that there is no error.
+				watch.Stop()
 			}
 		})
 	})

--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -237,6 +237,8 @@ func (c *networkPolicyClient) List(ctx context.Context, list model.ListInterface
 	}
 
 	// List all Namespaced Calico Network Policies.
+	// For consistency, we should split the revision that was input into CRD and K8s revisions,
+	// but the CRD client will fail on any non-empty revision anyway, so don't bother.
 	npKvps, err := c.crdClient.List(ctx, l, revision)
 	if err != nil {
 		log.WithError(err).Info("Unable to list Calico CRD-backed Network Policy resources")
@@ -341,11 +343,7 @@ func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterfac
 			return nil, errors.New("NetworkPolicy conversion with incorrect k8s resource type")
 		}
 
-		kvp, err := c.K8sNetworkPolicyToCalico(np)
-		if kvp != nil {
-			kvp.Revision = c.JoinNetworkPolicyRevisions("", kvp.Revision)
-		}
-		return kvp, err
+		return c.K8sNetworkPolicyToCalico(np)
 	}
 	k8sWatch := newK8sWatcherConverter(ctx, "NetworkPolicy (namespaced)", converter, k8sRawWatch)
 
@@ -474,16 +472,16 @@ func (npw *networkPolicyWatcher) processNPEvents() {
 		// event needs to able to be passed back into a Watch client so that we can resume watching
 		// when a watch fails.  The watch client is expecting a slash separated list of resource
 		// versions in the format <CRD NP Revision>/<k8s NP Revision>.
-		var value interface{}
+		var kvp *model.KVPair
 		switch e.Type {
 		case api.WatchModified, api.WatchAdded:
-			value = e.New.Value
+			kvp = e.New
 		case api.WatchDeleted:
-			value = e.Old.Value
+			kvp = e.Old
 		}
 
-		if value != nil {
-			oma, ok := value.(metav1.ObjectMetaAccessor)
+		if kvp != nil && kvp.Value != nil {
+			oma, ok := kvp.Value.(metav1.ObjectMetaAccessor)
 			if !ok {
 				log.WithField("event", e).Error(
 					"Resource returned from watch does not implement the ObjectMetaAccessor interface")
@@ -499,7 +497,12 @@ func (npw *networkPolicyWatcher) processNPEvents() {
 			} else {
 				npw.k8sNPRev = oma.GetObjectMeta().GetResourceVersion()
 			}
-			oma.GetObjectMeta().SetResourceVersion(npw.JoinNetworkPolicyRevisions(npw.crdNPRev, npw.k8sNPRev))
+			revision := npw.JoinNetworkPolicyRevisions(npw.crdNPRev, npw.k8sNPRev)
+			log.WithField("revision", revision).Debug("updating NP revision")
+			// The revision is accessible both on the object itself, and on the KVP.  Update them both to match.
+			oma.GetObjectMeta().SetResourceVersion(revision)
+			kvp.Revision = revision
+
 		} else if e.Error == nil {
 			log.WithField("event", e).Warning("Event had nil error and value")
 		}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes revision numbers coming out of watch events, so that we can resume from where we left off if our watch gets cancelled (which happens periodically).

Fixes https://github.com/projectcalico/typha/issues/335

## Todos
- [x] Tests
- [x] Documentation not required
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes an issue where Felix / Typha unnecessarily perform full resyncs of NetworkPolicies
```
