### PR TITLE
Add GlobalNetworkPolicy short name

### DIFF
--- a/test/crds.yaml
+++ b/test/crds.yaml
@@ -65,6 +65,8 @@ items:
       kind: GlobalNetworkPolicy
       plural: globalnetworkpolicies
       singular: globalnetworkpolicy
+      shortNames:
+      - gnp
 - apiVersion: apiextensions.k8s.io/v1beta1
   kind: CustomResourceDefinition
   metadata:


### PR DESCRIPTION
## Description
This PR introduces a short name for GlobalNetworkPolicy Custom Resource to keep CRD sync with Calico official.

## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/2651
related to: https://github.com/projectcalico/calico/pull/3436

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

```release-note
None required
```
