### PR TITLE
Add json tags to IPAM Block keys and Block Affinity keys

### DIFF
--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -43,7 +43,7 @@ var (
 )
 
 type BlockKey struct {
-	CIDR net.IPNet `json:"-" validate:"required,name"`
+	CIDR net.IPNet `json:"cidr" validate:"required,name"`
 }
 
 func (key BlockKey) defaultPath() (string, error) {

--- a/lib/backend/model/block_affinity.go
+++ b/lib/backend/model/block_affinity.go
@@ -40,8 +40,8 @@ const (
 )
 
 type BlockAffinityKey struct {
-	CIDR net.IPNet `json:"-" validate:"required,name"`
-	Host string    `json:"-"`
+	CIDR net.IPNet `json:"cidr" validate:"required,name"`
+	Host string    `json:"host"`
 }
 
 type BlockAffinity struct {


### PR DESCRIPTION
## Description
Adds json tags to IPAM block keys, block affinity keys, handle keys, and handles. This is intended to help simplify the serialization of IPAM objects for datastore migration.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
