### PR TITLE
Handle backend watch, if upstream closes channel[ClosedByRemote] 

### DIFF
--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -178,7 +178,6 @@ type WatchInterface interface {
 
 	// Returns a chan which will receive all the events.  This channel is closed when:
 	// -  Stop() is called, or
-	// -  An error of type errors.ErrorWatchTerminated is received.
 	// In both cases the watcher will be cleaned up, and the client should stop receiving
 	// from this channel.
 	ResultChan() <-chan WatchEvent


### PR DESCRIPTION
This PR handles following things.

If upstream Kubernetes API server closes watch the channel with backend libcalico-go, then stop the backend channels connected downstream and don't send any "ErrorTerminated" events back to downstream channels.

If upstream Kubernetes API server, sends Api.WatchError to backend libcalico-go, wrap this status change as an "ApiError" to downstream. Downstream will resync the channel.

Local Unit test passed.