### PR TITLE
v3 Client support for KubeControllersConfiguration

### DIFF
--- a/lib/apis/v3/constants.go
+++ b/lib/apis/v3/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,4 +45,8 @@ const (
 	OrchestratorCNI        = "cni"
 	OrchestratorDocker     = "libnetwork"
 	OrchestratorOpenStack  = "openstack"
+
+	// Enum options for enable/disable fields
+	Enabled  = "Enabled"
+	Disabled = "Disabled"
 )

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,6 +213,12 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 		apiv3.KindWorkloadEndpoint,
 		resources.NewWorkloadEndpointClient(cs),
 	)
+	kubeClient.registerResourceClient(
+		reflect.TypeOf(model.ResourceKey{}),
+		reflect.TypeOf(model.ResourceListOptions{}),
+		apiv3.KindKubeControllersConfiguration,
+		resources.NewKubeControllersConfigClient(cs, crdClientV1),
+	)
 
 	if ca.K8sUsePodCIDR {
 		// Using host-local IPAM. Use Kubernetes pod CIDRs to back IPAM.
@@ -318,6 +324,7 @@ func (c *KubeClient) Clean() error {
 		apiv3.KindNetworkSet,
 		apiv3.KindIPPool,
 		apiv3.KindHostEndpoint,
+		apiv3.KindKubeControllersConfiguration,
 	}
 	ctx := context.Background()
 	for _, k := range kinds {
@@ -420,6 +427,8 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 				&apiv3.IPAMHandleList{},
 				&apiv3.IPAMConfig{},
 				&apiv3.IPAMConfigList{},
+				&apiv3.KubeControllersConfiguration{},
+				&apiv3.KubeControllersConfigurationList{},
 			)
 			return nil
 		})

--- a/lib/backend/k8s/resources/kubecontrollersconfig.go
+++ b/lib/backend/k8s/resources/kubecontrollersconfig.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"reflect"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	KubeControllersConfigResourceName = "KubeControllersConfigurations"
+	KubeControllersConfigCRDName      = "kubecontrollersconfigurations.crd.projectcalico.org"
+)
+
+func NewKubeControllersConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	return &customK8sResourceClient{
+		clientSet:       c,
+		restClient:      r,
+		name:            KubeControllersConfigCRDName,
+		resource:        KubeControllersConfigResourceName,
+		description:     "Calico Cluster Information",
+		k8sResourceType: reflect.TypeOf(apiv3.KubeControllersConfiguration{}),
+		k8sResourceTypeMeta: metav1.TypeMeta{
+			Kind:       apiv3.KindKubeControllersConfiguration,
+			APIVersion: apiv3.GroupVersionCurrent,
+		},
+		k8sListType:  reflect.TypeOf(apiv3.KubeControllersConfigurationList{}),
+		resourceKind: apiv3.KindKubeControllersConfiguration,
+	}
+}

--- a/lib/backend/k8s/resources/kubecontrollersconfig.go
+++ b/lib/backend/k8s/resources/kubecontrollersconfig.go
@@ -35,7 +35,7 @@ func NewKubeControllersConfigClient(c *kubernetes.Clientset, r *rest.RESTClient)
 		restClient:      r,
 		name:            KubeControllersConfigCRDName,
 		resource:        KubeControllersConfigResourceName,
-		description:     "Calico Cluster Information",
+		description:     "Calico Kubernetes Controllers Configuration",
 		k8sResourceType: reflect.TypeOf(apiv3.KubeControllersConfiguration{}),
 		k8sResourceTypeMeta: metav1.TypeMeta{
 			Kind:       apiv3.KindKubeControllersConfiguration,

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,6 +118,10 @@ func init() {
 		"workloadendpoints",
 		reflect.TypeOf(apiv3.WorkloadEndpoint{}),
 	)
+	registerResourceInfo(
+		apiv3.KindKubeControllersConfiguration,
+		"kubecontrollersconfigurations",
+		reflect.TypeOf(apiv3.KubeControllersConfiguration{}))
 }
 
 type ResourceKey struct {

--- a/lib/clientv3/client.go
+++ b/lib/clientv3/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,6 +142,12 @@ func (c client) FelixConfigurations() FelixConfigurationInterface {
 // ClusterInformation returns an interface for managing the cluster information resource.
 func (c client) ClusterInformation() ClusterInformationInterface {
 	return clusterInformation{client: c}
+}
+
+// KubeControllersConfiguration returns an interface for managing the Kubernetes controllers
+// configuration resource.
+func (c client) KubeControllersConfiguration() KubeControllersConfigurationInterface {
+	return kubeControllersConfiguration{client: c}
 }
 
 type poolAccessor struct {

--- a/lib/clientv3/common_test.go
+++ b/lib/clientv3/common_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017, 2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import (
 )
 
 var MatchResource = testutils.Resource
+var MatchResourceWithStatus = testutils.ResourceWithStatus
 
 var _ = testutils.E2eDatastoreDescribe("Common resource tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 	Describe("Common resource tests", func() {

--- a/lib/clientv3/interface.go
+++ b/lib/clientv3/interface.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,10 @@ type Interface interface {
 	FelixConfigurations() FelixConfigurationInterface
 	// ClusterInformation returns an interface for managing the cluster information resource.
 	ClusterInformation() ClusterInformationInterface
+	// KubeControllersConfiguration returns an interface for managing the
+	// KubeControllersConfiguration resource.
+	KubeControllersConfiguration() KubeControllersConfigurationInterface
+
 	// EnsureInitialized is used to ensure the backend datastore is correctly
 	// initialized for use by Calico.  This method may be called multiple times, and
 	// will have no effect if the datastore is already correctly initialized.

--- a/lib/clientv3/kubecontrollersconfig.go
+++ b/lib/clientv3/kubecontrollersconfig.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+	"errors"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+// KubeControllersConfigurationInterface has methods to work with KubeControllersConfiguration resources.
+type KubeControllersConfigurationInterface interface {
+	Create(ctx context.Context, res *apiv3.KubeControllersConfiguration, opts options.SetOptions) (*apiv3.KubeControllersConfiguration, error)
+	Update(ctx context.Context, res *apiv3.KubeControllersConfiguration, opts options.SetOptions) (*apiv3.KubeControllersConfiguration, error)
+	Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.KubeControllersConfiguration, error)
+	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.KubeControllersConfiguration, error)
+	List(ctx context.Context, opts options.ListOptions) (*apiv3.KubeControllersConfigurationList, error)
+	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// KubeControllersConfiguration implements KubeControllersConfigurationInterface
+type kubeControllersConfiguration struct {
+	client client
+}
+
+// Create takes the representation of a KubeControllersConfiguration and creates it.
+// Returns the stored representation of the KubeControllersConfiguration, and an error
+// if there is any.
+func (r kubeControllersConfiguration) Create(ctx context.Context, res *apiv3.KubeControllersConfiguration, opts options.SetOptions) (*apiv3.KubeControllersConfiguration, error) {
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	if res.ObjectMeta.GetName() != "default" {
+		return nil, errors.New("Cannot create a Kube Controllers Configuration resource with a name other than \"default\"")
+	}
+	out, err := r.client.resources.Create(ctx, opts, apiv3.KindKubeControllersConfiguration, res)
+	if out != nil {
+		return out.(*apiv3.KubeControllersConfiguration), err
+	}
+	return nil, err
+}
+
+// Update takes the representation of a KubeControllersConfiguration and updates it.
+// Returns the stored representation of the KubeControllersConfiguration, and an error
+// if there is any.
+func (r kubeControllersConfiguration) Update(ctx context.Context, res *apiv3.KubeControllersConfiguration, opts options.SetOptions) (*apiv3.KubeControllersConfiguration, error) {
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Update(ctx, opts, apiv3.KindKubeControllersConfiguration, res)
+	if out != nil {
+		return out.(*apiv3.KubeControllersConfiguration), err
+	}
+	return nil, err
+}
+
+// Delete takes name of the KubeControllersConfiguration and deletes it. Returns an
+// error if one occurs.
+func (r kubeControllersConfiguration) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.KubeControllersConfiguration, error) {
+	out, err := r.client.resources.Delete(ctx, opts, apiv3.KindKubeControllersConfiguration, noNamespace, name)
+	if out != nil {
+		return out.(*apiv3.KubeControllersConfiguration), err
+	}
+	return nil, err
+}
+
+// Get takes name of the KubeControllersConfiguration, and returns the corresponding
+// KubeControllersConfiguration object, and an error if there is any.
+func (r kubeControllersConfiguration) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.KubeControllersConfiguration, error) {
+	out, err := r.client.resources.Get(ctx, opts, apiv3.KindKubeControllersConfiguration, noNamespace, name)
+	if out != nil {
+		return out.(*apiv3.KubeControllersConfiguration), err
+	}
+	return nil, err
+}
+
+// List returns the list of KubeControllersConfiguration objects that match the supplied options.
+func (r kubeControllersConfiguration) List(ctx context.Context, opts options.ListOptions) (*apiv3.KubeControllersConfigurationList, error) {
+	res := &apiv3.KubeControllersConfigurationList{}
+	if err := r.client.resources.List(ctx, opts, apiv3.KindKubeControllersConfiguration, apiv3.KindKubeControllersConfigurationList, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Watch returns a watch.Interface that watches the KubeControllersConfiguration that
+// match the supplied options.
+func (r kubeControllersConfiguration) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	return r.client.resources.Watch(ctx, opts, apiv3.KindKubeControllersConfiguration, nil)
+}

--- a/lib/clientv3/kubecontrollersconfig_e2e_test.go
+++ b/lib/clientv3/kubecontrollersconfig_e2e_test.go
@@ -134,7 +134,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(ContainSubstring("resource does not exist: KubeControllersConfiguration(" + name + ") with error:"))
 
-			By("Attempting to creating a new KubeControllersConfiguration with name/spec1 and a non-empty ResourceVersion")
+			By("Attempting to creating a new KubeControllersConfiguration with spec1 and a non-empty ResourceVersion")
 			_, outError = c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "12345"},
 				Spec:       spec1,
@@ -142,7 +142,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
 
-			By("Getting KubeControllersConfiguration (name) before it is created")
+			By("Getting KubeControllersConfiguration before it is created")
 			_, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(ContainSubstring("resource does not exist: KubeControllersConfiguration(" + name + ") with error:"))
@@ -155,7 +155,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("Cannot create a Kube Controllers Configuration resource with a name other than \"default\""))
 
-			By("Creating a new KubeControllersConfiguration with name/spec1")
+			By("Creating a new KubeControllersConfiguration with spec1")
 			res1, outError := c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: name},
 				Spec:       spec1,
@@ -166,7 +166,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			// Track the version of the original data for name.
 			rv1_1 := res1.ResourceVersion
 
-			By("Attempting to create the same KubeControllersConfiguration with name but with spec2")
+			By("Attempting to create the same KubeControllersConfiguration but with spec2")
 			_, outError = c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: name},
 				Spec:       spec2,
@@ -174,20 +174,20 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("resource already exists: KubeControllersConfiguration(" + name + ")"))
 
-			By("Getting KubeControllersConfiguration (name) and comparing the output against spec1")
+			By("Getting KubeControllersConfiguration and comparing the output against spec1")
 			res, outError := c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1))
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
 
-			By("Listing all the KubeControllersConfiguration, expecting a single result with name/spec1")
+			By("Listing all the KubeControllersConfiguration, expecting a single result with spec1")
 			outList, outError := c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(ConsistOf(
 				testutils.Resource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1),
 			))
 
-			By("Updating KubeControllersConfiguration name with spec2")
+			By("Updating KubeControllersConfiguration with spec2")
 			res1.Spec = spec2
 			res1, outError = c.KubeControllersConfiguration().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
@@ -214,14 +214,14 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			// Track the version of the updated name data.
 			rv1_2 := res1.ResourceVersion
 
-			By("Updating KubeControllersConfiguration name without specifying a resource version")
+			By("Updating KubeControllersConfiguration without specifying a resource version")
 			res1.Spec = spec1
 			res1.ObjectMeta.ResourceVersion = ""
 			_, outError = c.KubeControllersConfiguration().Update(ctx, res1, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
 
-			By("Updating KubeControllersConfiguration name using the previous resource version")
+			By("Updating KubeControllersConfiguration using the previous resource version")
 			res1.Spec = spec1
 			res1.ResourceVersion = rv1_1
 			_, outError = c.KubeControllersConfiguration().Update(ctx, res1, options.SetOptions{})
@@ -229,21 +229,21 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			Expect(outError.Error()).To(Equal("update conflict: KubeControllersConfiguration(" + name + ")"))
 
 			if config.Spec.DatastoreType != apiconfig.Kubernetes {
-				By("Getting KubeControllersConfiguration (name) with the original resource version and comparing the output against spec1")
+				By("Getting KubeControllersConfiguration with the original resource version and comparing the output against spec1")
 				res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{ResourceVersion: rv1_1})
 				Expect(outError).NotTo(HaveOccurred())
 				Expect(res).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1))
 				Expect(res.ResourceVersion).To(Equal(rv1_1))
 			}
 
-			By("Getting KubeControllersConfiguration (name) with the updated resource version and comparing the output against spec2")
+			By("Getting KubeControllersConfiguration with the updated resource version and comparing the output against spec2")
 			res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{ResourceVersion: rv1_2})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2))
 			Expect(res.ResourceVersion).To(Equal(rv1_2))
 
 			if config.Spec.DatastoreType != apiconfig.Kubernetes {
-				By("Listing KubeControllersConfiguration with the original resource version and checking for a single result with name/spec1")
+				By("Listing KubeControllersConfiguration with the original resource version and checking for a single result with spec1")
 				outList, outError = c.KubeControllersConfiguration().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
 				Expect(outError).NotTo(HaveOccurred())
 				Expect(outList.Items).To(ConsistOf(
@@ -251,7 +251,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 				))
 			}
 
-			By("Listing KubeControllersConfiguration with the latest resource version and checking for one result with name/spec2")
+			By("Listing KubeControllersConfiguration with the latest resource version and checking for one result with spec2")
 			outList, outError = c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(ConsistOf(
@@ -276,19 +276,19 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			Expect(res).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status2))
 			rv1_3 := res.ResourceVersion
 
-			By("Getting resource and verifying status1 is present")
+			By("Getting resource and verifying status2 is present")
 			res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
 			Expect(outError).ToNot(HaveOccurred())
 			Expect(res).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status2))
 
 			if config.Spec.DatastoreType != apiconfig.Kubernetes {
-				By("Deleting KubeControllersConfiguration (name) with the old resource version")
+				By("Deleting KubeControllersConfiguration with the old resource version")
 				_, outError = c.KubeControllersConfiguration().Delete(ctx, name, options.DeleteOptions{ResourceVersion: rv1_1})
 				Expect(outError).To(HaveOccurred())
 				Expect(outError.Error()).To(Equal("update conflict: KubeControllersConfiguration(" + name + ")"))
 			}
 
-			By("Deleting KubeControllersConfiguration (name) with the new resource version")
+			By("Deleting KubeControllersConfiguration with the new resource version")
 			dres, outError := c.KubeControllersConfiguration().Delete(ctx, name, options.DeleteOptions{ResourceVersion: rv1_3})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(dres).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status2))
@@ -306,13 +306,13 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 
 	Describe("KubeControllersConfiguration watch functionality", func() {
 		It("should handle watch events for different resource versions and event types", func() {
-			By("Listing KubeControllersConfiguration with the latest resource version and checking for one result with name/spec2")
+			By("Listing KubeControllersConfiguration with the latest resource version and checking for one result with spec2")
 			outList, outError := c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
-			By("Configuring a KubeControllersConfiguration name/spec1 and storing the response")
+			By("Configuring a KubeControllersConfiguration spec1 and storing the response")
 			outRes1, err := c.KubeControllersConfiguration().Create(
 				ctx,
 				&apiv3.KubeControllersConfiguration{
@@ -343,7 +343,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			})
 			testWatcher1.Stop()
 
-			By("Configuring a KubeControllersConfiguration name2/spec2 and storing the response")
+			By("Configuring a KubeControllersConfiguration spec2 and storing the response")
 			outRes2, err := c.KubeControllersConfiguration().Create(
 				ctx,
 				&apiv3.KubeControllersConfiguration{
@@ -392,7 +392,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 
 			// Only etcdv3 supports watching a specific instance of a resource.
 			if config.Spec.DatastoreType == apiconfig.EtcdV3 {
-				By("Starting a watcher from rev0 watching name - this should get all events for name")
+				By("Starting a watcher from rev0 watching by name - this should get all events")
 				w, err = c.KubeControllersConfiguration().Watch(ctx, options.ListOptions{Name: name, ResourceVersion: rev0})
 				Expect(err).NotTo(HaveOccurred())
 				testWatcher2_1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)

--- a/lib/clientv3/kubecontrollersconfig_e2e_test.go
+++ b/lib/clientv3/kubecontrollersconfig_e2e_test.go
@@ -1,0 +1,446 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name := "default"
+	spec1 := apiv3.KubeControllersConfigurationSpec{
+		HealthChecks: apiv3.Enabled,
+		Controllers: apiv3.ControllersConfig{
+			Node: &apiv3.NodeControllerConfig{
+				ReconcilerPeriod: "5m30s",
+				SyncLabels:       apiv3.Enabled,
+				HostEndpoint:     nil,
+			},
+			Policy:           nil,
+			WorkloadEndpoint: nil,
+			ServiceAccount:   nil,
+			Namespace:        nil,
+		},
+	}
+	spec2 := apiv3.KubeControllersConfigurationSpec{
+		HealthChecks: apiv3.Disabled,
+		Controllers: apiv3.ControllersConfig{
+			Node: &apiv3.NodeControllerConfig{
+				ReconcilerPeriod: "5m30s",
+				SyncLabels:       apiv3.Enabled,
+				HostEndpoint: &apiv3.AutoHostEndpointConfig{
+					AutoCreate: apiv3.Enabled,
+				},
+			},
+			Policy:           &apiv3.PolicyControllerConfig{ReconcilerPeriod: "3m"},
+			WorkloadEndpoint: &apiv3.WorkloadEndpointControllerConfig{ReconcilerPeriod: "4m"},
+			ServiceAccount:   &apiv3.ServiceAccountControllerConfig{ReconcilerPeriod: "5m"},
+			Namespace:        &apiv3.NamespaceControllerConfig{ReconcilerPeriod: "6m"},
+		},
+	}
+	status1 := apiv3.KubeControllersConfigurationStatus{
+		RunningConfig: apiv3.KubeControllersConfigurationSpec{
+			LogSeverityScreen: "Debug",
+			HealthChecks:      apiv3.Enabled,
+			Controllers: apiv3.ControllersConfig{
+				Node: &apiv3.NodeControllerConfig{
+					ReconcilerPeriod: "5m30s",
+					SyncLabels:       apiv3.Enabled,
+					HostEndpoint:     nil,
+				},
+				Policy:           nil,
+				WorkloadEndpoint: nil,
+				ServiceAccount:   nil,
+				Namespace:        nil,
+			},
+		},
+		EnvironmentVars: map[string]string{
+			"LOG_LEVEL":     "Debug",
+			"HEALTHENABLED": "true",
+		},
+	}
+	status2 := apiv3.KubeControllersConfigurationStatus{
+		RunningConfig: apiv3.KubeControllersConfigurationSpec{
+			HealthChecks: apiv3.Disabled,
+			Controllers: apiv3.ControllersConfig{
+				Node: &apiv3.NodeControllerConfig{
+					ReconcilerPeriod: "5m30s",
+					SyncLabels:       apiv3.Enabled,
+					HostEndpoint: &apiv3.AutoHostEndpointConfig{
+						AutoCreate: apiv3.Enabled,
+					},
+				},
+				Policy:           &apiv3.PolicyControllerConfig{ReconcilerPeriod: "3m"},
+				WorkloadEndpoint: &apiv3.WorkloadEndpointControllerConfig{ReconcilerPeriod: "4m"},
+				ServiceAccount:   &apiv3.ServiceAccountControllerConfig{ReconcilerPeriod: "5m"},
+				Namespace:        &apiv3.NamespaceControllerConfig{ReconcilerPeriod: "6m"},
+			},
+		},
+		EnvironmentVars: map[string]string{
+			"LOG_LEVEL":     "Info",
+			"HEALTHENABLED": "false",
+		},
+	}
+
+	var c clientv3.Interface
+	var be bapi.Client
+
+	BeforeEach(func() {
+		var err error
+		c, err = clientv3.New(config)
+		Expect(err).NotTo(HaveOccurred())
+
+		be, err = backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		err = be.Clean()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable("KubeControllersConfiguration e2e CRUD tests",
+		func(name string, spec1, spec2 apiv3.KubeControllersConfigurationSpec, status1, status2 apiv3.KubeControllersConfigurationStatus) {
+			By("Updating the KubeControllersConfiguration before it is created")
+			_, outError := c.KubeControllersConfiguration().Update(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-kubecontrollersconfig"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: KubeControllersConfiguration(" + name + ") with error:"))
+
+			By("Attempting to creating a new KubeControllersConfiguration with name/spec1 and a non-empty ResourceVersion")
+			_, outError = c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Getting KubeControllersConfiguration (name) before it is created")
+			_, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist: KubeControllersConfiguration(" + name + ") with error:"))
+
+			By("Attempting to create a new KubeControllersConfiguration with a non-default name and spec1")
+			_, outError = c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "not-default"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("Cannot create a Kube Controllers Configuration resource with a name other than \"default\""))
+
+			By("Creating a new KubeControllersConfiguration with name/spec1")
+			res1, outError := c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res1).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1))
+
+			// Track the version of the original data for name.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same KubeControllersConfiguration with name but with spec2")
+			_, outError = c.KubeControllersConfiguration().Create(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("resource already exists: KubeControllersConfiguration(" + name + ")"))
+
+			By("Getting KubeControllersConfiguration (name) and comparing the output against spec1")
+			res, outError := c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1))
+			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
+
+			By("Listing all the KubeControllersConfiguration, expecting a single result with name/spec1")
+			outList, outError := c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1),
+			))
+
+			By("Updating KubeControllersConfiguration name with spec2")
+			res1.Spec = spec2
+			res1, outError = c.KubeControllersConfiguration().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res1).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2))
+
+			By("Attempting to update the KubeControllersConfiguration without a Creation Timestamp")
+			res, outError = c.KubeControllersConfiguration().Update(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: "test-fail-kubecontrollersconfig"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.CreationTimestamp = '0001-01-01 00:00:00 +0000 UTC' (field must be set for an Update request)"))
+
+			By("Attempting to update the KubeControllersConfiguration without a UID")
+			res, outError = c.KubeControllersConfiguration().Update(ctx, &apiv3.KubeControllersConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now()},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(res).To(BeNil())
+			Expect(outError.Error()).To(Equal("error with field Metadata.UID = '' (field must be set for an Update request)"))
+
+			// Track the version of the updated name data.
+			rv1_2 := res1.ResourceVersion
+
+			By("Updating KubeControllersConfiguration name without specifying a resource version")
+			res1.Spec = spec1
+			res1.ObjectMeta.ResourceVersion = ""
+			_, outError = c.KubeControllersConfiguration().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '' (field must be set for an Update request)"))
+
+			By("Updating KubeControllersConfiguration name using the previous resource version")
+			res1.Spec = spec1
+			res1.ResourceVersion = rv1_1
+			_, outError = c.KubeControllersConfiguration().Update(ctx, res1, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("update conflict: KubeControllersConfiguration(" + name + ")"))
+
+			if config.Spec.DatastoreType != apiconfig.Kubernetes {
+				By("Getting KubeControllersConfiguration (name) with the original resource version and comparing the output against spec1")
+				res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{ResourceVersion: rv1_1})
+				Expect(outError).NotTo(HaveOccurred())
+				Expect(res).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1))
+				Expect(res.ResourceVersion).To(Equal(rv1_1))
+			}
+
+			By("Getting KubeControllersConfiguration (name) with the updated resource version and comparing the output against spec2")
+			res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{ResourceVersion: rv1_2})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res).To(MatchResource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2))
+			Expect(res.ResourceVersion).To(Equal(rv1_2))
+
+			if config.Spec.DatastoreType != apiconfig.Kubernetes {
+				By("Listing KubeControllersConfiguration with the original resource version and checking for a single result with name/spec1")
+				outList, outError = c.KubeControllersConfiguration().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+				Expect(outError).NotTo(HaveOccurred())
+				Expect(outList.Items).To(ConsistOf(
+					testutils.Resource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec1),
+				))
+			}
+
+			By("Listing KubeControllersConfiguration with the latest resource version and checking for one result with name/spec2")
+			outList, outError = c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2),
+			))
+
+			By("Setting status1 on resource")
+			res.Status = status1
+			res, outError = c.KubeControllersConfiguration().Update(ctx, res, options.SetOptions{})
+			Expect(outError).ToNot(HaveOccurred())
+			Expect(res).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status1))
+
+			By("Getting resource and verifying status1 is present")
+			res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
+			Expect(outError).ToNot(HaveOccurred())
+			Expect(res).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status1))
+
+			By("Setting status2 on resource")
+			res.Status = status2
+			res, outError = c.KubeControllersConfiguration().Update(ctx, res, options.SetOptions{})
+			Expect(outError).ToNot(HaveOccurred())
+			Expect(res).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status2))
+			rv1_3 := res.ResourceVersion
+
+			By("Getting resource and verifying status1 is present")
+			res, outError = c.KubeControllersConfiguration().Get(ctx, name, options.GetOptions{})
+			Expect(outError).ToNot(HaveOccurred())
+			Expect(res).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status2))
+
+			if config.Spec.DatastoreType != apiconfig.Kubernetes {
+				By("Deleting KubeControllersConfiguration (name) with the old resource version")
+				_, outError = c.KubeControllersConfiguration().Delete(ctx, name, options.DeleteOptions{ResourceVersion: rv1_1})
+				Expect(outError).To(HaveOccurred())
+				Expect(outError.Error()).To(Equal("update conflict: KubeControllersConfiguration(" + name + ")"))
+			}
+
+			By("Deleting KubeControllersConfiguration (name) with the new resource version")
+			dres, outError := c.KubeControllersConfiguration().Delete(ctx, name, options.DeleteOptions{ResourceVersion: rv1_3})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(dres).To(MatchResourceWithStatus(apiv3.KindKubeControllersConfiguration, testutils.ExpectNoNamespace, name, spec2, status2))
+
+			By("Listing all KubeControllersConfiguration and expecting no items")
+			outList, outError = c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+
+		},
+
+		// Test 1: Pass two fully populated KubeControllersConfigurationSpecs and expect the series of operations to succeed.
+		Entry("Two fully populated KubeControllersConfigurationSpecs", name, spec1, spec2, status1, status2),
+	)
+
+	Describe("KubeControllersConfiguration watch functionality", func() {
+		It("should handle watch events for different resource versions and event types", func() {
+			By("Listing KubeControllersConfiguration with the latest resource version and checking for one result with name/spec2")
+			outList, outError := c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+			rev0 := outList.ResourceVersion
+
+			By("Configuring a KubeControllersConfiguration name/spec1 and storing the response")
+			outRes1, err := c.KubeControllersConfiguration().Create(
+				ctx,
+				&apiv3.KubeControllersConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			rev1 := outRes1.ResourceVersion
+
+			By("Starting a watcher from revision rev1 - this should skip the first creation")
+			w, err := c.KubeControllersConfiguration().Watch(ctx, options.ListOptions{ResourceVersion: rev1})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+			defer testWatcher1.Stop()
+
+			By("Deleting res1")
+			_, err = c.KubeControllersConfiguration().Delete(ctx, name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for event: delete res1")
+			testWatcher1.ExpectEvents(apiv3.KindKubeControllersConfiguration, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+			})
+			testWatcher1.Stop()
+
+			By("Configuring a KubeControllersConfiguration name2/spec2 and storing the response")
+			outRes2, err := c.KubeControllersConfiguration().Create(
+				ctx,
+				&apiv3.KubeControllersConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Spec:       spec2,
+				},
+				options.SetOptions{},
+			)
+
+			By("Starting a watcher from rev0 - this should get all events")
+			w, err = c.KubeControllersConfiguration().Watch(ctx, options.ListOptions{ResourceVersion: rev0})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+			defer testWatcher2.Stop()
+
+			By("Modifying res2")
+			outRes3, err := c.KubeControllersConfiguration().Update(
+				ctx,
+				&apiv3.KubeControllersConfiguration{
+					ObjectMeta: outRes2.ObjectMeta,
+					Spec:       spec1,
+				},
+				options.SetOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher2.ExpectEvents(apiv3.KindKubeControllersConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes1,
+				},
+				{
+					Type:     watch.Deleted,
+					Previous: outRes1,
+				},
+				{
+					Type:   watch.Added,
+					Object: outRes2,
+				},
+				{
+					Type:     watch.Modified,
+					Previous: outRes2,
+					Object:   outRes3,
+				},
+			})
+			testWatcher2.Stop()
+
+			// Only etcdv3 supports watching a specific instance of a resource.
+			if config.Spec.DatastoreType == apiconfig.EtcdV3 {
+				By("Starting a watcher from rev0 watching name - this should get all events for name")
+				w, err = c.KubeControllersConfiguration().Watch(ctx, options.ListOptions{Name: name, ResourceVersion: rev0})
+				Expect(err).NotTo(HaveOccurred())
+				testWatcher2_1 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+				defer testWatcher2_1.Stop()
+				testWatcher2_1.ExpectEvents(apiv3.KindKubeControllersConfiguration, []watch.Event{
+					{
+						Type:   watch.Added,
+						Object: outRes1,
+					},
+					{
+						Type:     watch.Deleted,
+						Previous: outRes1,
+					},
+					{
+						Type:   watch.Added,
+						Object: outRes2,
+					},
+					{
+						Type:     watch.Modified,
+						Previous: outRes2,
+						Object:   outRes3,
+					},
+				})
+				testWatcher2_1.Stop()
+			}
+
+			By("Starting a watcher not specifying a rev - expect the current snapshot")
+			w, err = c.KubeControllersConfiguration().Watch(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+			defer testWatcher3.Stop()
+			testWatcher3.ExpectEventsAnyOrder(apiv3.KindKubeControllersConfiguration, []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: outRes3,
+				},
+			})
+
+			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
+			testWatcher3.ExpectEvents(apiv3.KindKubeControllersConfiguration, []watch.Event{
+				{
+					Type:     watch.Deleted,
+					Previous: outRes3,
+				},
+			})
+			testWatcher3.Stop()
+		})
+	})
+})

--- a/test/crds.yaml
+++ b/test/crds.yaml
@@ -198,3 +198,15 @@ items:
       kind: IPAMConfig
       plural: ipamconfigs
       singular: ipamconfig
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: kubecontrollersconfigurations.crd.projectcalico.org
+  spec:
+    scope: Cluster
+    group: crd.projectcalico.org
+    version: v1
+    names:
+      kind: KubeControllersConfiguration
+      plural: kubecontrollersconfigurations
+      singular: kubecontrollersconfiguration


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Adds support to the v3 client to read and write KubeControllersConfiguration resources.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
v3 Client can CRUD KubeControllersConfiguration resources
```
