### PR TITLE
Properly set deleted on block affinities

### DIFF
--- a/config/crd/crd.projectcalico.org_blockaffinities.yaml
+++ b/config/crd/crd.projectcalico.org_blockaffinities.yaml
@@ -39,6 +39,9 @@ spec:
               cidr:
                 type: string
               deleted:
+                description: Deleted indicates that this block affinity is being deleted.
+                  This field is a string for compatibility with older releases that
+                  mistakenly treat this field as a string.
                 type: string
               node:
                 type: string

--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -155,7 +155,7 @@ spec:
                   For back-compatibility, if the protocol is not specified, it defaults
                   to “tcp”. To disable all inbound host ports, use the value none.
                   The default value allows ssh access and DHCP. [Default: tcp:22,
-                  udp:68]'
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
                 items:
                   description: ProtoPort is combination of protocol and port, both
                     must be specified.
@@ -179,7 +179,8 @@ spec:
                   to “tcp”. To disable all outbound host ports, use the value none.
                   The default value opens etcd’s standard ports to ensure that Felix
                   does not get cut off from etcd as well as allowing DHCP and DNS.
-                  [Default: tcp:2379, tcp:2380, tcp:4001, tcp:7001, udp:53, udp:67]'
+                  [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
+                  udp:53, udp:67]'
                 items:
                   description: ProtoPort is combination of protocol and port, both
                     must be specified.

--- a/lib/apis/v3/blockaffinity.go
+++ b/lib/apis/v3/blockaffinity.go
@@ -37,9 +37,13 @@ type BlockAffinity struct {
 
 // BlockAffinitySpec contains the specification for a BlockAffinity resource.
 type BlockAffinitySpec struct {
-	State   string `json:"state"`
-	Node    string `json:"node"`
-	CIDR    string `json:"cidr"`
+	State string `json:"state"`
+	Node  string `json:"node"`
+	CIDR  string `json:"cidr"`
+
+	// Deleted indicates that this block affinity is being deleted.
+	// This field is a string for compatibility with older releases that
+	// mistakenly treat this field as a string.
 	Deleted string `json:"deleted"`
 }
 

--- a/lib/backend/k8s/resources/ipam_affinity_test.go
+++ b/lib/backend/k8s/resources/ipam_affinity_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+var _ = testutils.E2eDatastoreDescribe("IPAM affinity k8s backend tests", testutils.DatastoreK8s, func(config apiconfig.CalicoAPIConfig) {
+	It("should properly handle the deleted flag", func() {
+		be, err := backend.NewClient(config)
+		Expect(err).NotTo(HaveOccurred())
+		be.Clean()
+
+		// Create a new block affinity.
+		kvp := model.KVPair{
+			Key: model.BlockAffinityKey{
+				Host: "my-host",
+				CIDR: net.MustParseCIDR("192.168.1.0/24"),
+			},
+			Value: &model.BlockAffinity{
+				State:   model.StateConfirmed,
+				Deleted: false,
+			},
+		}
+		_, err = be.Create(context.Background(), &kvp)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that it can be seen.
+		newKVP, err := be.Get(context.Background(), kvp.Key, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Update it to be deleted.
+		newKVP.Value.(*model.BlockAffinity).Deleted = true
+		_, err = be.Update(context.Background(), newKVP)
+
+		// Can no longer see it.
+		_, err = be.Get(context.Background(), kvp.Key, "")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(BeAssignableToTypeOf(errors.ErrorResourceDoesNotExist{}))
+	})
+})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We use a "deleted" flag on IPAM resources in KDD to help defend against race conditions where the object might be re-created. We do an Update() first to set the bit and invalidate other operations, and then other clients know to ignore it if it has the deleted flag set.

However, we weren't actually setting the deleted flag on block affinities!

This also changes the schema to a bool instead of a string to match blocks, which I think is maybe OK since this field isn't actually getting set today. However, it does mean that older clients (CNI plugins, etc) won't be able to write to this IPAM affinity API onces the new CRDs are applied (i.e., you'll need a new CNI plugin to match the new CRDs) since the schema will have changed. This does leave a small gap during rolling update from <=v3.14 to > v3.14, where old CNI plugins won't be able to allocate new block affinities, but I think that is probably acceptable. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race condition during block affinity deletion
```