### PR TITLE
v3 API for IPAM import / export

### DIFF
--- a/lib/backend/k8s/resources/ipam_affinity.go
+++ b/lib/backend/k8s/resources/ipam_affinity.go
@@ -16,8 +16,6 @@ package resources
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"reflect"
 
@@ -32,9 +30,8 @@ import (
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
-	"github.com/projectcalico/libcalico-go/lib/names"
-	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 const (
@@ -62,6 +59,25 @@ func NewBlockAffinityClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sReso
 	return &blockAffinityClient{rc: rc}
 }
 
+// NewV3BlockAffinityClient returns a resource client that accepts BlockAffinity resources
+// in V3 format, as opposed to the NewBlockAffinityClient that accepts V1 resources.
+func NewV3BlockAffinityClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	return &customK8sResourceClient{
+		clientSet:       c,
+		restClient:      r,
+		name:            BlockAffinityCRDName,
+		resource:        BlockAffinityResourceName,
+		description:     "Calico IPAM block affinities",
+		k8sResourceType: reflect.TypeOf(apiv3.BlockAffinity{}),
+		k8sResourceTypeMeta: metav1.TypeMeta{
+			Kind:       apiv3.KindBlockAffinity,
+			APIVersion: apiv3.GroupVersionCurrent,
+		},
+		k8sListType:  reflect.TypeOf(apiv3.BlockAffinityList{}),
+		resourceKind: apiv3.KindBlockAffinity,
+	}
+}
+
 // blockAffinityClient implements the api.Client interface for BlockAffinity objects. It
 // handles the translation between v1 objects understood by the IPAM codebase in lib/ipam,
 // and the CRDs which are used to actually store the data in the Kubernetes API.
@@ -71,91 +87,15 @@ type blockAffinityClient struct {
 	rc customK8sResourceClient
 }
 
-// toV1 converts the given v3 CRD KVPair into a v1 model representation
-// which can be passed to the IPAM code.
-func (c blockAffinityClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
-	// Parse the CIDR into a struct.
-	_, cidr, err := net.ParseCIDR(kvpv3.Value.(*apiv3.BlockAffinity).Spec.CIDR)
-	if err != nil {
-		log.WithField("cidr", cidr).WithError(err).Error("failed to parse cidr")
-		return nil, err
-	}
-	state := model.BlockAffinityState(kvpv3.Value.(*apiv3.BlockAffinity).Spec.State)
-	return &model.KVPair{
-		Key: model.BlockAffinityKey{
-			CIDR: *cidr,
-			Host: kvpv3.Value.(*apiv3.BlockAffinity).Spec.Node,
-		},
-		Value: &model.BlockAffinity{
-			State: state,
-		},
-		Revision: kvpv3.Revision,
-		UID:      &kvpv3.Value.(*apiv3.BlockAffinity).UID,
-	}, nil
-}
-
-// parseKey parses the given model.Key, returning a suitable name, CIDR
-// and host for use in the Kubernetes API.
-func (c blockAffinityClient) parseKey(k model.Key) (name, cidr, host string) {
-	host = k.(model.BlockAffinityKey).Host
-	cidr = fmt.Sprintf("%s", k.(model.BlockAffinityKey).CIDR)
-	cidrname := names.CIDRToName(k.(model.BlockAffinityKey).CIDR)
-
-	// Include the hostname as well.
-	host = k.(model.BlockAffinityKey).Host
-	name = fmt.Sprintf("%s-%s", host, cidrname)
-
-	if len(name) >= 253 {
-		// If the name is too long, we need to shorten it.
-		// Remove enough characters to get it below the 253 character limit,
-		// as well as 11 characters to add a hash which helps with uniqueness,
-		// and two characters for the `-` separators between clauses.
-		name = fmt.Sprintf("%s-%s", host[:252-len(cidrname)-13], cidrname)
-
-		// Add a hash to help with uniqueness.
-		h := sha256.New()
-		h.Write([]byte(fmt.Sprintf("%s+%s", host, cidrname)))
-		name = fmt.Sprintf("%s-%s", name, hex.EncodeToString(h.Sum(nil))[:11])
-	}
-	return
-}
-
-// toV3 takes the given v1 KVPair and converts it into a v3 representation, suitable
-// for writing as a CRD to the Kubernetes API.
-func (c blockAffinityClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
-	name, cidr, host := c.parseKey(kvpv1.Key)
-	state := kvpv1.Value.(*model.BlockAffinity).State
-	return &model.KVPair{
-		Key: model.ResourceKey{
-			Name: name,
-			Kind: apiv3.KindBlockAffinity,
-		},
-		Value: &apiv3.BlockAffinity{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       apiv3.KindBlockAffinity,
-				APIVersion: "crd.projectcalico.org/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            name,
-				ResourceVersion: kvpv1.Revision,
-			},
-			Spec: apiv3.BlockAffinitySpec{
-				State: string(state),
-				Node:  host,
-				CIDR:  cidr,
-			},
-		},
-		Revision: kvpv1.Revision,
-	}
-}
+var blockAffinityConverter = converter.BlockAffinityConverter{}
 
 func (c *blockAffinityClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp := c.toV3(kvp)
+	nkvp := blockAffinityConverter.ToV3(kvp)
 	kvp, err := c.rc.Create(ctx, nkvp)
 	if err != nil {
 		return nil, err
 	}
-	v1kvp, err := c.toV1(kvp)
+	v1kvp, err := blockAffinityConverter.ToV1(kvp)
 	if err != nil {
 		return nil, err
 	}
@@ -163,12 +103,12 @@ func (c *blockAffinityClient) Create(ctx context.Context, kvp *model.KVPair) (*m
 }
 
 func (c *blockAffinityClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp := c.toV3(kvp)
+	nkvp := blockAffinityConverter.ToV3(kvp)
 	kvp, err := c.rc.Update(ctx, nkvp)
 	if err != nil {
 		return nil, err
 	}
-	v1kvp, err := c.toV1(kvp)
+	v1kvp, err := blockAffinityConverter.ToV1(kvp)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +118,7 @@ func (c *blockAffinityClient) Update(ctx context.Context, kvp *model.KVPair) (*m
 func (c *blockAffinityClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	// We need to mark as deleted first, since the Kubernetes API doesn't support
 	// compare-and-delete. This update operation allows us to eliminate races with other clients.
-	name, _, _ := c.parseKey(kvp.Key)
+	name, _, _ := blockAffinityConverter.ParseKey(kvp.Key)
 	kvp.Value.(*model.BlockAffinity).Deleted = true
 	v1kvp, err := c.Update(ctx, kvp)
 	if err != nil {
@@ -191,7 +131,7 @@ func (c *blockAffinityClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) 
 	if err != nil {
 		return nil, err
 	}
-	return c.toV1(kvp)
+	return blockAffinityConverter.ToV1(kvp)
 }
 
 func (c *blockAffinityClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
@@ -205,7 +145,7 @@ func (c *blockAffinityClient) Delete(ctx context.Context, key model.Key, revisio
 
 func (c *blockAffinityClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
 	// Get the object.
-	name, _, _ := c.parseKey(key)
+	name, _, _ := blockAffinityConverter.ParseKey(key)
 	k := model.ResourceKey{Name: name, Kind: apiv3.KindBlockAffinity}
 	kvp, err := c.rc.Get(ctx, k, revision)
 	if err != nil {
@@ -213,7 +153,7 @@ func (c *blockAffinityClient) Get(ctx context.Context, key model.Key, revision s
 	}
 
 	// Convert it to v1.
-	v1kvp, err := c.toV1(kvp)
+	v1kvp, err := blockAffinityConverter.ToV1(kvp)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +182,7 @@ func (c *blockAffinityClient) List(ctx context.Context, list model.ListInterface
 
 	kvpl := &model.KVPairList{KVPairs: []*model.KVPair{}}
 	for _, i := range v3list.KVPairs {
-		v1kvp, err := c.toV1(i)
+		v1kvp, err := blockAffinityConverter.ToV1(i)
 		if err != nil {
 			return nil, err
 		}
@@ -270,7 +210,7 @@ func (c *blockAffinityClient) Watch(ctx context.Context, list model.ListInterfac
 		if err != nil {
 			return nil, err
 		}
-		return c.toV1(conv)
+		return blockAffinityConverter.ToV1(conv)
 	}
 
 	return newK8sWatcherConverter(ctx, resl.Kind+" (custom)", toKVPair, k8sWatch), nil

--- a/lib/backend/k8s/resources/ipam_block.go
+++ b/lib/backend/k8s/resources/ipam_block.go
@@ -30,9 +30,8 @@ import (
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
-	"github.com/projectcalico/libcalico-go/lib/names"
-	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 const (
@@ -60,6 +59,26 @@ func NewIPAMBlockClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResource
 	return &ipamBlockClient{rc: rc}
 }
 
+// NewV3IPAMBlockClient returns a resource client that accepts IPAMBlock resources
+// in V3 format, as opposed to the NewIPAMBlockClient that accepts V1 resources.
+func NewV3IPAMBlockClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	// Create a resource client which manages k8s CRDs.
+	return &customK8sResourceClient{
+		clientSet:       c,
+		restClient:      r,
+		name:            IPAMBlockCRDName,
+		resource:        IPAMBlockResourceName,
+		description:     "Calico IPAM blocks",
+		k8sResourceType: reflect.TypeOf(apiv3.IPAMBlock{}),
+		k8sResourceTypeMeta: metav1.TypeMeta{
+			Kind:       apiv3.KindIPAMBlock,
+			APIVersion: apiv3.GroupVersionCurrent,
+		},
+		k8sListType:  reflect.TypeOf(apiv3.IPAMBlockList{}),
+		resourceKind: apiv3.KindIPAMBlock,
+	}
+}
+
 // ipamBlockClient implements the api.Client interface for IPAMBlocks. It handles the translation between
 // v1 objects understood by the IPAM codebase in lib/ipam, and the CRDs which are used
 // to actually store the data in the Kubernetes API. It uses a customK8sResourceClient under
@@ -68,97 +87,15 @@ type ipamBlockClient struct {
 	rc customK8sResourceClient
 }
 
-func (c ipamBlockClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
-	cidrStr := kvpv3.Value.(*apiv3.IPAMBlock).Spec.CIDR
-	_, cidr, err := net.ParseCIDR(cidrStr)
-	if err != nil {
-		return nil, err
-	}
-
-	ab := kvpv3.Value.(*apiv3.IPAMBlock)
-
-	// Convert attributes.
-	attrs := []model.AllocationAttribute{}
-	for _, a := range ab.Spec.Attributes {
-		attrs = append(attrs, model.AllocationAttribute{
-			AttrPrimary:   a.AttrPrimary,
-			AttrSecondary: a.AttrSecondary,
-		})
-	}
-
-	return &model.KVPair{
-		Key: model.BlockKey{
-			CIDR: *cidr,
-		},
-		Value: &model.AllocationBlock{
-			CIDR:           *cidr,
-			Affinity:       ab.Spec.Affinity,
-			StrictAffinity: ab.Spec.StrictAffinity,
-			Allocations:    ab.Spec.Allocations,
-			Unallocated:    ab.Spec.Unallocated,
-			Attributes:     attrs,
-			Deleted:        ab.Spec.Deleted,
-		},
-		Revision: kvpv3.Revision,
-		UID:      &ab.UID,
-	}, nil
-}
-
-func (c ipamBlockClient) parseKey(k model.Key) (name, cidr string) {
-	cidr = fmt.Sprintf("%s", k.(model.BlockKey).CIDR)
-	name = names.CIDRToName(k.(model.BlockKey).CIDR)
-	return
-}
-
-func (c ipamBlockClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
-	name, cidr := c.parseKey(kvpv1.Key)
-
-	ab := kvpv1.Value.(*model.AllocationBlock)
-
-	// Convert attributes.
-	attrs := []apiv3.AllocationAttribute{}
-	for _, a := range ab.Attributes {
-		attrs = append(attrs, apiv3.AllocationAttribute{
-			AttrPrimary:   a.AttrPrimary,
-			AttrSecondary: a.AttrSecondary,
-		})
-	}
-
-	return &model.KVPair{
-		Key: model.ResourceKey{
-			Name: name,
-			Kind: apiv3.KindIPAMBlock,
-		},
-		Value: &apiv3.IPAMBlock{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       apiv3.KindIPAMBlock,
-				APIVersion: "crd.projectcalico.org/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            name,
-				ResourceVersion: kvpv1.Revision,
-			},
-			Spec: apiv3.IPAMBlockSpec{
-				CIDR:           cidr,
-				Allocations:    ab.Allocations,
-				Unallocated:    ab.Unallocated,
-				Affinity:       ab.Affinity,
-				StrictAffinity: ab.StrictAffinity,
-				Attributes:     attrs,
-				Deleted:        ab.Deleted,
-			},
-		},
-		Revision: kvpv1.Revision,
-	}
-}
+var blockConverter = converter.IPAMBlockConverter{}
 
 func (c *ipamBlockClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp := c.toV3(kvp)
+	nkvp := blockConverter.ToV3(kvp)
 	b, err := c.rc.Create(ctx, nkvp)
 	if err != nil {
 		return nil, err
 	}
-	v1kvp, err := c.toV1(b)
+	v1kvp, err := blockConverter.ToV1(b)
 	if err != nil {
 		return nil, err
 	}
@@ -166,12 +103,12 @@ func (c *ipamBlockClient) Create(ctx context.Context, kvp *model.KVPair) (*model
 }
 
 func (c *ipamBlockClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp := c.toV3(kvp)
+	nkvp := blockConverter.ToV3(kvp)
 	b, err := c.rc.Update(ctx, nkvp)
 	if err != nil {
 		return nil, err
 	}
-	v1kvp, err := c.toV1(b)
+	v1kvp, err := blockConverter.ToV1(b)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +118,7 @@ func (c *ipamBlockClient) Update(ctx context.Context, kvp *model.KVPair) (*model
 func (c *ipamBlockClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	// We need to mark as deleted first, since the Kubernetes API doesn't support
 	// compare-and-delete. This update operation allows us to eliminate races with other clients.
-	name, _ := c.parseKey(kvp.Key)
+	name, _ := blockConverter.ParseKey(kvp.Key)
 	kvp.Value.(*model.AllocationBlock).Deleted = true
 	v1kvp, err := c.Update(ctx, kvp)
 	if err != nil {
@@ -194,7 +131,7 @@ func (c *ipamBlockClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*mo
 	if err != nil {
 		return nil, err
 	}
-	return c.toV1(kvp)
+	return blockConverter.ToV1(kvp)
 }
 
 func (c *ipamBlockClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
@@ -208,7 +145,7 @@ func (c *ipamBlockClient) Delete(ctx context.Context, key model.Key, revision st
 
 func (c *ipamBlockClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
 	// Get the object.
-	name, _ := c.parseKey(key)
+	name, _ := blockConverter.ParseKey(key)
 	k := model.ResourceKey{Name: name, Kind: apiv3.KindIPAMBlock}
 	kvp, err := c.rc.Get(ctx, k, revision)
 	if err != nil {
@@ -216,7 +153,7 @@ func (c *ipamBlockClient) Get(ctx context.Context, key model.Key, revision strin
 	}
 
 	// Convert it back to V1 format.
-	v1kvp, err := c.toV1(kvp)
+	v1kvp, err := blockConverter.ToV1(kvp)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +179,7 @@ func (c *ipamBlockClient) List(ctx context.Context, list model.ListInterface, re
 
 	kvpl := &model.KVPairList{KVPairs: []*model.KVPair{}}
 	for _, i := range v3list.KVPairs {
-		v1kvp, err := c.toV1(i)
+		v1kvp, err := blockConverter.ToV1(i)
 		if err != nil {
 			return nil, err
 		}
@@ -263,7 +200,7 @@ func (c *ipamBlockClient) Watch(ctx context.Context, list model.ListInterface, r
 		if err != nil {
 			return nil, err
 		}
-		return c.toV1(conv)
+		return blockConverter.ToV1(conv)
 	}
 
 	return newK8sWatcherConverter(ctx, resl.Kind+" (custom)", toKVPair, k8sWatch), nil

--- a/lib/backend/k8s/resources/ipam_handle.go
+++ b/lib/backend/k8s/resources/ipam_handle.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,7 @@ import (
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/converter"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
 
@@ -57,6 +57,26 @@ func NewIPAMHandleClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourc
 	return &ipamHandleClient{rc: rc}
 }
 
+// NewV3IPAMHandleClient returns a resource client that accepts IPAMHandle resources
+// in V3 format, as opposed to the NewIPAMHandleClient that accepts V1 resources.
+func NewV3IPAMHandleClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+	// Create a resource client which manages k8s CRDs.
+	return &customK8sResourceClient{
+		clientSet:       c,
+		restClient:      r,
+		name:            IPAMHandleCRDName,
+		resource:        IPAMHandleResourceName,
+		description:     "Calico IPAM handles",
+		k8sResourceType: reflect.TypeOf(apiv3.IPAMHandle{}),
+		k8sResourceTypeMeta: metav1.TypeMeta{
+			Kind:       apiv3.KindIPAMHandle,
+			APIVersion: apiv3.GroupVersionCurrent,
+		},
+		k8sListType:  reflect.TypeOf(apiv3.IPAMHandleList{}),
+		resourceKind: apiv3.KindIPAMHandle,
+	}
+}
+
 // affinityHandleClient implements the api.Client interface for IPAMHandle objects. It
 // handles the translation between v1 objects understood by the IPAM codebase in lib/ipam,
 // and the CRDs which are used to actually store the data in the Kubernetes API.
@@ -66,74 +86,30 @@ type ipamHandleClient struct {
 	rc customK8sResourceClient
 }
 
-func (c ipamHandleClient) toV1(kvpv3 *model.KVPair) *model.KVPair {
-	handle := kvpv3.Value.(*apiv3.IPAMHandle).Spec.HandleID
-	block := kvpv3.Value.(*apiv3.IPAMHandle).Spec.Block
-	return &model.KVPair{
-		Key: model.IPAMHandleKey{
-			HandleID: handle,
-		},
-		Value: &model.IPAMHandle{
-			HandleID: handle,
-			Block:    block,
-		},
-		Revision: kvpv3.Revision,
-	}
-}
-
-func (c ipamHandleClient) parseKey(k model.Key) string {
-	return strings.ToLower(k.(model.IPAMHandleKey).HandleID)
-}
-
-func (c ipamHandleClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
-	name := c.parseKey(kvpv1.Key)
-	handle := kvpv1.Key.(model.IPAMHandleKey).HandleID
-	block := kvpv1.Value.(*model.IPAMHandle).Block
-	return &model.KVPair{
-		Key: model.ResourceKey{
-			Name: name,
-			Kind: apiv3.KindIPAMHandle,
-		},
-		Value: &apiv3.IPAMHandle{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       apiv3.KindIPAMHandle,
-				APIVersion: "crd.projectcalico.org/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            name,
-				ResourceVersion: kvpv1.Revision,
-			},
-			Spec: apiv3.IPAMHandleSpec{
-				HandleID: handle,
-				Block:    block,
-			},
-		},
-		Revision: kvpv1.Revision,
-	}
-}
+var ipamHandleConverter = converter.IPAMHandleConverter{}
 
 func (c *ipamHandleClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp := c.toV3(kvp)
+	nkvp := ipamHandleConverter.ToV3(kvp)
 	kvp, err := c.rc.Create(ctx, nkvp)
 	if err != nil {
 		return nil, err
 	}
-	return c.toV1(kvp), nil
+	return ipamHandleConverter.ToV1(kvp)
 }
 
 func (c *ipamHandleClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp := c.toV3(kvp)
+	nkvp := ipamHandleConverter.ToV3(kvp)
 	kvp, err := c.rc.Update(ctx, nkvp)
 	if err != nil {
 		return nil, err
 	}
-	return c.toV1(kvp), nil
+	return ipamHandleConverter.ToV1(kvp)
 }
 
 func (c *ipamHandleClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	// We need to mark as deleted first, since the Kubernetes API doesn't support
 	// compare-and-delete. This update operation allows us to eliminate races with other clients.
-	name := c.parseKey(kvp.Key)
+	name := ipamHandleConverter.ParseKey(kvp.Key)
 	kvp.Value.(*model.IPAMHandle).Deleted = true
 	v1kvp, err := c.Update(ctx, kvp)
 	if err != nil {
@@ -146,7 +122,7 @@ func (c *ipamHandleClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*m
 	if err != nil {
 		return nil, err
 	}
-	return c.toV1(kvp), nil
+	return ipamHandleConverter.ToV1(kvp)
 }
 
 func (c *ipamHandleClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
@@ -159,15 +135,15 @@ func (c *ipamHandleClient) Delete(ctx context.Context, key model.Key, revision s
 }
 
 func (c *ipamHandleClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
-	name := c.parseKey(key)
+	name := ipamHandleConverter.ParseKey(key)
 	k := model.ResourceKey{Name: name, Kind: apiv3.KindIPAMHandle}
 	kvp, err := c.rc.Get(ctx, k, revision)
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert it to v1.
-	v1kvp := c.toV1(kvp)
+	// Convert it to v1. (Note: conversion never fails)
+	v1kvp, _ := ipamHandleConverter.ToV1(kvp)
 
 	// If this object has been marked as deleted, then we need to clean it up and
 	// return not found.
@@ -190,7 +166,8 @@ func (c *ipamHandleClient) List(ctx context.Context, list model.ListInterface, r
 
 	kvpl := &model.KVPairList{KVPairs: []*model.KVPair{}}
 	for _, i := range v3list.KVPairs {
-		v1kvp := c.toV1(i)
+		// Note: conversion to v1 never fails
+		v1kvp, _ := ipamHandleConverter.ToV1(i)
 		kvpl.KVPairs = append(kvpl.KVPairs, v1kvp)
 	}
 	return kvpl, nil

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -121,7 +121,28 @@ func init() {
 	registerResourceInfo(
 		apiv3.KindKubeControllersConfiguration,
 		"kubecontrollersconfigurations",
-		reflect.TypeOf(apiv3.KubeControllersConfiguration{}))
+		reflect.TypeOf(apiv3.KubeControllersConfiguration{}),
+	)
+	registerResourceInfo(
+		apiv3.KindBlockAffinity,
+		"blockaffinities",
+		reflect.TypeOf(apiv3.BlockAffinity{}),
+	)
+	registerResourceInfo(
+		apiv3.KindIPAMBlock,
+		"ipamblocks",
+		reflect.TypeOf(apiv3.IPAMBlock{}),
+	)
+	registerResourceInfo(
+		apiv3.KindIPAMHandle,
+		"ipamhandles",
+		reflect.TypeOf(apiv3.IPAMHandle{}),
+	)
+	registerResourceInfo(
+		apiv3.KindIPAMConfig,
+		"ipamconfigs",
+		reflect.TypeOf(apiv3.IPAMConfig{}),
+	)
 }
 
 type ResourceKey struct {

--- a/lib/clientv3/bgpconfig_e2e_test.go
+++ b/lib/clientv3/bgpconfig_e2e_test.go
@@ -87,7 +87,8 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 
 			be, err := backend.NewClient(config)
 			Expect(err).NotTo(HaveOccurred())
-			be.Clean()
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Updating the BGPConfiguration before it is created")
 			_, outError := c.BGPConfigurations().Update(ctx, &apiv3.BGPConfiguration{
@@ -338,7 +339,8 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 
 			be, err := backend.NewClient(config)
 			Expect(err).NotTo(HaveOccurred())
-			be.Clean()
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Listing BGPConfigurations with the latest resource version and checking for two results with name1/specDebug and name2/specDebug")
 			outList, outError := c.BGPConfigurations().List(ctx, options.ListOptions{})
@@ -355,6 +357,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 				},
 				options.SetOptions{},
 			)
+			Expect(err).NotTo(HaveOccurred())
 			rev1 := outRes1.ResourceVersion
 
 			By("Configuring a BGPConfiguration name2/specDebug and storing the response")
@@ -487,7 +490,8 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 			})
 
 			By("Cleaning the datastore and expecting deletion events for each configured resource (tests prefix deletes results in individual events for each key)")
-			be.Clean()
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
 			testWatcher4.ExpectEvents(apiv3.KindBGPConfiguration, []watch.Event{
 				{
 					Type:     watch.Deleted,

--- a/lib/clientv3/blockaffinity.go
+++ b/lib/clientv3/blockaffinity.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
+)
+
+// BlockAffinityInterface has methods to work with BlockAffinity resources.
+type BlockAffinityInterface interface {
+	Create(ctx context.Context, res *apiv3.BlockAffinity, opts options.SetOptions) (*apiv3.BlockAffinity, error)
+	List(ctx context.Context, opts options.ListOptions) (*apiv3.BlockAffinityList, error)
+
+	// Update is not supported on the etcdv3 backend, because it doesn't store the CreationTimestamp or UID.
+	//Update(ctx context.Context, res *apiv3.BlockAffinity, opts options.SetOptions) (*apiv3.BlockAffinity, error)
+
+	// Delete is not supported on the etcdv3 backend, because the resource name might be a hash of nodename + CIDR
+	// which doesn't reliably allow us to infer the etcd key.
+	//Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.BlockAffinity, error)
+
+	// Get is not supported on the etcdv3 backend, because the resource name might be a hash of nodename + CIDR
+	// which doesn't reliably allow us to infer the etcd key.
+	//Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.BlockAffinity, error)
+
+	// Watch is not supported because we don't need it right now; this interface
+	// is added to support etcd -> KDD migration
+	//Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// blockAffinities implements the BlockAffinityInterface
+type blockAffinities struct {
+	client client
+}
+
+// Create takes the representation of a BlockAffinity and creates it.
+// Returns the stored representation of the BlockAffinity, and an error
+// if there is any.
+func (r blockAffinities) Create(ctx context.Context, res *apiv3.BlockAffinity, opts options.SetOptions) (*apiv3.BlockAffinity, error) {
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Create(ctx, opts, apiv3.KindBlockAffinity, res)
+	if out != nil {
+		return out.(*apiv3.BlockAffinity), err
+	}
+	return nil, err
+}
+
+// List returns the list of BlockAffinity objects that match the supplied options.
+func (r blockAffinities) List(ctx context.Context, opts options.ListOptions) (*apiv3.BlockAffinityList, error) {
+	res := &apiv3.BlockAffinityList{}
+	if err := r.client.resources.List(ctx, opts, apiv3.KindBlockAffinity, apiv3.KindBlockAffinityList, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/lib/clientv3/blockaffinity_e2e_test.go
+++ b/lib/clientv3/blockaffinity_e2e_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("BlockAffinity tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "node-1-192-168-142-64-26"
+	name2 := "node-2-192-168-142-0-26"
+	spec1 := apiv3.BlockAffinitySpec{
+		State:   "confirmed",
+		Node:    "node-1",
+		CIDR:    "192.168.142.64/26",
+		Deleted: "",
+	}
+	spec1mod := apiv3.BlockAffinitySpec{
+		State:   "confirmed",
+		Node:    "node-1",
+		CIDR:    "192.168.142.64/26",
+		Deleted: "true",
+	}
+	spec2 := apiv3.BlockAffinitySpec{
+		State:   "confirmed",
+		Node:    "node-2",
+		CIDR:    "192.168.142.0/26",
+		Deleted: "",
+	}
+
+	DescribeTable("BlockAffinity e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv3.BlockAffinitySpec) {
+			c, err := clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM := c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Attempting to creating a new BlockAffinity with name1/spec1 and a non-empty ResourceVersion")
+			_, outError := llIPAM.BlockAffinities().Create(ctx, &apiv3.BlockAffinity{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new BlockAffinity with name1/spec1")
+			res1, outError := llIPAM.BlockAffinities().Create(ctx, &apiv3.BlockAffinity{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res1).To(MatchResource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name1, spec1))
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same BlockAffinity with name1 but with spec1mod")
+			_, outError = llIPAM.BlockAffinities().Create(ctx, &apiv3.BlockAffinity{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1mod,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			// The KDD and etcd backends give slightly different errors because of the V1 vs V3 conversion, so just look for "resource does not exist"
+			Expect(outError.Error()).To(ContainSubstring("resource already exists:"))
+
+			By("Listing all the BlockAffinities, expecting a single result with name1/spec1")
+			outList, outError := llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name1, spec1),
+			))
+
+			By("Creating a new BlockAffinity with name2/spec2")
+			res2, outError := llIPAM.BlockAffinities().Create(ctx, &apiv3.BlockAffinity{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res2).To(MatchResource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name2, spec2))
+
+			By("Listing all the LowLevelIPAM().BlockAffinities, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name1, spec1),
+				testutils.Resource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name2, spec2),
+			))
+
+			if config.Spec.DatastoreType != apiconfig.Kubernetes {
+				By("Listing LowLevelIPAM().BlockAffinities with the original resource version and checking for a single result with name1/spec1")
+				outList, outError = llIPAM.BlockAffinities().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+				Expect(outError).NotTo(HaveOccurred())
+				Expect(outList.Items).To(ConsistOf(
+					testutils.Resource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name1, spec1),
+				))
+			}
+
+			By("Listing LowLevelIPAM().BlockAffinities with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name1, spec1),
+				testutils.Resource(apiv3.KindBlockAffinity, testutils.ExpectNoNamespace, name2, spec2),
+			))
+
+			err = be.Clean()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Listing all LowLevelIPAM().BlockAffinities and expecting no items")
+			outList, outError = llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+		},
+
+		// Test 1: Pass two fully populated LowLevelIPAM().BlockAffinitiespecs and expect the series of operations to succeed.
+		Entry("Two fully populated BlockAffinitySpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("correspondence between IPAM and LowLevelIPAM", func() {
+		var c clientv3.Interface
+		var be bapi.Client
+		var llIPAM clientv3.LowLevelIPAMInterface
+
+		BeforeEach(func() {
+			var err error
+			c, err = clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM = c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err = backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("with IPPool defined", func() {
+			BeforeEach(func() {
+				err := be.Clean()
+				Expect(err).NotTo(HaveOccurred())
+
+				pool := apiv3.NewIPPool()
+				pool.Name = "default"
+				pool.Spec.CIDR = "10.13.0.0/16"
+				pool, err = c.IPPools().Create(ctx, pool, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				err := be.Clean()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Should list host affinity claimed by IPAM()", func() {
+				ba, err := llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ba.Items).To(HaveLen(0))
+
+				cidr := cnet.MustParseNetwork("10.13.14.0/26")
+				claimed, failed, err := c.IPAM().ClaimAffinity(ctx, cidr, "node-1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(failed).To(HaveLen(0))
+				Expect(claimed).To(HaveLen(1))
+
+				ba, err = llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ba.Items).To(HaveLen(1))
+
+				err = c.IPAM().ReleaseAffinity(ctx, cidr, "node-1", true)
+				Expect(err).ToNot(HaveOccurred())
+
+				ba, err = llIPAM.BlockAffinities().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ba.Items).To(HaveLen(0))
+			})
+		})
+	})
+})

--- a/lib/clientv3/client.go
+++ b/lib/clientv3/client.go
@@ -150,6 +150,10 @@ func (c client) KubeControllersConfiguration() KubeControllersConfigurationInter
 	return kubeControllersConfiguration{client: c}
 }
 
+func (c client) LowLevelIPAM() LowLevelIPAMInterface {
+	return llIPAM{client: c}
+}
+
 type poolAccessor struct {
 	client *client
 }

--- a/lib/clientv3/interface.go
+++ b/lib/clientv3/interface.go
@@ -62,5 +62,21 @@ type Interface interface {
 	EnsureInitialized(ctx context.Context, calicoVersion, clusterType string) error
 }
 
-// Compile-time assertion that our client implements its interface.
+// LowLevelIPAMClient allows interacting with the LowLevelIPAMInterface. It's a separate interface
+// from the main client for backward compatibility, since some test code that doesn't need to care
+// about this new interface implements the main Interface.  Code that needs access to this interface
+// from the main Interface, can do a type assertion, e.g.
+//
+// llIPAM := client.(LowLevelIPAMClient).LowLevelIPAM()
+//
+type LowLevelIPAMClient interface {
+	// LowLevelIPAM returns an interface for interacting with low-level IPAM data directly.
+	// This interface should not be used for ordinary IPAM operations: use the IPAM interface instead.
+	// The low level interface gives unsafe access to the direct data objects, and incorrect use
+	// could put the datastore in an inconsistent state.
+	LowLevelIPAM() LowLevelIPAMInterface
+}
+
+// Compile-time assertion that our client implements its interface(s).
 var _ Interface = (*client)(nil)
+var _ LowLevelIPAMClient = (*client)(nil)

--- a/lib/clientv3/ipam_block.go
+++ b/lib/clientv3/ipam_block.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
+)
+
+// IPAMBlockInterface has methods to work with IPAMBlock resources.
+type IPAMBlockInterface interface {
+	Create(ctx context.Context, res *apiv3.IPAMBlock, opts options.SetOptions) (*apiv3.IPAMBlock, error)
+	List(ctx context.Context, opts options.ListOptions) (*apiv3.IPAMBlockList, error)
+
+	// Update is not supported on the etcdv3 backend, because it doesn't store the CreationTimestamp or UID.
+	//Update(ctx context.Context, res *apiv3.IPAMBlock, opts options.SetOptions) (*apiv3.IPAMBlock, error)
+
+	// Delete, Get, and Watch are not implemented because only Create and List are needed for
+	// etcd -> KDD migration
+	//Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.IPAMBlock, error)
+	//Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.IPAMBlock, error)
+	//Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// ipamBlocks implements the IPAMBlockInterface
+type ipamBlocks struct {
+	client client
+}
+
+// Create takes the representation of a IPAMBlock and creates it.
+// Returns the stored representation of the IPAMBlock, and an error
+// if there is any.
+func (r ipamBlocks) Create(ctx context.Context, res *apiv3.IPAMBlock, opts options.SetOptions) (*apiv3.IPAMBlock, error) {
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Create(ctx, opts, apiv3.KindIPAMBlock, res)
+	if out != nil {
+		return out.(*apiv3.IPAMBlock), err
+	}
+	return nil, err
+}
+
+// List returns the list of IPAMBlock objects that match the supplied options.
+func (r ipamBlocks) List(ctx context.Context, opts options.ListOptions) (*apiv3.IPAMBlockList, error) {
+	res := &apiv3.IPAMBlockList{}
+	if err := r.client.resources.List(ctx, opts, apiv3.KindIPAMBlock, apiv3.KindIPAMBlockList, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/lib/clientv3/ipam_block_e2e_test.go
+++ b/lib/clientv3/ipam_block_e2e_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("IPAMBlock tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "192-168-142-64-26"
+	name2 := "192-168-142-0-26"
+	spec1 := apiv3.IPAMBlockSpec{
+		CIDR:       "192.168.142.64/26",
+		Attributes: []apiv3.AllocationAttribute{},
+	}
+	spec1mod := apiv3.IPAMBlockSpec{
+		CIDR:       "192.168.142.64/26",
+		Attributes: []apiv3.AllocationAttribute{},
+		Deleted:    true,
+	}
+	spec2 := apiv3.IPAMBlockSpec{
+		CIDR:       "192.168.142.0/26",
+		Attributes: []apiv3.AllocationAttribute{},
+	}
+
+	DescribeTable("IPAMBlock e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv3.IPAMBlockSpec) {
+			c, err := clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM := c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Attempting to creating a new IPAMBlock with name1/spec1 and a non-empty ResourceVersion")
+			_, outError := llIPAM.IPAMBlocks().Create(ctx, &apiv3.IPAMBlock{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new IPAMBlock with name1/spec1")
+			res1, outError := llIPAM.IPAMBlocks().Create(ctx, &apiv3.IPAMBlock{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res1).To(MatchResource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name1, spec1))
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same IPAMBlock with name1 but with spec1mod")
+			_, outError = llIPAM.IPAMBlocks().Create(ctx, &apiv3.IPAMBlock{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1mod,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			// The KDD and etcd backends give slightly different errors because of the V1 vs V3 conversion, so just look for "resource does not exist"
+			Expect(outError.Error()).To(ContainSubstring("resource already exists:"))
+
+			By("Listing all the IPAMBlocks, expecting a single result with name1/spec1")
+			outList, outError := llIPAM.IPAMBlocks().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name1, spec1),
+			))
+
+			By("Creating a new IPAMBlock with name2/spec2")
+			res2, outError := llIPAM.IPAMBlocks().Create(ctx, &apiv3.IPAMBlock{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res2).To(MatchResource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name2, spec2))
+
+			By("Listing all the LowLevelIPAM().IPAMBlocks, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = llIPAM.IPAMBlocks().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name1, spec1),
+				testutils.Resource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name2, spec2),
+			))
+
+			if config.Spec.DatastoreType != apiconfig.Kubernetes {
+				By("Listing LowLevelIPAM().IPAMBlocks with the original resource version and checking for a single result with name1/spec1")
+				outList, outError = llIPAM.IPAMBlocks().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+				Expect(outError).NotTo(HaveOccurred())
+				Expect(outList.Items).To(ConsistOf(
+					testutils.Resource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name1, spec1),
+				))
+			}
+
+			By("Listing LowLevelIPAM().IPAMBlocks with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = llIPAM.IPAMBlocks().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name1, spec1),
+				testutils.Resource(apiv3.KindIPAMBlock, testutils.ExpectNoNamespace, name2, spec2),
+			))
+
+			err = be.Clean()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Listing all LowLevelIPAM().IPAMBlocks and expecting no items")
+			outList, outError = llIPAM.IPAMBlocks().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+		},
+
+		// Test 1: Pass two fully populated LowLevelIPAM().IPAMBlocks specs and expect the series of operations to succeed.
+		Entry("Two fully populated IPAMBlockSpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("correspondence between IPAM and LowLevelIPAM", func() {
+		var c clientv3.Interface
+		var be bapi.Client
+		var llIPAM clientv3.LowLevelIPAMInterface
+
+		BeforeEach(func() {
+			var err error
+			c, err = clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM = c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err = backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("with IPPool defined", func() {
+			BeforeEach(func() {
+				err := be.Clean()
+				Expect(err).NotTo(HaveOccurred())
+
+				pool := apiv3.NewIPPool()
+				pool.Name = "default"
+				pool.Spec.CIDR = "10.13.0.0/16"
+				pool, err = c.IPPools().Create(ctx, pool, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				err := be.Clean()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Should list IPAMBlocks for assigned addresses", func() {
+				ba, err := llIPAM.IPAMBlocks().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ba.Items).To(HaveLen(0))
+
+				// Assign an IP
+				ip := cnet.MustParseIP("10.13.0.2")
+				args := ipam.AssignIPArgs{
+					IP:       ip,
+					HandleID: nil,
+					Attrs:    nil,
+					Hostname: "testnode",
+				}
+				err = c.IPAM().AssignIP(ctx, args)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Should create 1 block
+				ba, err = llIPAM.IPAMBlocks().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ba.Items).To(HaveLen(1))
+			})
+		})
+	})
+})

--- a/lib/clientv3/ipam_config.go
+++ b/lib/clientv3/ipam_config.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+	"errors"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
+)
+
+// IPAMConfigInterface has methods to work with IPAMConfig resources.
+type IPAMConfigInterface interface {
+	Create(ctx context.Context, res *apiv3.IPAMConfig, opts options.SetOptions) (*apiv3.IPAMConfig, error)
+
+	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.IPAMConfig, error)
+
+	// Update is not supported on the etcdv3 backend, because it doesn't store the CreationTimestamp or UID.
+	//Update(ctx context.Context, res *apiv3.IPAMConfig, opts options.SetOptions) (*apiv3.IPAMConfig, error)
+
+	// List is not supported on the etcdv3 backend, because the IPAM Config model doesn't have a
+	// list interface.
+	// List(ctx context.Context, opts options.ListOptions) (*apiv3.IPAMConfigList, error)
+
+	// Delete, and Watch are not implemented because only Create and List are needed for
+	// etcd -> KDD migration
+	//Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.IPAMConfig, error)
+	//Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// ipamConfigs implements the IPAMConfigInterface
+type ipamConfigs struct {
+	client client
+}
+
+// Create takes the representation of a IPAMConfig and creates it.
+// Returns the stored representation of the IPAMConfig, and an error
+// if there is any.
+func (r ipamConfigs) Create(ctx context.Context, res *apiv3.IPAMConfig, opts options.SetOptions) (*apiv3.IPAMConfig, error) {
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	if res.ObjectMeta.GetName() != "default" {
+		return nil, errors.New("Cannot create an IPAM Config resource with a name other than \"default\"")
+	}
+	out, err := r.client.resources.Create(ctx, opts, apiv3.KindIPAMConfig, res)
+	if out != nil {
+		return out.(*apiv3.IPAMConfig), err
+	}
+	return nil, err
+}
+
+// Get takes name of the IPAMConfig, and returns the corresponding
+// IPAMConfig object, and an error if there is any.
+func (r ipamConfigs) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.IPAMConfig, error) {
+	out, err := r.client.resources.Get(ctx, opts, apiv3.KindIPAMConfig, noNamespace, name)
+	if out != nil {
+		return out.(*apiv3.IPAMConfig), err
+	}
+	return nil, err
+}

--- a/lib/clientv3/ipam_config_e2e_test.go
+++ b/lib/clientv3/ipam_config_e2e_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "default"
+	name2 := "not-default"
+	spec1 := apiv3.IPAMConfigSpec{
+		StrictAffinity: true,
+	}
+	spec1mod := apiv3.IPAMConfigSpec{
+		StrictAffinity: false,
+	}
+
+	It("IPAMConfig e2e CRUD tests", func() {
+
+		c, err := clientv3.New(config)
+		Expect(err).NotTo(HaveOccurred())
+		llIPAM := c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+		be, err := backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		err = be.Clean()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Attempting to creating a new IPAMConfig with name1/spec1 and a non-empty ResourceVersion")
+		_, outError := llIPAM.IPAMConfig().Create(ctx, &apiv3.IPAMConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+			Spec:       spec1,
+		}, options.SetOptions{})
+		Expect(outError).To(HaveOccurred())
+		Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+		By("Creating a new IPAMConfig with name1/spec1")
+		res1, outError := llIPAM.IPAMConfig().Create(ctx, &apiv3.IPAMConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name1},
+			Spec:       spec1,
+		}, options.SetOptions{})
+		Expect(outError).NotTo(HaveOccurred())
+		Expect(res1).To(MatchResource(apiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name1, spec1))
+
+		By("Attempting to create the same IPAMConfig with name1 but with spec1mod")
+		_, outError = llIPAM.IPAMConfig().Create(ctx, &apiv3.IPAMConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name1},
+			Spec:       spec1mod,
+		}, options.SetOptions{})
+		Expect(outError).To(HaveOccurred())
+		// The KDD and etcd backends give slightly different errors because of the V1 vs V3 conversion, so just look for "resource does not exist"
+		Expect(outError.Error()).To(ContainSubstring("resource already exists:"))
+
+		By("Getting the IPAMConfig, expecting result with spec1")
+		out, outError := llIPAM.IPAMConfig().Get(ctx, name1, options.GetOptions{})
+		Expect(outError).NotTo(HaveOccurred())
+		Expect(out).To(MatchResource(apiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name1, spec1))
+
+		By("Creating a new IPAMConfig with name2/spec1")
+		_, outError = llIPAM.IPAMConfig().Create(ctx, &apiv3.IPAMConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name2},
+			Spec:       spec1,
+		}, options.SetOptions{})
+		Expect(outError).To(HaveOccurred())
+		Expect(outError.Error()).To(Equal("Cannot create an IPAM Config resource with a name other than \"default\""))
+
+		err = be.Clean()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Getting IPAMConfig and expecting no items")
+		_, outError = llIPAM.IPAMConfig().Get(ctx, name1, options.GetOptions{})
+		Expect(outError).To(HaveOccurred())
+		Expect(outError.Error()).To(ContainSubstring("resource does not exist"))
+	})
+
+	Describe("correspondence between IPAM and LowLevelIPAM", func() {
+		var c clientv3.Interface
+		var be bapi.Client
+		var llIPAM clientv3.LowLevelIPAMInterface
+
+		BeforeEach(func() {
+			var err error
+			c, err = clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM = c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err = backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := be.Clean()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should list IPAMConfig set in IPAM()", func() {
+			_, outError := llIPAM.IPAMConfig().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(ContainSubstring("resource does not exist"))
+
+			cfg := ipam.IPAMConfig{StrictAffinity: true, AutoAllocateBlocks: true}
+			err := c.IPAM().SetIPAMConfig(ctx, cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Should create IPAM Config
+			out, outError := llIPAM.IPAMConfig().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(out).To(MatchResource(
+				apiv3.KindIPAMConfig, testutils.ExpectNoNamespace, "default", apiv3.IPAMConfigSpec{
+					StrictAffinity:     true,
+					AutoAllocateBlocks: true,
+				}))
+
+			cfg = ipam.IPAMConfig{StrictAffinity: false, AutoAllocateBlocks: true}
+			err = c.IPAM().SetIPAMConfig(ctx, cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			out, outError = llIPAM.IPAMConfig().Get(ctx, name1, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(out).To(MatchResource(
+				apiv3.KindIPAMConfig, testutils.ExpectNoNamespace, "default", apiv3.IPAMConfigSpec{
+					StrictAffinity:     false,
+					AutoAllocateBlocks: true,
+				}))
+		})
+	})
+})

--- a/lib/clientv3/ipam_handle.go
+++ b/lib/clientv3/ipam_handle.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
+)
+
+// IPAMHandleInterface has methods to work with IPAMHandle resources.
+type IPAMHandleInterface interface {
+	Create(ctx context.Context, res *apiv3.IPAMHandle, opts options.SetOptions) (*apiv3.IPAMHandle, error)
+	List(ctx context.Context, opts options.ListOptions) (*apiv3.IPAMHandleList, error)
+
+	// Update is not supported on the etcdv3 backend, because it doesn't store the CreationTimestamp or UID.
+	//Update(ctx context.Context, res *apiv3.IPAMHandle, opts options.SetOptions) (*apiv3.IPAMHandle, error)
+
+	// Delete, Get, and Watch are not implemented because only Create and List are needed for
+	// etcd -> KDD migration
+	//Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.IPAMHandle, error)
+	//Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.IPAMHandle, error)
+	//Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+}
+
+// ipamHandles implements the IPAMHandleInterface
+type ipamHandles struct {
+	client client
+}
+
+// Create takes the representation of a IPAMHandle and creates it.
+// Returns the stored representation of the IPAMHandle, and an error
+// if there is any.
+func (r ipamHandles) Create(ctx context.Context, res *apiv3.IPAMHandle, opts options.SetOptions) (*apiv3.IPAMHandle, error) {
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Create(ctx, opts, apiv3.KindIPAMHandle, res)
+	if out != nil {
+		return out.(*apiv3.IPAMHandle), err
+	}
+	return nil, err
+}
+
+// List returns the list of IPAMHandle objects that match the supplied options.
+func (r ipamHandles) List(ctx context.Context, opts options.ListOptions) (*apiv3.IPAMHandleList, error) {
+	res := &apiv3.IPAMHandleList{}
+	if err := r.client.resources.List(ctx, opts, apiv3.KindIPAMHandle, apiv3.KindIPAMHandleList, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/lib/clientv3/ipam_handle_e2e_test.go
+++ b/lib/clientv3/ipam_handle_e2e_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("IPAMHandle tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+
+	ctx := context.Background()
+	name1 := "handle1"
+	name2 := "handle2"
+	spec1 := apiv3.IPAMHandleSpec{
+		HandleID: name1,
+		Block:    map[string]int{"10-0-0-0-24": 5},
+	}
+	spec1mod := apiv3.IPAMHandleSpec{
+		HandleID: name1,
+		Block:    map[string]int{"10-0-0-0-24": 7},
+	}
+	spec2 := apiv3.IPAMHandleSpec{
+		HandleID: name2,
+		Block:    map[string]int{"10-0-0-0-24": 15},
+	}
+
+	DescribeTable("IPAMHandle e2e CRUD tests",
+		func(name1, name2 string, spec1, spec2 apiv3.IPAMHandleSpec) {
+			c, err := clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM := c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err := backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+			err = be.Clean()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Attempting to creating a new IPAMHandle with name1/spec1 and a non-empty ResourceVersion")
+			_, outError := llIPAM.IPAMHandles().Create(ctx, &apiv3.IPAMHandle{
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "12345"},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(Equal("error with field Metadata.ResourceVersion = '12345' (field must not be set for a Create request)"))
+
+			By("Creating a new IPAMHandle with name1/spec1")
+			res1, outError := llIPAM.IPAMHandles().Create(ctx, &apiv3.IPAMHandle{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res1).To(MatchResource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name1, spec1))
+
+			// Track the version of the original data for name1.
+			rv1_1 := res1.ResourceVersion
+
+			By("Attempting to create the same IPAMHandle with name1 but with spec1mod")
+			_, outError = llIPAM.IPAMHandles().Create(ctx, &apiv3.IPAMHandle{
+				ObjectMeta: metav1.ObjectMeta{Name: name1},
+				Spec:       spec1mod,
+			}, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			// The KDD and etcd backends give slightly different errors because of the V1 vs V3 conversion, so just look for "resource does not exist"
+			Expect(outError.Error()).To(ContainSubstring("resource already exists:"))
+
+			By("Listing all the IPAMHandles, expecting a single result with name1/spec1")
+			outList, outError := llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name1, spec1),
+			))
+
+			By("Creating a new IPAMHandle with name2/spec2")
+			res2, outError := llIPAM.IPAMHandles().Create(ctx, &apiv3.IPAMHandle{
+				ObjectMeta: metav1.ObjectMeta{Name: name2},
+				Spec:       spec2,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res2).To(MatchResource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name2, spec2))
+
+			By("Listing all the LowLevelIPAM().IPAMHandles, expecting a two results with name1/spec1 and name2/spec2")
+			outList, outError = llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name1, spec1),
+				testutils.Resource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name2, spec2),
+			))
+
+			if config.Spec.DatastoreType != apiconfig.Kubernetes {
+				By("Listing LowLevelIPAM().IPAMHandles with the original resource version and checking for a single result with name1/spec1")
+				outList, outError = llIPAM.IPAMHandles().List(ctx, options.ListOptions{ResourceVersion: rv1_1})
+				Expect(outError).NotTo(HaveOccurred())
+				Expect(outList.Items).To(ConsistOf(
+					testutils.Resource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name1, spec1),
+				))
+			}
+
+			By("Listing LowLevelIPAM().IPAMHandles with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			outList, outError = llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name1, spec1),
+				testutils.Resource(apiv3.KindIPAMHandle, testutils.ExpectNoNamespace, name2, spec2),
+			))
+
+			err = be.Clean()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Listing all LowLevelIPAM().IPAMHandles and expecting no items")
+			outList, outError = llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(HaveLen(0))
+		},
+
+		// Test 1: Pass two fully populated LowLevelIPAM().IPAMHandles specs and expect the series of operations to succeed.
+		Entry("Two fully populated IPAMHandleSpecs", name1, name2, spec1, spec2),
+	)
+
+	Describe("correspondence between IPAM and LowLevelIPAM", func() {
+		var c clientv3.Interface
+		var be bapi.Client
+		var llIPAM clientv3.LowLevelIPAMInterface
+
+		BeforeEach(func() {
+			var err error
+			c, err = clientv3.New(config)
+			Expect(err).NotTo(HaveOccurred())
+			llIPAM = c.(clientv3.LowLevelIPAMClient).LowLevelIPAM()
+
+			be, err = backend.NewClient(config)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("with IPPool defined", func() {
+			BeforeEach(func() {
+				err := be.Clean()
+				Expect(err).NotTo(HaveOccurred())
+
+				pool := apiv3.NewIPPool()
+				pool.Name = "default"
+				pool.Spec.CIDR = "10.13.0.0/16"
+				pool, err = c.IPPools().Create(ctx, pool, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				err := be.Clean()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Should list IPAMHandles for assigned addresses", func() {
+				handles, err := llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handles.Items).To(HaveLen(0))
+
+				// Assign an IP
+				ip := cnet.MustParseIP("10.13.0.2")
+				handle := "testhandle"
+				args := ipam.AssignIPArgs{
+					IP:       ip,
+					HandleID: &handle,
+					Attrs:    nil,
+					Hostname: "testnode",
+				}
+				err = c.IPAM().AssignIP(ctx, args)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Handle should exist
+				handles, err = llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handles.Items).To(HaveLen(1))
+
+				// Unassign the IP
+				err = c.IPAM().ReleaseByHandle(ctx, handle)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Handle should not exist
+				handles, err = llIPAM.IPAMHandles().List(ctx, options.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handles.Items).To(HaveLen(0))
+			})
+		})
+	})
+})

--- a/lib/clientv3/lowlevelipam.go
+++ b/lib/clientv3/lowlevelipam.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+type LowLevelIPAMInterface interface {
+	// IPAMBlocks returns an interface for managing IPAM block resources.
+	IPAMBlocks() IPAMBlockInterface
+	// BlockAffinities returns an interface for managing IPAM block affinity resources.
+	BlockAffinities() BlockAffinityInterface
+	// IPAMHandles returns an interface for managing IPAM allocation handle resources.
+	IPAMHandles() IPAMHandleInterface
+	// IPAMConfig returns an interface for managing IPAM config resources.
+	IPAMConfig() IPAMConfigInterface
+}
+
+type llIPAM struct {
+	client client
+}
+
+func (l llIPAM) IPAMBlocks() IPAMBlockInterface {
+	return ipamBlocks{l.client}
+}
+
+func (l llIPAM) BlockAffinities() BlockAffinityInterface {
+	return blockAffinities{l.client}
+}
+
+func (l llIPAM) IPAMHandles() IPAMHandleInterface {
+	return ipamHandles{l.client}
+}
+
+func (l llIPAM) IPAMConfig() IPAMConfigInterface {
+	return ipamConfigs{l.client}
+}

--- a/lib/converter/blockaffinity.go
+++ b/lib/converter/blockaffinity.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/names"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+type BlockAffinityConverter struct{}
+
+// ToV1 converts the given v3 KVPair into a v1 model representation
+func (c BlockAffinityConverter) ToV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
+	// Parse the CIDR into a struct.
+	_, cidr, err := net.ParseCIDR(kvpv3.Value.(*apiv3.BlockAffinity).Spec.CIDR)
+	if err != nil {
+		log.WithField("cidr", cidr).WithError(err).Error("failed to parse cidr")
+		return nil, err
+	}
+	state := model.BlockAffinityState(kvpv3.Value.(*apiv3.BlockAffinity).Spec.State)
+	return &model.KVPair{
+		Key: model.BlockAffinityKey{
+			CIDR: *cidr,
+			Host: kvpv3.Value.(*apiv3.BlockAffinity).Spec.Node,
+		},
+		Value: &model.BlockAffinity{
+			State: state,
+		},
+		Revision: kvpv3.Revision,
+		UID:      &kvpv3.Value.(*apiv3.BlockAffinity).UID,
+	}, nil
+}
+
+// ParseKey parses the given model.Key, returning a suitable name, and CIDR
+// for use in the v3 API.
+func (c BlockAffinityConverter) ParseKey(k model.Key) (name, cidr, host string) {
+	host = k.(model.BlockAffinityKey).Host
+	cidr = fmt.Sprintf("%s", k.(model.BlockAffinityKey).CIDR)
+	cidrname := names.CIDRToName(k.(model.BlockAffinityKey).CIDR)
+
+	// Include the hostname as well.
+	host = k.(model.BlockAffinityKey).Host
+	name = fmt.Sprintf("%s-%s", host, cidrname)
+
+	if len(name) >= 253 {
+		// If the name is too long, we need to shorten it.
+		// Remove enough characters to get it below the 253 character limit,
+		// as well as 11 characters to add a hash which helps with uniqueness,
+		// and two characters for the `-` separators between clauses.
+		name = fmt.Sprintf("%s-%s", host[:252-len(cidrname)-13], cidrname)
+
+		// Add a hash to help with uniqueness.
+		h := sha256.New()
+		h.Write([]byte(fmt.Sprintf("%s+%s", host, cidrname)))
+		name = fmt.Sprintf("%s-%s", name, hex.EncodeToString(h.Sum(nil))[:11])
+	}
+	return
+}
+
+// ToV3 takes the given v1 KVPair and converts it into a v3 representation.
+func (c BlockAffinityConverter) ToV3(kvpv1 *model.KVPair) *model.KVPair {
+	name, cidr, host := c.ParseKey(kvpv1.Key)
+	state := kvpv1.Value.(*model.BlockAffinity).State
+	return &model.KVPair{
+		Key: model.ResourceKey{
+			Name: name,
+			Kind: apiv3.KindBlockAffinity,
+		},
+		Value: &apiv3.BlockAffinity{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apiv3.KindBlockAffinity,
+				APIVersion: apiv3.GroupVersionCurrent,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				ResourceVersion: kvpv1.Revision,
+			},
+			Spec: apiv3.BlockAffinitySpec{
+				State: string(state),
+				Node:  host,
+				CIDR:  cidr,
+			},
+		},
+		Revision: kvpv1.Revision,
+	}
+}
+
+// ToV1Key takes a v3 key and converts it to v1 representation
+func (c BlockAffinityConverter) ToV1Key(k model.Key) (model.Key, error) {
+	return nil, errors.New("cannot convert v3 BlockAffinity key to v1 key")
+}
+
+// ToV1ListInterface takes a v3 list interface and converts it to v1 representation
+func (c BlockAffinityConverter) ToV1ListInterface(l model.ResourceListOptions) (model.ListInterface, error) {
+	if l.Kind != apiv3.KindBlockAffinity {
+		return nil, errors.New("passed wrong kind to BlockAffinityConverter")
+	}
+	if l.Name != "" {
+		return nil, errors.New("cannot list v3 BlockAffinity by name")
+	}
+	return model.BlockAffinityListOptions{
+		Host:      "",
+		IPVersion: 0,
+	}, nil
+}

--- a/lib/converter/ipam_block.go
+++ b/lib/converter/ipam_block.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/names"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+type IPAMBlockConverter struct{}
+
+// ToV1 converts the given v3 KVPair into a v1 model representation
+func (c IPAMBlockConverter) ToV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
+	cidrStr := kvpv3.Value.(*apiv3.IPAMBlock).Spec.CIDR
+	_, cidr, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return nil, err
+	}
+
+	ab := kvpv3.Value.(*apiv3.IPAMBlock)
+
+	// Convert attributes.
+	attrs := []model.AllocationAttribute{}
+	for _, a := range ab.Spec.Attributes {
+		attrs = append(attrs, model.AllocationAttribute{
+			AttrPrimary:   a.AttrPrimary,
+			AttrSecondary: a.AttrSecondary,
+		})
+	}
+
+	return &model.KVPair{
+		Key: model.BlockKey{
+			CIDR: *cidr,
+		},
+		Value: &model.AllocationBlock{
+			CIDR:           *cidr,
+			Affinity:       ab.Spec.Affinity,
+			StrictAffinity: ab.Spec.StrictAffinity,
+			Allocations:    ab.Spec.Allocations,
+			Unallocated:    ab.Spec.Unallocated,
+			Attributes:     attrs,
+			Deleted:        ab.Spec.Deleted,
+		},
+		Revision: kvpv3.Revision,
+		UID:      &ab.UID,
+	}, nil
+}
+
+// ParseKey parses the given model.Key, returning a suitable name, and CIDR
+// for use in the v3 API.
+func (c IPAMBlockConverter) ParseKey(k model.Key) (name, cidr string) {
+	cidr = fmt.Sprintf("%s", k.(model.BlockKey).CIDR)
+	name = names.CIDRToName(k.(model.BlockKey).CIDR)
+	return
+}
+
+// ToV3 takes the given v1 KVPair and converts it into a v3 representation.
+func (c IPAMBlockConverter) ToV3(kvpv1 *model.KVPair) *model.KVPair {
+	name, cidr := c.ParseKey(kvpv1.Key)
+
+	ab := kvpv1.Value.(*model.AllocationBlock)
+
+	// Convert attributes.
+	attrs := []apiv3.AllocationAttribute{}
+	for _, a := range ab.Attributes {
+		attrs = append(attrs, apiv3.AllocationAttribute{
+			AttrPrimary:   a.AttrPrimary,
+			AttrSecondary: a.AttrSecondary,
+		})
+	}
+
+	return &model.KVPair{
+		Key: model.ResourceKey{
+			Name: name,
+			Kind: apiv3.KindIPAMBlock,
+		},
+		Value: &apiv3.IPAMBlock{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apiv3.KindIPAMBlock,
+				APIVersion: apiv3.GroupVersionCurrent,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				ResourceVersion: kvpv1.Revision,
+			},
+			Spec: apiv3.IPAMBlockSpec{
+				CIDR:           cidr,
+				Allocations:    ab.Allocations,
+				Unallocated:    ab.Unallocated,
+				Affinity:       ab.Affinity,
+				StrictAffinity: ab.StrictAffinity,
+				Attributes:     attrs,
+				Deleted:        ab.Deleted,
+			},
+		},
+		Revision: kvpv1.Revision,
+	}
+}
+
+// ToV1ListInterface takes a v3 list interface and converts it to v1 representation
+func (c IPAMBlockConverter) ToV1ListInterface(l model.ResourceListOptions) (model.ListInterface, error) {
+	if l.Kind != apiv3.KindIPAMBlock {
+		return nil, errors.New("passed wrong kind to IPAMBlockConverter")
+	}
+	if l.Name != "" {
+		return nil, errors.New("cannot list v3 IPAMBlock by name")
+	}
+	return model.BlockListOptions{
+		IPVersion: 0,
+	}, nil
+}
+
+// ToV1Key takes a v3 key and converts it to v1 representation
+func (c IPAMBlockConverter) ToV1Key(k model.Key) (model.Key, error) {
+	return nil, errors.New("cannot convert v3 IPAMBlock key to v1 key")
+}

--- a/lib/converter/ipam_config.go
+++ b/lib/converter/ipam_config.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+type IPAMConfigConverter struct{}
+
+// ToV1 converts the given v3 KVPair into a v1 model representation
+func (c IPAMConfigConverter) ToV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
+	v3obj := kvpv3.Value.(*apiv3.IPAMConfig)
+	return &model.KVPair{
+		Key: model.IPAMConfigKey{},
+		Value: &model.IPAMConfig{
+			StrictAffinity:     v3obj.Spec.StrictAffinity,
+			AutoAllocateBlocks: v3obj.Spec.AutoAllocateBlocks,
+		},
+		Revision: kvpv3.Revision,
+		UID:      &kvpv3.Value.(*apiv3.IPAMConfig).UID,
+	}, nil
+}
+
+// ToV3 takes the given v1 KVPair and converts it into a v3 representation.
+func (c IPAMConfigConverter) ToV3(kvpv1 *model.KVPair) *model.KVPair {
+	v1obj := kvpv1.Value.(*model.IPAMConfig)
+	return &model.KVPair{
+		Key: model.ResourceKey{
+			Name: model.IPAMConfigGlobalName,
+			Kind: apiv3.KindIPAMConfig,
+		},
+		Value: &apiv3.IPAMConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apiv3.KindIPAMConfig,
+				APIVersion: apiv3.GroupVersionCurrent,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            model.IPAMConfigGlobalName,
+				ResourceVersion: kvpv1.Revision,
+			},
+			Spec: apiv3.IPAMConfigSpec{
+				StrictAffinity:     v1obj.StrictAffinity,
+				AutoAllocateBlocks: v1obj.AutoAllocateBlocks,
+			},
+		},
+		Revision: kvpv1.Revision,
+	}
+}
+
+// ToV1ListInterface takes a v3 list interface and converts it to v1 representation
+func (c IPAMConfigConverter) ToV1ListInterface(l model.ResourceListOptions) (model.ListInterface, error) {
+	return nil, errors.New("cannot list v3 IPAMConfig")
+}
+
+// ToV1Key takes a v3 key and converts it to v1 representation
+func (c IPAMConfigConverter) ToV1Key(k model.Key) (model.Key, error) {
+	return model.IPAMConfigKey{}, nil
+}

--- a/lib/converter/ipam_handle.go
+++ b/lib/converter/ipam_handle.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"errors"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+type IPAMHandleConverter struct{}
+
+// ToV1 converts the given v3 KVPair into a v1 model representation
+func (c IPAMHandleConverter) ToV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
+	handle := kvpv3.Value.(*apiv3.IPAMHandle).Spec.HandleID
+	block := kvpv3.Value.(*apiv3.IPAMHandle).Spec.Block
+	return &model.KVPair{
+		Key: model.IPAMHandleKey{
+			HandleID: handle,
+		},
+		Value: &model.IPAMHandle{
+			HandleID: handle,
+			Block:    block,
+		},
+		Revision: kvpv3.Revision,
+	}, nil
+}
+
+// ParseKey parses the given model.Key, returning a suitable name, and CIDR
+// for use in the v3 API.
+func (c IPAMHandleConverter) ParseKey(k model.Key) string {
+	return strings.ToLower(k.(model.IPAMHandleKey).HandleID)
+}
+
+// ToV3 takes the given v1 KVPair and converts it into a v3 representation.
+func (c IPAMHandleConverter) ToV3(kvpv1 *model.KVPair) *model.KVPair {
+	name := c.ParseKey(kvpv1.Key)
+	handle := kvpv1.Key.(model.IPAMHandleKey).HandleID
+	block := kvpv1.Value.(*model.IPAMHandle).Block
+	return &model.KVPair{
+		Key: model.ResourceKey{
+			Name: name,
+			Kind: apiv3.KindIPAMHandle,
+		},
+		Value: &apiv3.IPAMHandle{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apiv3.KindIPAMHandle,
+				APIVersion: apiv3.GroupVersionCurrent,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				ResourceVersion: kvpv1.Revision,
+			},
+			Spec: apiv3.IPAMHandleSpec{
+				HandleID: handle,
+				Block:    block,
+			},
+		},
+		Revision: kvpv1.Revision,
+	}
+}
+
+// ToV1ListInterface takes a v3 list interface and converts it to v1 representation
+func (c IPAMHandleConverter) ToV1ListInterface(l model.ResourceListOptions) (model.ListInterface, error) {
+	if l.Kind != apiv3.KindIPAMHandle {
+		return nil, errors.New("passed wrong kind to IPAMHandleConverter")
+	}
+	if l.Name != "" {
+		return nil, errors.New("cannot list v3 IPAMHandle by name")
+	}
+	return model.IPAMHandleListOptions{}, nil
+}
+
+// ToV1Key takes a v3 key and converts it to v1 representation
+func (c IPAMHandleConverter) ToV1Key(k model.Key) (model.Key, error) {
+	return nil, errors.New("cannot convert v3 IPAMHandle key to v1 key")
+}


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Adds `LowLevelIPAM()` interface to the v3 client, which allows direct access to the backing IPAM objects. The primary purpose of this interface is import/export of IPAM data, and so the interface is limited to Create & List (or Create & Get in the case of IPAMConfig). etcdv3 datastore limitations make a full implementation tricky, so we just stick to what's needed for import/export.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
IPAM import / export functions on the v3 client & v3 API
```
