### PR TITLE
Refactor WorkloadEndpoint conversion and clients

### DIFF
--- a/lib/backend/k8s/conversion/workload_endpoint.go
+++ b/lib/backend/k8s/conversion/workload_endpoint.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO move the WorkloadEndpoint converters to is own package. Some refactoring of the annotation and label constants
+// is necessary to avoid circular imports, which is why this has been deferred.
+package conversion
+
+import (
+	kapiv1 "k8s.io/api/core/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+type WorkloadEndpointConverter interface {
+	VethNameForWorkload(namespace, podName string) string
+	PodToWorkloadEndpoints(pod *kapiv1.Pod) ([]*model.KVPair, error)
+}
+
+func NewWorkloadEndpointConverter() WorkloadEndpointConverter {
+	return &defaultWorkloadEndpointConverter{}
+}

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversion
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/names"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+)
+
+type defaultWorkloadEndpointConverter struct{}
+
+// VethNameForWorkload returns a deterministic veth name
+// for the given Kubernetes workload (WEP) name and namespace.
+func (wc defaultWorkloadEndpointConverter) VethNameForWorkload(namespace, podname string) string {
+	// A SHA1 is always 20 bytes long, and so is sufficient for generating the
+	// veth name and mac addr.
+	h := sha1.New()
+	h.Write([]byte(fmt.Sprintf("%s.%s", namespace, podname)))
+	prefix := os.Getenv("FELIX_INTERFACEPREFIX")
+	if prefix == "" {
+		// Prefix is not set. Default to "cali"
+		prefix = "cali"
+	} else {
+		// Prefix is set - use the first value in the list.
+		splits := strings.Split(prefix, ",")
+		prefix = splits[0]
+	}
+	log.WithField("prefix", prefix).Debugf("Using prefix to create a WorkloadEndpoint veth name")
+	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
+}
+
+func (wc defaultWorkloadEndpointConverter) PodToWorkloadEndpoints(pod *kapiv1.Pod) ([]*model.KVPair, error) {
+	wep, err := wc.podToDefaultWorkloadEndpoint(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*model.KVPair{wep}, nil
+}
+
+// PodToWorkloadEndpoint converts a Pod to a WorkloadEndpoint.  It assumes the calling code
+// has verified that the provided Pod is valid to convert to a WorkloadEndpoint.
+// PodToWorkloadEndpoint requires a Pods Name and Node Name to be populated. It will
+// fail to convert from a Pod to WorkloadEndpoint otherwise.
+func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kapiv1.Pod) (*model.KVPair, error) {
+	log.WithField("pod", pod).Debug("Converting pod to WorkloadEndpoint")
+	// Get all the profiles that apply
+	var profiles []string
+
+	// Pull out the Namespace based profile off the pod name and Namespace.
+	profiles = append(profiles, NamespaceProfileNamePrefix+pod.Namespace)
+
+	// Pull out the Serviceaccount based profile off the pod SA and namespace
+	if pod.Spec.ServiceAccountName != "" {
+		profiles = append(profiles, serviceAccountNameToProfileName(pod.Spec.ServiceAccountName, pod.Namespace))
+	}
+
+	wepids := names.WorkloadEndpointIdentifiers{
+		Node:         pod.Spec.NodeName,
+		Orchestrator: apiv3.OrchestratorKubernetes,
+		Endpoint:     "eth0",
+		Pod:          pod.Name,
+	}
+	wepName, err := wepids.CalculateWorkloadEndpointName(false)
+	if err != nil {
+		return nil, err
+	}
+
+	podIPNets, err := getPodIPs(pod)
+	if err != nil {
+		// IP address was present but malformed in some way, handle as an explicit failure.
+		return nil, err
+	}
+
+	if IsFinished(pod) {
+		// Pod is finished but not yet deleted.  In this state the IP will have been freed and returned to the pool
+		// so we need to make sure we don't let the caller believe it still belongs to this endpoint.
+		// Pods with no IPs will get filtered out before they get to Felix in the watcher syncer cache layer.
+		// We can't pretend the workload endpoint is deleted _here_ because that would confuse users of the
+		// native v3 Watch() API.
+		podIPNets = nil
+	}
+
+	ipNets := []string{}
+	for _, ipNet := range podIPNets {
+		ipNets = append(ipNets, ipNet.String())
+	}
+
+	// Generate the interface name based on workload.  This must match
+	// the host-side veth configured by the CNI plugin.
+	interfaceName := wc.VethNameForWorkload(pod.Namespace, pod.Name)
+
+	// Build the labels map.  Start with the pod labels, and append two additional labels for
+	// namespace and orchestrator matches.
+	labels := pod.Labels
+	if labels == nil {
+		labels = make(map[string]string, 2)
+	}
+	labels[apiv3.LabelNamespace] = pod.Namespace
+	labels[apiv3.LabelOrchestrator] = apiv3.OrchestratorKubernetes
+
+	if pod.Spec.ServiceAccountName != "" {
+		labels[apiv3.LabelServiceAccount] = pod.Spec.ServiceAccountName
+	}
+
+	// Pull out floating IP annotation
+	var floatingIPs []apiv3.IPNAT
+	if annotation, ok := pod.Annotations["cni.projectcalico.org/floatingIPs"]; ok && len(podIPNets) > 0 {
+
+		// Parse Annotation data
+		var ips []string
+		err := json.Unmarshal([]byte(annotation), &ips)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", annotation, err)
+		}
+
+		// Get IPv4 and IPv6 targets for NAT
+		var podnetV4, podnetV6 *cnet.IPNet
+		for _, ipNet := range podIPNets {
+			if ipNet.IP.To4() != nil {
+				podnetV4 = ipNet
+				netmask, _ := podnetV4.Mask.Size()
+				if netmask != 32 {
+					return nil, fmt.Errorf("PodIP %v is not a valid IPv4: Mask size is %d, not 32", ipNet, netmask)
+				}
+			} else {
+				podnetV6 = ipNet
+				netmask, _ := podnetV6.Mask.Size()
+				if netmask != 128 {
+					return nil, fmt.Errorf("PodIP %v is not a valid IPv6: Mask size is %d, not 128", ipNet, netmask)
+				}
+			}
+		}
+
+		for _, ip := range ips {
+			if strings.Contains(ip, ":") {
+				if podnetV6 != nil {
+					floatingIPs = append(floatingIPs, apiv3.IPNAT{
+						InternalIP: podnetV6.IP.String(),
+						ExternalIP: ip,
+					})
+				}
+			} else {
+				if podnetV4 != nil {
+					floatingIPs = append(floatingIPs, apiv3.IPNAT{
+						InternalIP: podnetV4.IP.String(),
+						ExternalIP: ip,
+					})
+				}
+			}
+		}
+	}
+
+	// Map any named ports through.
+	var endpointPorts []apiv3.EndpointPort
+	for _, container := range pod.Spec.Containers {
+		for _, containerPort := range container.Ports {
+			if containerPort.Name != "" && containerPort.ContainerPort != 0 {
+				var modelProto numorstring.Protocol
+				switch containerPort.Protocol {
+				case kapiv1.ProtocolUDP:
+					modelProto = numorstring.ProtocolFromString("udp")
+				case kapiv1.ProtocolTCP, kapiv1.Protocol("") /* K8s default is TCP. */ :
+					modelProto = numorstring.ProtocolFromString("tcp")
+				default:
+					log.WithFields(log.Fields{
+						"protocol": containerPort.Protocol,
+						"pod":      pod,
+						"port":     containerPort,
+					}).Debug("Ignoring named port with unknown protocol")
+					continue
+				}
+
+				endpointPorts = append(endpointPorts, apiv3.EndpointPort{
+					Name:     containerPort.Name,
+					Protocol: modelProto,
+					Port:     uint16(containerPort.ContainerPort),
+				})
+			}
+		}
+	}
+
+	// Create the workload endpoint.
+	wep := apiv3.NewWorkloadEndpoint()
+	wep.ObjectMeta = metav1.ObjectMeta{
+		Name:              wepName,
+		Namespace:         pod.Namespace,
+		CreationTimestamp: pod.CreationTimestamp,
+		UID:               pod.UID,
+		Labels:            labels,
+		GenerateName:      pod.GenerateName,
+	}
+	wep.Spec = apiv3.WorkloadEndpointSpec{
+		Orchestrator:  "k8s",
+		Node:          pod.Spec.NodeName,
+		Pod:           pod.Name,
+		Endpoint:      "eth0",
+		InterfaceName: interfaceName,
+		Profiles:      profiles,
+		IPNetworks:    ipNets,
+		Ports:         endpointPorts,
+		IPNATs:        floatingIPs,
+	}
+
+	// Embed the workload endpoint into a KVPair.
+	kvp := model.KVPair{
+		Key: model.ResourceKey{
+			Name:      wepName,
+			Namespace: pod.Namespace,
+			Kind:      apiv3.KindWorkloadEndpoint,
+		},
+		Value:    wep,
+		Revision: pod.ResourceVersion,
+	}
+	return &kvp, nil
+}

--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -61,6 +61,7 @@ func NewNetworkPolicyClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sReso
 		namespaced:   true,
 	}
 	return &networkPolicyClient{
+		Converter: conversion.NewConverter(),
 		clientSet: c,
 		crdClient: crdClient,
 	}
@@ -365,6 +366,7 @@ func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterfac
 func newNetworkPolicyWatcher(ctx context.Context, k8sRev, crdRev string, k8sWatch, calicoWatch api.WatchInterface) api.WatchInterface {
 	ctx, cancel := context.WithCancel(ctx)
 	wc := &networkPolicyWatcher{
+		Converter:  conversion.NewConverter(),
 		k8sNPRev:   k8sRev,
 		crdNPRev:   crdRev,
 		k8sNPWatch: k8sWatch,

--- a/lib/backend/k8s/resources/profile.go
+++ b/lib/backend/k8s/resources/profile.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import (
 func NewProfileClient(c *kubernetes.Clientset) K8sResourceClient {
 	return &profileClient{
 		clientSet: c,
-		Converter: conversion.Converter{},
+		Converter: conversion.NewConverter(),
 	}
 }
 
@@ -314,7 +314,7 @@ func newProfileWatcher(ctx context.Context, k8sWatchNS, k8sWatchSA api.WatchInte
 		context:    ctx,
 		cancel:     cancel,
 		resultChan: make(chan api.WatchEvent, resultsBufSize),
-		Converter:  conversion.Converter{},
+		Converter:  conversion.NewConverter(),
 	}
 	go wc.processProfileEvents()
 	return wc

--- a/lib/backend/k8s/resources/resources.go
+++ b/lib/backend/k8s/resources/resources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,21 @@ type ResourceList interface {
 // Function signature for conversion function to convert a K8s resouce to a
 // KVPair equivalent.
 type ConvertK8sResourceToKVPair func(Resource) (*model.KVPair, error)
+type ConvertK8sResourceToKVPairs func(Resource) ([]*model.KVPair, error)
+
+// ConvertK8sResourceOneToOneAdapter converts a ConvertK8sResourceToKVPair function to a ConvertK8sResourceToKVPairs function
+func ConvertK8sResourceOneToOneAdapter(oneToOne ConvertK8sResourceToKVPair) ConvertK8sResourceToKVPairs {
+	return func(r Resource) ([]*model.KVPair, error) {
+		kvp, err := oneToOne(r)
+		if err != nil {
+			return nil, err
+		} else if kvp != nil {
+			return []*model.KVPair{kvp}, nil
+		}
+
+		return nil, nil
+	}
+}
 
 // Store Calico Metadata in the k8s resource annotations for non-CRD backed resources.
 // Currently this just stores Annotations and Labels and drops all other metadata

--- a/lib/backend/k8s/resources/resources_test.go
+++ b/lib/backend/k8s/resources/resources_test.go
@@ -1,0 +1,53 @@
+package resources_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+var _ = Describe("ConvertK8sResourceOneToOneAdapter", func() {
+	DescribeTable("adapter conversion cases", func(ret1 *model.KVPair, ret2 error, expected1 []*model.KVPair, expected2 error) {
+		fun := resources.ConvertK8sResourceOneToOneAdapter(func(r resources.Resource) (*model.KVPair, error) {
+			return ret1, ret2
+		})
+
+		resources, err := fun(&v1.Pod{})
+
+		matcher1 := BeNil()
+		if expected1 != nil {
+			matcher1 = Equal(expected1)
+		}
+
+		matcher2 := BeNil()
+		if expected2 != nil {
+			matcher2 = Equal(expected2)
+		}
+
+		Expect(resources).Should(matcher1)
+		Expect(err).Should(matcher2)
+	}, TableEntry{
+		Description: "resource not nil error nil returns resource list of one with no error",
+		Parameters:  []interface{}{&model.KVPair{}, nil, []*model.KVPair{{}}, nil},
+	},
+		TableEntry{
+			Description: "resource nil error nil returns empty resource list with no error",
+			Parameters:  []interface{}{nil, nil, []*model.KVPair(nil), nil},
+		},
+		TableEntry{
+			Description: "resource nil error not nil returns resource empty list with error",
+			Parameters:  []interface{}{nil, errors.New(""), []*model.KVPair(nil), errors.New("")},
+		},
+		TableEntry{
+			Description: "resource not nil error not nil returns empty resource list with error",
+			Parameters:  []interface{}{&model.KVPair{}, errors.New(""), []*model.KVPair(nil), errors.New("")},
+		},
+	)
+})

--- a/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -1,0 +1,635 @@
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/names"
+
+	k8sapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("WorkloadEndpointClient", func() {
+	Describe("Create", func() {
+		Context("WorkloadEndpoint has no IPs set", func() {
+			It("does not set the cni.projectcalico.org/podIP and cni.projectcalico.org/podIPs annotations", func() {
+				k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simplePod",
+						Namespace: "testNamespace",
+					},
+					Spec: k8sapi.PodSpec{
+						NodeName: "test-node",
+					},
+				})
+
+				wepClient := resources.NewWorkloadEndpointClient(k8sClient)
+
+				wepIDs := names.WorkloadEndpointIdentifiers{
+					Orchestrator: "k8s",
+					Node:         "test-node",
+					Pod:          "simplePod",
+					Endpoint:     "eth0",
+				}
+
+				wepName, err := wepIDs.CalculateWorkloadEndpointName(false)
+				Expect(err).ShouldNot(HaveOccurred())
+				wep := &apiv3.WorkloadEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wepName,
+						Namespace: "testNamespace",
+					},
+					Spec: apiv3.WorkloadEndpointSpec{
+						IPNetworks: []string{},
+					},
+				}
+
+				kvp := &model.KVPair{
+					Key: model.ResourceKey{
+						Name:      wep.Name,
+						Namespace: wep.Namespace,
+						Kind:      apiv3.KindWorkloadEndpoint,
+					},
+					Value: wep,
+				}
+
+				_, err = wepClient.Create(context.Background(), kvp)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get("simplePod", metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pod.GetAnnotations()).Should(BeNil())
+			})
+		})
+		Context("WorkloadEndpoint has IPs set", func() {
+			It("sets the cni.projectcalico.org/podIP and cni.projectcalico.org/podIPs annotations to the WorkloadEndpoint IPs", func() {
+				k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simplePod",
+						Namespace: "testNamespace",
+					},
+					Spec: k8sapi.PodSpec{
+						NodeName: "test-node",
+					},
+				})
+
+				wepClient := resources.NewWorkloadEndpointClient(k8sClient)
+				wepIDs := names.WorkloadEndpointIdentifiers{
+					Orchestrator: "k8s",
+					Node:         "test-node",
+					Pod:          "simplePod",
+					Endpoint:     "eth0",
+				}
+
+				wepName, err := wepIDs.CalculateWorkloadEndpointName(false)
+				Expect(err).ShouldNot(HaveOccurred())
+				wep := &apiv3.WorkloadEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wepName,
+						Namespace: "testNamespace",
+					},
+					Spec: apiv3.WorkloadEndpointSpec{
+						IPNetworks: []string{"192.168.91.117/32", "192.168.91.118/32"},
+					},
+				}
+
+				kvp := &model.KVPair{
+					Key: model.ResourceKey{
+						Name:      wep.Name,
+						Namespace: wep.Namespace,
+						Kind:      apiv3.KindWorkloadEndpoint,
+					},
+					Value: wep,
+				}
+
+				_, err = wepClient.Create(context.Background(), kvp)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get("simplePod", metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
+					conversion.AnnotationPodIP:  "192.168.91.117/32",
+					conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+				}))
+			})
+		})
+	})
+	Describe("Update", func() {
+		Context("WorkloadEndpoint has no IPs set", func() {
+			It("does not set the cni.projectcalico.org/podIP and cni.projectcalico.org/podIPs annotations", func() {
+				k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simplePod",
+						Namespace: "testNamespace",
+					},
+					Spec: k8sapi.PodSpec{
+						NodeName: "test-node",
+					},
+				})
+
+				wepClient := resources.NewWorkloadEndpointClient(k8sClient)
+				wepIDs := names.WorkloadEndpointIdentifiers{
+					Orchestrator: "k8s",
+					Node:         "test-node",
+					Pod:          "simplePod",
+					Endpoint:     "eth0",
+				}
+
+				wepName, err := wepIDs.CalculateWorkloadEndpointName(false)
+				Expect(err).ShouldNot(HaveOccurred())
+				wep := &apiv3.WorkloadEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wepName,
+						Namespace: "testNamespace",
+					},
+					Spec: apiv3.WorkloadEndpointSpec{
+						IPNetworks: []string{},
+					},
+				}
+
+				kvp := &model.KVPair{
+					Key: model.ResourceKey{
+						Name:      wep.Name,
+						Namespace: wep.Namespace,
+						Kind:      apiv3.KindWorkloadEndpoint,
+					},
+					Value: wep,
+				}
+
+				_, err = wepClient.Update(context.Background(), kvp)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get("simplePod", metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pod.GetAnnotations()).Should(BeNil())
+			})
+		})
+		Context("WorkloadEndpoint has IPs set", func() {
+			It("sets the cni.projectcalico.org/podIP and cni.projectcalico.org/podIPs annotations to the WorkloadEndpoint IPs", func() {
+				k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simplePod",
+						Namespace: "testNamespace",
+					},
+					Spec: k8sapi.PodSpec{
+						NodeName: "test-node",
+					},
+				})
+
+				wepClient := resources.NewWorkloadEndpointClient(k8sClient)
+				wepIDs := names.WorkloadEndpointIdentifiers{
+					Orchestrator: "k8s",
+					Node:         "test-node",
+					Pod:          "simplePod",
+					Endpoint:     "eth0",
+				}
+
+				wepName, err := wepIDs.CalculateWorkloadEndpointName(false)
+				Expect(err).ShouldNot(HaveOccurred())
+				wep := &apiv3.WorkloadEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wepName,
+						Namespace: "testNamespace",
+					},
+					Spec: apiv3.WorkloadEndpointSpec{
+						IPNetworks: []string{"192.168.91.117/32", "192.168.91.118/32"},
+					},
+				}
+
+				kvp := &model.KVPair{
+					Key: model.ResourceKey{
+						Name:      wep.Name,
+						Namespace: wep.Namespace,
+						Kind:      apiv3.KindWorkloadEndpoint,
+					},
+					Value: wep,
+				}
+
+				_, err = wepClient.Update(context.Background(), kvp)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get("simplePod", metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
+					conversion.AnnotationPodIP:  "192.168.91.117/32",
+					conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+				}))
+			})
+		})
+	})
+	Describe("Get", func() {
+		It("gets the WorkloadEndpoint using the given name", func() {
+			k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simplePod",
+					Namespace: "testNamespace",
+				},
+				Spec: k8sapi.PodSpec{
+					NodeName: "test-node",
+				},
+			})
+
+			wepClient := resources.NewWorkloadEndpointClient(k8sClient).(*resources.WorkloadEndpointClient)
+			wepIDs := names.WorkloadEndpointIdentifiers{
+				Orchestrator: "k8s",
+				Node:         "test-node",
+				Pod:          "simplePod",
+				Endpoint:     "eth0",
+			}
+
+			wepName, err := wepIDs.CalculateWorkloadEndpointName(false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			wep, err := wepClient.Get(context.Background(), model.ResourceKey{
+				Name:      wepName,
+				Namespace: "testNamespace",
+				Kind:      apiv3.KindWorkloadEndpoint,
+			}, "")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(wep.Value).Should(Equal(&apiv3.WorkloadEndpoint{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv3.KindWorkloadEndpoint,
+					APIVersion: apiv3.GroupVersionCurrent,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      wepName,
+					Namespace: "testNamespace",
+					Labels: map[string]string{
+						apiv3.LabelNamespace:    "testNamespace",
+						apiv3.LabelOrchestrator: "k8s",
+					},
+				},
+				Spec: apiv3.WorkloadEndpointSpec{
+					Orchestrator:  "k8s",
+					Node:          "test-node",
+					Pod:           "simplePod",
+					Endpoint:      "eth0",
+					Profiles:      []string{"kns.testNamespace"},
+					IPNetworks:    []string{},
+					InterfaceName: "caliedff4356bd6",
+				},
+			}))
+		})
+	})
+	Describe("List", func() {
+		Context("name is specified", func() {
+			Context("the name contains an end suffix", func() {
+				It("returns a list of WorkloadEndpoints with the single WorkloadEndpoint with the given name", func() {
+					testListWorkloadEndpoints(
+						[]runtime.Object{&k8sapi.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "simplePod",
+								Namespace: "testNamespace",
+							},
+							Spec: k8sapi.PodSpec{
+								NodeName: "test-node",
+							},
+							Status: k8sapi.PodStatus{
+								PodIP: "192.168.91.113",
+							},
+						}},
+						model.ResourceListOptions{
+							Name:      "test--node-k8s-simplePod-eth0",
+							Namespace: "testNamespace",
+							Kind:      apiv3.KindWorkloadEndpoint,
+						},
+						[]*apiv3.WorkloadEndpoint{{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       apiv3.KindWorkloadEndpoint,
+								APIVersion: apiv3.GroupVersionCurrent,
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test--node-k8s-simplePod-eth0",
+								Namespace: "testNamespace",
+								Labels: map[string]string{
+									apiv3.LabelNamespace:    "testNamespace",
+									apiv3.LabelOrchestrator: "k8s",
+								},
+							},
+							Spec: apiv3.WorkloadEndpointSpec{
+								Orchestrator:  "k8s",
+								Node:          "test-node",
+								Pod:           "simplePod",
+								Endpoint:      "eth0",
+								Profiles:      []string{"kns.testNamespace"},
+								IPNetworks:    []string{"192.168.91.113/32"},
+								InterfaceName: "caliedff4356bd6",
+							},
+						}},
+					)
+				})
+				It("returns an empty list if the endpoint is specified and does not match the pods wep endpoint", func() {
+					testListWorkloadEndpoints(
+						[]runtime.Object{&k8sapi.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "simplePod",
+								Namespace: "testNamespace",
+							},
+							Spec: k8sapi.PodSpec{
+								NodeName: "test-node",
+							},
+							Status: k8sapi.PodStatus{
+								PodIP: "192.168.91.113",
+							},
+						}},
+						model.ResourceListOptions{
+							Name:      "test--node-k8s-simplePod-ens4",
+							Namespace: "testNamespace",
+							Kind:      apiv3.KindWorkloadEndpoint,
+						},
+						[]*apiv3.WorkloadEndpoint(nil),
+					)
+				})
+			})
+			Context("the name does not contain endpoint suffix, but contains the Pod name midfix", func() {
+				It("returns a list of WorkloadEndpoints with the single WorkloadEndpoint for the matching pod", func() {
+					testListWorkloadEndpoints(
+						[]runtime.Object{&k8sapi.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "simplePod",
+								Namespace: "testNamespace",
+							},
+							Spec: k8sapi.PodSpec{
+								NodeName: "test-node",
+							},
+							Status: k8sapi.PodStatus{
+								PodIP: "192.168.91.113",
+							},
+						}},
+						model.ResourceListOptions{
+							Name:      "test--node-k8s-simplePod",
+							Namespace: "testNamespace",
+							Kind:      apiv3.KindWorkloadEndpoint,
+						},
+						[]*apiv3.WorkloadEndpoint{{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       apiv3.KindWorkloadEndpoint,
+								APIVersion: apiv3.GroupVersionCurrent,
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test--node-k8s-simplePod-eth0",
+								Namespace: "testNamespace",
+								Labels: map[string]string{
+									apiv3.LabelNamespace:    "testNamespace",
+									apiv3.LabelOrchestrator: "k8s",
+								},
+							},
+							Spec: apiv3.WorkloadEndpointSpec{
+								Orchestrator:  "k8s",
+								Node:          "test-node",
+								Pod:           "simplePod",
+								Endpoint:      "eth0",
+								Profiles:      []string{"kns.testNamespace"},
+								IPNetworks:    []string{"192.168.91.113/32"},
+								InterfaceName: "caliedff4356bd6",
+							},
+						}},
+					)
+				})
+			})
+			Context("name contains neither the endpoint suffix or the pod name midfix", func() {
+				It("returns an error", func() {
+					k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "simplePod",
+							Namespace: "testNamespace",
+						},
+						Spec: k8sapi.PodSpec{
+							NodeName: "test-node",
+						},
+						Status: k8sapi.PodStatus{
+							PodIP: "192.168.91.113",
+						},
+					})
+					wepClient := resources.NewWorkloadEndpointClient(k8sClient).(*resources.WorkloadEndpointClient)
+
+					_, err := wepClient.List(context.Background(), model.ResourceListOptions{
+						Name:      "test--node-k8s",
+						Namespace: "testNamespace",
+						Kind:      apiv3.KindWorkloadEndpoint,
+					}, "")
+
+					Expect(err).Should(Equal(cerrors.ErrorResourceDoesNotExist{
+						Identifier: model.ResourceListOptions{
+							Name:      "test--node-k8s",
+							Namespace: "testNamespace",
+							Kind:      apiv3.KindWorkloadEndpoint,
+						},
+						Err: errors.New("malformed WorkloadEndpoint name - unable to determine Pod name"),
+					}))
+				})
+			})
+		})
+		Context("name is not specified", func() {
+			It("returns WorkloadEndpoints for each pod in the namespace", func() {
+				testListWorkloadEndpoints(
+					[]runtime.Object{
+						&k8sapi.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "simplePod",
+								Namespace: "testNamespace",
+							},
+							Spec: k8sapi.PodSpec{
+								NodeName: "test-node",
+							},
+							Status: k8sapi.PodStatus{
+								PodIP: "192.168.91.113",
+							},
+						},
+						&k8sapi.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "simplePod2",
+								Namespace: "testNamespace",
+							},
+							Spec: k8sapi.PodSpec{
+								NodeName: "test-node",
+							},
+							Status: k8sapi.PodStatus{
+								PodIP: "192.168.91.120",
+							},
+						},
+					},
+					model.ResourceListOptions{
+						Namespace: "testNamespace",
+						Kind:      apiv3.KindWorkloadEndpoint,
+					},
+					[]*apiv3.WorkloadEndpoint{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       apiv3.KindWorkloadEndpoint,
+								APIVersion: apiv3.GroupVersionCurrent,
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test--node-k8s-simplePod-eth0",
+								Namespace: "testNamespace",
+								Labels: map[string]string{
+									apiv3.LabelNamespace:    "testNamespace",
+									apiv3.LabelOrchestrator: "k8s",
+								},
+							},
+							Spec: apiv3.WorkloadEndpointSpec{
+								Orchestrator:  "k8s",
+								Node:          "test-node",
+								Pod:           "simplePod",
+								Endpoint:      "eth0",
+								Profiles:      []string{"kns.testNamespace"},
+								IPNetworks:    []string{"192.168.91.113/32"},
+								InterfaceName: "caliedff4356bd6",
+							},
+						},
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       apiv3.KindWorkloadEndpoint,
+								APIVersion: apiv3.GroupVersionCurrent,
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test--node-k8s-simplePod2-eth0",
+								Namespace: "testNamespace",
+								Labels: map[string]string{
+									apiv3.LabelNamespace:    "testNamespace",
+									apiv3.LabelOrchestrator: "k8s",
+								},
+							},
+							Spec: apiv3.WorkloadEndpointSpec{
+								Orchestrator:  "k8s",
+								Node:          "test-node",
+								Pod:           "simplePod2",
+								Endpoint:      "eth0",
+								Profiles:      []string{"kns.testNamespace"},
+								IPNetworks:    []string{"192.168.91.120/32"},
+								InterfaceName: "cali4274eb44391",
+							},
+						},
+					},
+				)
+			})
+		})
+	})
+	Describe("Watch", func() {
+		Context("Pod added", func() {
+			It("returns a single event containing the Pod's WorkloadEndpoint", func() {
+				testWatchWorkloadEndpoints(&k8sapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simplePod",
+						Namespace: "testNamespace",
+					},
+					Spec: k8sapi.PodSpec{
+						NodeName: "test-node",
+					},
+					Status: k8sapi.PodStatus{
+						PodIP: "192.168.91.113",
+					},
+				}, []*apiv3.WorkloadEndpoint{{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       apiv3.KindWorkloadEndpoint,
+						APIVersion: apiv3.GroupVersionCurrent,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test--node-k8s-simplePod-eth0",
+						Namespace: "testNamespace",
+						Labels: map[string]string{
+							apiv3.LabelNamespace:    "testNamespace",
+							apiv3.LabelOrchestrator: "k8s",
+						},
+					},
+					Spec: apiv3.WorkloadEndpointSpec{
+						Orchestrator:  "k8s",
+						Node:          "test-node",
+						Pod:           "simplePod",
+						Endpoint:      "eth0",
+						Profiles:      []string{"kns.testNamespace"},
+						IPNetworks:    []string{"192.168.91.113/32"},
+						InterfaceName: "caliedff4356bd6",
+					},
+				}})
+			})
+		})
+	})
+})
+
+func testListWorkloadEndpoints(pods []runtime.Object, listOptions model.ResourceListOptions, expectedWEPs []*apiv3.WorkloadEndpoint) {
+	k8sClient := fake.NewSimpleClientset(pods...)
+	wepClient := resources.NewWorkloadEndpointClient(k8sClient).(*resources.WorkloadEndpointClient)
+
+	kvps, err := wepClient.List(context.Background(), listOptions, "")
+	Expect(err).ShouldNot(HaveOccurred())
+
+	var weps []*apiv3.WorkloadEndpoint
+	for _, kvp := range kvps.KVPairs {
+		weps = append(weps, kvp.Value.(*apiv3.WorkloadEndpoint))
+	}
+
+	Expect(weps).Should(Equal(expectedWEPs))
+}
+
+func testWatchWorkloadEndpoints(pod *k8sapi.Pod, expectedWEPs []*apiv3.WorkloadEndpoint) {
+	k8sClient := fake.NewSimpleClientset()
+
+	wepClient := resources.NewWorkloadEndpointClient(k8sClient).(*resources.WorkloadEndpointClient)
+	wepWatcher, err := wepClient.Watch(context.Background(), model.ResourceListOptions{}, "")
+
+	Expect(err).ShouldNot(HaveOccurred())
+
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer GinkgoRecover()
+		i := 0
+
+		for {
+			select {
+			case event := <-wepWatcher.ResultChan():
+				Expect(event.Error).ShouldNot(HaveOccurred())
+				Expect(event.New.Value).Should(Equal(expectedWEPs[i]))
+
+				i++
+				if i == len(expectedWEPs) {
+					return
+				}
+			case <-timer.C:
+				Fail(fmt.Sprintf("expected exactly %d events before timer expired, received %d", len(expectedWEPs), i))
+			}
+		}
+	}()
+
+	_, err = k8sClient.CoreV1().Pods(pod.Namespace).Create(pod)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	wg.Wait()
+	wepWatcher.Stop()
+}

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -248,7 +248,7 @@ var _ = Describe("Test the NetworkPolicy update processor + conversion", func() 
 	DescribeTable("NetworkPolicy update processor + conversion tests",
 		func(np networkingv1.NetworkPolicy, expected []*model.KVPair) {
 			// First, convert the NetworkPolicy using the k8s conversion logic.
-			c := conversion.Converter{}
+			c := conversion.NewConverter()
 			kvp, err := c.K8sNetworkPolicyToCalico(&np)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/lib/clientv3/networkpolicy_e2e_test.go
+++ b/lib/clientv3/networkpolicy_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			} else {
 				// Resource version for KDD is a combination of both the CRD and K8s NP backed
 				// resources separated by a slash.
-				rv = conversion.Converter{}.JoinNetworkPolicyRevisions("1234", "5678")
+				rv = conversion.NewConverter().JoinNetworkPolicyRevisions("1234", "5678")
 			}
 			_, outError := c.NetworkPolicies().Update(ctx, &apiv3.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: rv, CreationTimestamp: metav1.Now(), UID: "test-fail-networkpolicy"},


### PR DESCRIPTION
This is to allow to allow for conversion from a pod to multiple workload endpoints and different implementations of that conversion.

This will help avoid conflicts when merging to the private repo where we have alternative workload endpoint conversion implementations.
