### PR TITLE
Fix typos

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -475,7 +475,7 @@ All of these properties are optional but some have dependencies (such as
 requiring the protocol to be specified):
 
 `protocol`: if present, restricts the rule to only apply to traffic of a
-specific IP protocol. Required if `*_ports` is used (becuase ports
+specific IP protocol. Required if `*_ports` is used (because ports
 only apply to certain protocols).
 
     Must be one of these string values: `"tcp"`, `"udp"`, `"icmp"`,

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -196,13 +196,13 @@ type FelixConfigurationSpec struct {
 	PrometheusProcessMetricsEnabled *bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 
 	// FailsafeInboundHostPorts is a comma-delimited list of UDP/TCP ports that Felix will allow incoming traffic to host endpoints
-	// on irrespective of the security policy. This is useful to avoid accidently cutting off a host with incorrect configuration. Each
+	// on irrespective of the security policy. This is useful to avoid accidentally cutting off a host with incorrect configuration. Each
 	// port should be specified as tcp:<port-number> or udp:<port-number>. For back-compatibility, if the protocol is not specified, it
 	// defaults to “tcp”. To disable all inbound host ports, use the value none. The default value allows ssh access and DHCP.
 	// [Default: tcp:22, udp:68]
 	FailsafeInboundHostPorts *[]ProtoPort `json:"failsafeInboundHostPorts,omitempty"`
 	// FailsafeOutboundHostPorts is a comma-delimited list of UDP/TCP ports that Felix will allow outgoing traffic from host endpoints to
-	// irrespective of the security policy. This is useful to avoid accidently cutting off a host with incorrect configuration. Each port
+	// irrespective of the security policy. This is useful to avoid accidentally cutting off a host with incorrect configuration. Each port
 	// should be specified as tcp:<port-number> or udp:<port-number>. For back-compatibility, if the protocol is not specified, it defaults
 	// to “tcp”. To disable all outbound host ports, use the value none. The default value opens etcd’s standard ports to ensure that Felix
 	// does not get cut off from etcd as well as allowing DHCP and DNS. [Default: tcp:2379, tcp:2380, tcp:4001, tcp:7001, udp:53, udp:67]
@@ -303,7 +303,7 @@ type FelixConfigurationSpec struct {
 
 	// RouteSource configures where Felix gets its routing information.
 	// - WorkloadIPs: use workload endpoints to construct routes.
-	// - CalicoIPAM: the default - use IPAM data to contruct routes.
+	// - CalicoIPAM: the default - use IPAM data to construct routes.
 	RouteSource string `json:"routeSource,omitempty" validate:"omitempty,routeSource"`
 
 	// Calico programs additional Linux route tables for various purposes.  RouteTableRange

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -376,7 +376,7 @@ func (c *ModelAdaptor) listNodes(ctx context.Context, l model.NodeListOptions) (
 }
 
 // listBlock returns list of KVPairs for Block, includes making sure
-// backwards compatiblity. See getBlock for more details.
+// backwards compatibility. See getBlock for more details.
 func (c *ModelAdaptor) listBlock(ctx context.Context, l model.BlockListOptions) (*model.KVPairList, error) {
 
 	// Get a list of block KVPairs.

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -647,7 +647,7 @@ type watcherDeletion struct {
 
 // snapshotRequest is sent by the merge thread to the snapshot thread when a new snapshot
 // is required.  Thread safety: the merge thead should only send this message when the
-// snapshot thread is quiesced, I.e. after it receives teh snapshotFinished message from
+// snapshot thread is quiesced, I.e. after it receives the snapshotFinished message from
 // the previous snapshot.
 type snapshotRequest struct {
 	minRequiredSnapshotIndex uint64

--- a/lib/backend/etcdv3/etcdv3.go
+++ b/lib/backend/etcdv3/etcdv3.go
@@ -79,9 +79,9 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 	}
 
 	// Create the etcd client
-	// If Etcd Certificate and Key are provided inline through command line agrument,
+	// If Etcd Certificate and Key are provided inline through command line argument,
 	// then the inline values take precedence over the ones in the config file.
-	// All the three parametes, Certificate, key and CA certificate are to be provided inline for processing.
+	// All the three parameters, Certificate, key and CA certificate are to be provided inline for processing.
 	var tls *tls.Config
 	var err error
 

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -166,7 +166,7 @@ func (c cb) OnUpdates(updates []api.Update) {
 			log.Infof("[TEST] Syncer received deleted: %+v", u)
 			Expect(u.Value).To(BeNil())
 		case api.UpdateTypeKVUnknown:
-			panic(fmt.Sprintf("[TEST] Syncer received unkown update: %+v", u))
+			panic(fmt.Sprintf("[TEST] Syncer received unknown update: %+v", u))
 		}
 
 		// Send the update to a goroutine which will process it.

--- a/lib/backend/k8s/resources/networkpolicy.go
+++ b/lib/backend/k8s/resources/networkpolicy.go
@@ -301,7 +301,7 @@ func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterfac
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
 
-	// Setting to Watch all networkPolicies in all namespaces; overriden below
+	// Setting to Watch all networkPolicies in all namespaces; overridden below
 	watchK8s, watchCrd := true, true
 
 	// Watch a specific networkPolicy

--- a/lib/backend/k8s/resources/profile.go
+++ b/lib/backend/k8s/resources/profile.go
@@ -239,7 +239,7 @@ func (c *profileClient) Watch(ctx context.Context, list model.ListInterface, rev
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
 
-	// Setting to Watch all profiles in all namespaces; overriden below
+	// Setting to Watch all profiles in all namespaces; overridden below
 	watchNS, watchSA := true, true
 	ns := kapiv1.NamespaceAll
 	sa := ""

--- a/lib/backend/k8s/resources/resources.go
+++ b/lib/backend/k8s/resources/resources.go
@@ -42,7 +42,7 @@ type ResourceList interface {
 	metav1.ListMetaAccessor
 }
 
-// Function signature for conversion function to convert a K8s resouce to a
+// Function signature for conversion function to convert a K8s resource to a
 // KVPair equivalent.
 type ConvertK8sResourceToKVPair func(Resource) (*model.KVPair, error)
 type ConvertK8sResourceToKVPairs func(Resource) ([]*model.KVPair, error)

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -188,7 +188,7 @@ kind: notCalicoApiConfig
 		},
 	}
 
-	// Environments to test ETCD SRV paramater
+	// Environments to test ETCD SRV parameter
 	env5 := map[string]string{
 		"APIV1_ETCD_DISCOVERY_SRV": "example.com",
 	}

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -135,7 +135,7 @@ func (e ErrorResourceUpdateConflict) Error() string {
 
 // Error indicating that the operation may have partially succeeded, then
 // failed, without rolling back. A common example is when a function failed
-// in an acceptable way after it succesfully wrote some data to the datastore.
+// in an acceptable way after it successfully wrote some data to the datastore.
 type ErrorPartialFailure struct {
 	Err error
 }

--- a/lib/health/health.go
+++ b/lib/health/health.go
@@ -204,12 +204,12 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 const (
 	// The HTTP status that we use for 'ready' or 'live'.  204 means "No Content: The server
 	// successfully processed the request and is not returning any content."  (Kubernetes
-	// interpets any 200<=status<400 as 'good'.)
+	// interprets any 200<=status<400 as 'good'.)
 	StatusGood = 204
 
 	// The HTTP status that we use for 'not ready' or 'not live'.  503 means "Service
 	// Unavailable: The server is currently unavailable (because it is overloaded or down for
-	// maintenance). Generally, this is a temporary state."  (Kubernetes interpets any
+	// maintenance). Generally, this is a temporary state."  (Kubernetes interprets any
 	// status>=400 as 'bad'.)
 	StatusBad = 503
 )

--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -255,7 +255,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, host strin
 	// Make sure hostname is not empty.
 	if host == "" {
 		log.Errorf("Hostname can't be empty")
-		return errors.New("Hostname must be sepcified to release block affinity")
+		return errors.New("Hostname must be specified to release block affinity")
 	}
 
 	// Read the model.KVPair containing the block affinity.

--- a/lib/upgrade/migrator/clients/v1/compat/compat.go
+++ b/lib/upgrade/migrator/clients/v1/compat/compat.go
@@ -192,7 +192,7 @@ func (c *ModelAdaptor) listNodes(l model.NodeListOptions) ([]*model.KVPair, erro
 }
 
 // listBlock returns list of KVPairs for Block, includes making sure
-// backwards compatiblity. See getBlock for more details.
+// backwards compatibility. See getBlock for more details.
 func (c *ModelAdaptor) listBlock(l model.BlockListOptions) ([]*model.KVPair, error) {
 
 	// Get a list of block KVPairs.
@@ -353,7 +353,7 @@ func toDatastoreGlobalBGPConfigKey(key model.GlobalBGPConfigKey) model.GlobalBGP
 }
 
 // toDatastoreGlobalBGPConfigList modifies the Global BGP Config List interface to the one required by
-// the datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+// the datastore (for back-compatibility with what is expected in the etcdv2 datastore driver).
 func toDatastoreGlobalBGPConfigList(l model.GlobalBGPConfigListOptions) model.GlobalBGPConfigListOptions {
 	switch l.Name {
 	case "AsNumber":
@@ -367,7 +367,7 @@ func toDatastoreGlobalBGPConfigList(l model.GlobalBGPConfigListOptions) model.Gl
 }
 
 // fromDatastoreGlobalBGPKey modifies the Global BGP Config key from the one required by
-// the datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+// the datastore (for back-compatibility with what is expected in the etcdv2 datastore driver).
 func fromDatastoreGlobalBGPKey(key model.GlobalBGPConfigKey) model.GlobalBGPConfigKey {
 	switch key.Name {
 	case "as_num":
@@ -381,7 +381,7 @@ func fromDatastoreGlobalBGPKey(key model.GlobalBGPConfigKey) model.GlobalBGPConf
 }
 
 // fromDatastoreGlobalBGPConfig modifies the Global BGP Config KVPair from the format required in the
-// datastore (for back-compatibility with what is expected in teh etcdv2 datastore driver).
+// datastore (for back-compatibility with what is expected in the etcdv2 datastore driver).
 func fromDatastoreGlobalBGPConfig(d model.KVPair) *model.KVPair {
 	modifiedKey := fromDatastoreGlobalBGPKey(d.Key.(model.GlobalBGPConfigKey))
 	d.Key = modifiedKey

--- a/lib/upgrade/migrator/migrate.go
+++ b/lib/upgrade/migrator/migrate.go
@@ -1012,7 +1012,7 @@ func (m *migrationHelper) storeV3Resources(data *MigrationData) error {
 	m.statusBullet("Storing resources in v3 format")
 	for n, r := range data.Resources {
 		// Convert the resource to a KVPair and access the backend datastore directly.
-		// This is slightly more efficient, and cuts out some of the unneccessary additional
+		// This is slightly more efficient, and cuts out some of the unnecessary additional
 		// processing. Since we are applying directly to the backend we need to set the UUID
 		// and creation timestamp which is normally handled by clientv3.
 		r = toStorage(r)

--- a/lib/upgrade/migrator/migrate_test.go
+++ b/lib/upgrade/migrator/migrate_test.go
@@ -210,7 +210,7 @@ var _ = testutils.E2eDatastoreDescribe("Migration tests", testutils.DatastoreEtc
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// Create the dummy v1 client, if necesary including the v1 cluster version.
+			// Create the dummy v1 client, if necessary including the v1 cluster version.
 			By("Configuring a cluster version in the v1 datastore")
 			v1Client := fakeClientV1{}
 			if v1Version != nil {


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 1 typo in `docs/data-model.md`
- 3 typos in `lib/apis/v3/felixconfig.go`
- 1 typo in `lib/backend/compat/compat.go`
- 1 typo in `lib/backend/etcd/syncer.go`
- 2 typos in `lib/backend/etcdv3/etcdv3.go`
- 1 typo in `lib/backend/k8s/k8s_test.go`
- 1 typo in `lib/backend/k8s/resources/networkpolicy.go`
- 1 typo in `lib/backend/k8s/resources/profile.go`
- 1 typo in `lib/backend/k8s/resources/resources.go`
- 1 typo in `lib/client/client_test.go`
- 1 typo in `lib/errors/errors.go`
- 2 typos in `lib/health/health.go`
- 1 typo in `lib/ipam/ipam_block_reader_writer.go`
- 4 typos in `lib/upgrade/migrator/clients/v1/compat/compat.go`
- 1 typo in `lib/upgrade/migrator/migrate.go`
- 1 typo in `lib/upgrade/migrator/migrate_test.go`



Cheers! :robot: