### PR TITLE
Fix up noisy and unhelpful log

### DIFF
--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -280,7 +280,9 @@ func (c *networkPolicyClient) List(ctx context.Context, list model.ListInterface
 	// that can be decoded by the Watch.
 	npKvps.Revision = c.JoinNetworkPolicyRevisions(npKvps.Revision, networkPolicies.ResourceVersion)
 
-	log.WithField("KVPs", npKvps).Info("Returning NP KVPs")
+	log.WithFields(log.Fields{
+		"num_kvps": len(npKvps.KVPairs),
+		"revision": npKvps.Revision}).Debug("Returning NP KVPs")
 	return npKvps, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes a noisy log.  Firstly, it logs at `Info`, which is probably not the right level for a low level log about the results of Listing network policies, so this PR turns it down to `Debug`.

Secondly, it logs an object that contains a list of pointers, which creates logs like

```
networkpolicy.go 283: Returning NP KVPs KVPs=&model.KVPairList{KVPairs:[]*model.KVPair{(*model.KVPair)(0xc01a14b800),...
```

Pointer memory addresses aren't very useful, and when there are a lot of network policies, it can make for a really long line. Instead we just list the number of KVPs and the Revision.

## Todos
- [x] Tests not required
- [x] Documentation not required
- [x] Release note not required

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
