### PR TITLE
Add global() selector 

### DIFF
--- a/lib/apis/v3/policy.go
+++ b/lib/apis/v3/policy.go
@@ -137,6 +137,9 @@ type EntityRule struct {
 	// For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
 	// only workload endpoints in the same namespace as the NetworkPolicy.
 	//
+	// For NetworkPolicy, `global` NamespaceSelector implies that the Selector is limited to selecting
+	// only GlobalNetworkSet or HostEndpoint.
+	//
 	// For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
 	// endpoints across all namespaces.
 	NamespaceSelector string `json:"namespaceSelector,omitempty" validate:"omitempty,selector"`

--- a/lib/apis/v3/policy.go
+++ b/lib/apis/v3/policy.go
@@ -137,7 +137,7 @@ type EntityRule struct {
 	// For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
 	// only workload endpoints in the same namespace as the NetworkPolicy.
 	//
-	// For NetworkPolicy, `global` NamespaceSelector implies that the Selector is limited to selecting
+	// For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
 	// only GlobalNetworkSet or HostEndpoint.
 	//
 	// For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload

--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -70,6 +70,11 @@ func getEndpointSelector(namespaceSelector, endpointSelector, serviceAccountSele
 		// all endpoints, translate this to an equivalent expression which means select any workload that
 		// is in a namespace.
 		nsSelector = strings.Replace(nsSelector, "all()", "has(projectcalico.org/namespace)", -1)
+
+		// We treat "global()" as opposite to `all()`, selects only host endpoints or GlobalNetworksets
+		// Since in the v1 data model "all()" will select all endpoints,
+		// translate this to an equivalent expressions which means select no workload endpoints
+		nsSelector = strings.Replace(nsSelector, "global()", "!has(projectcalico.org/namespace)", -1)
 	} else if ns != "" {
 		// No namespace selector was given and this is a namespaced network policy,
 		// so the rule applies only to its own namespace.

--- a/lib/selector/parser/ast.go
+++ b/lib/selector/parser/ast.go
@@ -429,3 +429,19 @@ func appendLabelOpAndQuotedString(fragments []string, label, op, s string) []str
 	}
 	return append(fragments, label, op, quote, s, quote)
 }
+
+type GlobalNode struct {
+}
+
+func (node *GlobalNode) Evaluate(labels Labels) bool {
+
+	return true
+}
+
+func (node *GlobalNode) AcceptVisitor(v Visitor) {
+	v.Visit(node)
+}
+
+func (node *GlobalNode) collectFragments(fragments []string) []string {
+	return append(fragments, "global()")
+}

--- a/lib/selector/parser/parser.go
+++ b/lib/selector/parser/parser.go
@@ -147,6 +147,9 @@ func parseOperation(tokens []tokenizer.Token) (sel node, remTokens []tokenizer.T
 	case tokenizer.TokAll:
 		sel = &AllNode{}
 		remTokens = tokens[1:]
+	case tokenizer.TokGlobal:
+		sel = &GlobalNode{}
+		remTokens = tokens[1:]
 	case tokenizer.TokLabel:
 		// should have an operator and a literal.
 		if len(tokens) < 3 {

--- a/lib/selector/parser/parser_test.go
+++ b/lib/selector/parser/parser_test.go
@@ -128,6 +128,9 @@ var selectorTests = []selectorTest{
 	{`all()`, []map[string]string{{}}, []map[string]string{}},
 	{` all()`, []map[string]string{{}}, []map[string]string{}},
 	{` all()`, []map[string]string{{"a": "b"}}, []map[string]string{}},
+	{`global()`, []map[string]string{{}}, []map[string]string{}},
+	{` global()`, []map[string]string{{}}, []map[string]string{}},
+	{` global()`, []map[string]string{{"a": "b"}}, []map[string]string{}},
 
 	{`a == 'a'`, []map[string]string{}, []map[string]string{{"a": "b"}}},
 	{`a == 'a'`, []map[string]string{}, []map[string]string{{}}},

--- a/lib/selector/tokenizer/tokenizer.go
+++ b/lib/selector/tokenizer/tokenizer.go
@@ -46,6 +46,7 @@ const (
 	TokRParen
 	TokAnd
 	TokOr
+	TokGlobal
 	TokEOF
 )
 
@@ -66,6 +67,7 @@ const (
 	allExpr         = `all\(\s*\)`
 	notInExpr       = `not\s*in\b`
 	inExpr          = `in\b`
+	globalExpr      = `global\(\s*\)`
 )
 
 var (
@@ -77,6 +79,7 @@ var (
 	allRegex        = regexp.MustCompile("^" + allExpr)
 	notInRegex      = regexp.MustCompile("^" + notInExpr)
 	inRegex         = regexp.MustCompile("^" + inExpr)
+	globalRegex     = regexp.MustCompile("^" + globalExpr)
 )
 
 // Tokenize transforms string to token slice
@@ -198,6 +201,10 @@ func Tokenize(input string) (tokens []Token, err error) {
 			} else if idxs := allRegex.FindStringIndex(input); idxs != nil {
 				// Found "all"
 				tokens = append(tokens, Token{TokAll, nil})
+				input = input[idxs[1]:]
+			} else if idxs := globalRegex.FindStringIndex(input); idxs != nil {
+				// Found "global"
+				tokens = append(tokens, Token{TokGlobal, nil})
 				input = input[idxs[1]:]
 			} else if idxs := identifierRegex.FindStringIndex(input); idxs != nil {
 				// Found "label"

--- a/lib/selector/tokenizer/tokenizer_test.go
+++ b/lib/selector/tokenizer/tokenizer_test.go
@@ -207,6 +207,14 @@ var tokenTests = []struct {
 		{tokenizer.TokRBrace, nil},
 		{tokenizer.TokEOF, nil},
 	}},
+	{`global()`, []tokenizer.Token{
+		{tokenizer.TokGlobal, nil},
+		{tokenizer.TokEOF, nil},
+	}},
+	{`all()`, []tokenizer.Token{
+		{tokenizer.TokAll, nil},
+		{tokenizer.TokEOF, nil},
+	}},
 }
 
 var _ = Describe("Token", func() {

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -94,7 +94,7 @@ var (
 	protocolPortsMsg      = "rules that specify ports must set protocol to TCP or UDP or SCTP"
 	protocolIcmpMsg       = "rules that specify ICMP fields must set protocol to ICMP"
 	protocolAndHTTPMsg    = "rules that specify HTTP fields must set protocol to TCP or empty"
-	globalSelectorMsg     = fmt.Sprintf("%v can only be used in an EntityRule namespaceSelector", globalSelector)
+	globalSelectorEntRule = fmt.Sprintf("%v can only be used in an EntityRule namespaceSelector", globalSelector)
 	globalSelectorOnly    = fmt.Sprintf("%v cannot be combined with other selectors", globalSelector)
 	namespaceSelectorOnly = fmt.Sprintf("%v cannot be combined with other selectors", conversion.NameLabel)
 
@@ -963,7 +963,7 @@ func validateEntityRule(structLevel validator.StructLevel) {
 	rule := structLevel.Current().Interface().(api.EntityRule)
 	if strings.Contains(rule.Selector, globalSelector) {
 		structLevel.ReportError(reflect.ValueOf(rule.Selector),
-			"Selector field", "", reason(globalSelectorMsg), "")
+			"Selector field", "", reason(globalSelectorEntRule), "")
 	}
 
 	// Get the parsed and canonicalised string of the namespaceSelector
@@ -1130,7 +1130,7 @@ func validateNetworkPolicy(structLevel validator.StructLevel) {
 			reflect.ValueOf(spec.Selector),
 			"NetworkPolicySpec.Selector",
 			"",
-			reason(fmt.Sprintf("%s can only be used in a GlobalNetworkPolicy EntityRule", globalSelector)),
+			reason(globalSelectorEntRule),
 			"")
 	}
 
@@ -1139,7 +1139,7 @@ func validateNetworkPolicy(structLevel validator.StructLevel) {
 			reflect.ValueOf(spec.ServiceAccountSelector),
 			"NetworkPolicySpec.ServiceAccountSelector",
 			"",
-			reason(fmt.Sprintf("%s can only be used in GlobalNetworkPolicy EntityRule", globalSelector)),
+			reason(globalSelectorEntRule),
 			"")
 	}
 }
@@ -1260,7 +1260,7 @@ func validateGlobalNetworkPolicy(structLevel validator.StructLevel) {
 			reflect.ValueOf(spec.Selector),
 			"GlobalNetworkPolicySpec.Selector",
 			"",
-			reason(fmt.Sprintf("%s can only be used in EntityRule", globalSelector)),
+			reason(globalSelectorEntRule),
 			"")
 	}
 
@@ -1269,7 +1269,7 @@ func validateGlobalNetworkPolicy(structLevel validator.StructLevel) {
 			reflect.ValueOf(spec.Selector),
 			"GlobalNetworkPolicySpec.ServiceAccountSelector",
 			"",
-			reason(fmt.Sprintf("%s can only be used in EntityRule", globalSelector)),
+			reason(globalSelectorEntRule),
 			"")
 	}
 
@@ -1278,7 +1278,7 @@ func validateGlobalNetworkPolicy(structLevel validator.StructLevel) {
 			reflect.ValueOf(spec.Selector),
 			"GlobalNetworkPolicySpec.NamespaceSelector",
 			"",
-			reason(fmt.Sprintf("%s can only be used in EntityRule", globalSelector)),
+			reason(globalSelectorEntRule),
 			"")
 	}
 }

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1856,8 +1856,7 @@ func init() {
 				},
 			}, true,
 		),
-		// Validate EntityRule against special selectors global() and
-		// projectcalico.org/name.
+		// Validate EntityRule against special selectors global().
 		// Extra spaces added in some cases to make sure validation handles it.
 		Entry("disallow global() in EntityRule selector field",
 			&api.EntityRule{
@@ -1879,29 +1878,9 @@ func init() {
 				NamespaceSelector: "global()||all()",
 			}, false,
 		),
-		Entry("allow projectcalico.org/name in EntityRule namespaceSelector field",
-			&api.EntityRule{
-				NamespaceSelector: "projectcalico.org/name=='test' ",
-			}, true,
-		),
-		Entry("disallow projectcalico.org/name in EntityRule namespaceSelector field AND'd with other expressions",
-			&api.EntityRule{
-				NamespaceSelector: "   projectcalico.org/name=='test' && all() ",
-			}, false,
-		),
-		Entry("disallow projectcalico.org/name in EntityRule namespaceSelector field OR'd other expressions",
-			&api.EntityRule{
-				NamespaceSelector: "   projectcalico.org/name=='test' || all() ",
-			}, false,
-		),
 		Entry("disallow bad selectors in EntityRule selector field",
 			&api.EntityRule{
 				Selector: "global() && bad",
-			}, false,
-		),
-		Entry("disallow bad selectors in EntityRule namespaceSelector field",
-			&api.EntityRule{
-				Selector: "projectcalico.org/name == 'test' || bad",
 			}, false,
 		),
 		Entry("allow HTTP Path with permitted match clauses",

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1658,6 +1658,21 @@ func init() {
 				},
 			}, false,
 		),
+		Entry("disallow global() in EntityRule selector field",
+			&api.GlobalNetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.GlobalNetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Source: api.EntityRule{
+								Selector: "global()",
+							},
+						},
+					},
+				},
+			}, false,
+		),
 		Entry("allow global() in EntityRule namespaceSelector field",
 			&api.GlobalNetworkPolicy{
 				ObjectMeta: v1.ObjectMeta{Name: "thing"},
@@ -1666,6 +1681,9 @@ func init() {
 						{
 							Action: "Allow",
 							Source: api.EntityRule{
+								NamespaceSelector: "global()",
+							},
+							Destination: api.EntityRule{
 								NamespaceSelector: "global()",
 							},
 						},

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1634,6 +1634,45 @@ func init() {
 				},
 			}, false,
 		),
+		Entry("disallow global() in namespaceSelector field",
+			&api.GlobalNetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.GlobalNetworkPolicySpec{
+					NamespaceSelector: "global()",
+				},
+			}, false,
+		),
+		Entry("disallow global() in selector field",
+			&api.GlobalNetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.GlobalNetworkPolicySpec{
+					Selector: "global()",
+				},
+			}, false,
+		),
+		Entry("disallow global() in serviceAccountSelector field",
+			&api.GlobalNetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.GlobalNetworkPolicySpec{
+					ServiceAccountSelector: "global()",
+				},
+			}, false,
+		),
+		Entry("allow global() in EntityRule namespaceSelector field",
+			&api.GlobalNetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.GlobalNetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Source: api.EntityRule{
+								NamespaceSelector: "global()",
+							},
+						},
+					},
+				},
+			}, true,
+		),
 
 		// NetworkPolicySpec Types field checks.
 		Entry("allow valid name", &api.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "thing"}}, true),
@@ -1765,6 +1804,23 @@ func init() {
 				},
 			}, false,
 		),
+		Entry("disallow global() in selector field",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Selector: "global()",
+				},
+			}, false,
+		),
+		Entry("disallow global() in serviceAccountSelector field",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					ServiceAccountSelector: "global()",
+				},
+			}, false,
+		),
+
 		Entry("allow HTTP Path with permitted match clauses",
 			&api.HTTPMatch{Paths: []api.HTTPPath{{Exact: "/foo"}, {Prefix: "/bar"}}},
 			true,


### PR DESCRIPTION
## Description

This PR adds support for the `global()` keyword
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Network policy now has the global() namespace selector which selects host endpoints or global network sets
```
