### PR TITLE
Don't rewrite the v3 policy protocol when converting it to v1

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -230,8 +230,9 @@ func parseServiceAccounts(sam *apiv3.ServiceAccountMatch) string {
 
 // convertV3ProtocolToV1 converts a v1 protocol string to a v3 protocol string
 func convertV3ProtocolToV1(p *numorstring.Protocol) *numorstring.Protocol {
-	if p != nil && p.Type == numorstring.NumOrStringString {
-		p.StrVal = strings.ToLower(p.String())
+	if p != nil {
+		v1P := p.ToV1()
+		return &v1P
 	}
 	return p
 }

--- a/lib/backend/syncersv1/updateprocessors/rules_test.go
+++ b/lib/backend/syncersv1/updateprocessors/rules_test.go
@@ -77,6 +77,12 @@ var _ = Describe("Test the Rules Conversion Functions", func() {
 		}
 		// Correct inbound rule
 		rulev1 := updateprocessors.RuleAPIV2ToBackend(irule, "namespace2")
+
+		// Assert we don't change the original protocol.
+		Expect(irule.Protocol.String()).To(Equal("TCP"))
+		Expect(irule.NotProtocol.String()).To(Equal("UDP"))
+
+		// Assert rule converted to v1 is correct
 		Expect(rulev1.Action).To(Equal("allow"))
 		Expect(rulev1.IPVersion).To(Equal(&v4))
 		Expect(rulev1.Protocol.StrVal).To(Equal("tcp"))

--- a/lib/backend/syncersv1/updateprocessors/shared_test.go
+++ b/lib/backend/syncersv1/updateprocessors/shared_test.go
@@ -21,16 +21,18 @@ var itype = 1
 var intype = 3
 var icode = 4
 var incode = 6
-var ProtocolTCP = numorstring.ProtocolFromString("tcp")
-var ProtocolUDP = numorstring.ProtocolFromString("udp")
+var ProtocolTCPV1 = numorstring.ProtocolFromStringV1("tcp")
+var ProtocolUDPV1 = numorstring.ProtocolFromStringV1("udp")
 var port80 = numorstring.SinglePort(uint16(80))
 var Port443 = numorstring.SinglePort(uint16(443))
+var ProtocolTCPv3 = numorstring.ProtocolFromString("TCP")
+var ProtocolUDPv3 = numorstring.ProtocolFromString("UDP")
 
 var v1TestIngressRule = model.Rule{
 	Action:      "allow",
 	IPVersion:   &v4,
-	Protocol:    &ProtocolTCP,
-	NotProtocol: &ProtocolUDP,
+	Protocol:    &ProtocolTCPV1,
+	NotProtocol: &ProtocolUDPV1,
 	ICMPType:    &itype,
 	ICMPCode:    &icode,
 	NotICMPType: &intype,
@@ -59,9 +61,9 @@ var v1TestIngressRule = model.Rule{
 var v3TestIngressRule = apiv3.Rule{
 	Action:      apiv3.Allow,
 	IPVersion:   &v4,
-	Protocol:    &ProtocolTCP,
+	Protocol:    &ProtocolTCPv3,
 	ICMP:        &apiv3.ICMPFields{Type: &itype, Code: &icode},
-	NotProtocol: &ProtocolUDP,
+	NotProtocol: &ProtocolUDPv3,
 	NotICMP:     &apiv3.ICMPFields{Type: &intype, Code: &incode},
 	Source: apiv3.EntityRule{
 		Nets:        []string{"10.100.10.1"},


### PR DESCRIPTION
## Description

We were accidentally rewriting the v3 policies protocol field. Instead, when converting to v1 always create a new `numstring.Protocol` containing the v1 protocol value from the v3 protocol

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
