### PR TITLE
Don't need to query blocks individually to see if they exist

### DIFF
--- a/lib/ipam/ipam_block_reader_writer.go
+++ b/lib/ipam/ipam_block_reader_writer.go
@@ -98,6 +98,19 @@ func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string,
 		return nil, fmt.Errorf("no configured Calico pools for node %s", host)
 	}
 
+	// List blocks up front to reduce number of queries.
+	// We will try to write the block later to prevent races.
+	existingBlocks, err := rw.listBlocks(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	/// Build a map for faster lookups.
+	exists := map[string]bool{}
+	for _, e := range existingBlocks.KVPairs {
+		exists[e.Key.(model.BlockKey).CIDR.String()] = true
+	}
+
 	// Iterate through pools to find a new block.
 	for _, pool := range pools {
 		// Use a block generator to iterate through all of the blocks
@@ -107,14 +120,9 @@ func (rw blockReaderWriter) findUnclaimedBlock(ctx context.Context, host string,
 		for subnet := blocks(); subnet != nil; subnet = blocks() {
 			// Check if a block already exists for this subnet.
 			log.Debugf("Getting block: %s", subnet.String())
-			_, err := rw.queryBlock(ctx, *subnet, "")
-			if err != nil {
-				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
-					log.Infof("Found free block: %+v", *subnet)
-					return subnet, nil
-				}
-				log.Errorf("Error getting block: %v", err)
-				return nil, err
+			if _, ok := exists[subnet.String()]; !ok {
+				log.Infof("Found free block: %+v", *subnet)
+				return subnet, nil
 			}
 			log.Debugf("Block %s already exists", subnet.String())
 		}
@@ -360,6 +368,10 @@ func (rw blockReaderWriter) deleteAffinity(ctx context.Context, aff *model.KVPai
 // queryBlock gets a block for the given block CIDR key.
 func (rw blockReaderWriter) queryBlock(ctx context.Context, blockCIDR cnet.IPNet, revision string) (*model.KVPair, error) {
 	return rw.client.Get(ctx, model.BlockKey{CIDR: blockCIDR}, revision)
+}
+
+func (rw blockReaderWriter) listBlocks(ctx context.Context, revision string) (*model.KVPairList, error) {
+	return rw.client.List(ctx, model.BlockListOptions{}, revision)
 }
 
 // updateBlock updates the given block.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

An attempt to fix https://github.com/projectcalico/libcalico-go/issues/1236

I don't think we need to query each block - we write the block later to catch race conditions - in fact, we needed to handle this race condition already anyway, since two clients can pick the same CIDR and then try to claim that block even with the existing code.

This means we'll do substantially fewer datastore queries in scenarios where most of the blocks have already been taken. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Speed up allocation of new IPAM blocks when most blocks are already in-use.
```