### PR TITLE
Revert config change for AWS EC2 src-dst-check

### DIFF
--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -36,15 +36,6 @@ spec:
           spec:
             description: FelixConfigurationSpec contains the values of the Felix configuration.
             properties:
-              awsSrcDstCheck:
-                description: 'Set source-destination-check on AWS EC2 instances. Accepted
-                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
-                  DoNothing]'
-                enum:
-                - DoNothing
-                - Enable
-                - Disable
-                type: string
               bpfConnectTimeLoadBalancingEnabled:
                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
                   controls whether Felix installs the connection-time load balancer.  The

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -29,15 +29,6 @@ const (
 	IptablesBackendNFTables    = "NFT"
 )
 
-// +kubebuilder:validation:Enum=DoNothing;Enable;Disable
-type AWSSrcDstCheckOption string
-
-const (
-	AWSSrcDstCheckOptionDoNothing AWSSrcDstCheckOption = "DoNothing"
-	AWSSrcDstCheckOptionEnable                         = "Enable"
-	AWSSrcDstCheckOptionDisable                        = "Disable"
-)
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -333,10 +324,6 @@ type FelixConfigurationSpec struct {
 	WireguardInterfaceName string `json:"wireguardInterfaceName,omitempty" validate:"omitempty,interface"`
 	// WireguardMTU controls the MTU on the Wireguard interface. See Configuring MTU [Default: 1420]
 	WireguardMTU *int `json:"wireguardMTU,omitempty"`
-
-	// Set source-destination-check on AWS EC2 instances. Accepted value must be one of "DoNothing", "Enabled" or "Disabled".
-	// [Default: DoNothing]
-	AWSSrcDstCheck *AWSSrcDstCheckOption `json:"awsSrcDstCheck,omitempty" validate:"omitempty,oneof=DoNothing Enable Disable"`
 }
 
 type RouteTableRange struct {

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -871,11 +871,6 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(int)
 		**out = **in
 	}
-	if in.AWSSrcDstCheck != nil {
-		in, out := &in.AWSSrcDstCheck, &out.AWSSrcDstCheck
-		*out = new(AWSSrcDstCheckOption)
-		**out = **in
-	}
 	return
 }
 

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 86
+	numFelixConfigs := 85
 	numClusterConfigs := 5
 	numNodeClusterConfigs := 4
 	numBgpConfigs := 5

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -66,15 +66,6 @@ func init() {
 	validWireguardPortOrRulePriority := 12345
 	invalidWireguardPortOrRulePriority := 99999
 
-	var awsCheckEnable, awsCheckDisable, awsCheckDoNothing,
-		awsCheckbadVal, awsCheckenable api.AWSSrcDstCheckOption
-
-	awsCheckEnable = api.AWSSrcDstCheckOptionEnable
-	awsCheckDisable = api.AWSSrcDstCheckOptionDisable
-	awsCheckDoNothing = api.AWSSrcDstCheckOptionDoNothing
-	awsCheckbadVal = api.AWSSrcDstCheckOption("badVal")
-	awsCheckenable = api.AWSSrcDstCheckOption("enable")
-
 	// longLabelsValue is 63 and 64 chars long
 	maxAnnotationsLength := 256 * (1 << 10)
 	longValue := make([]byte, maxAnnotationsLength)
@@ -1371,13 +1362,6 @@ func init() {
 		Entry("should reject invalid Wireguard public-key", api.NodeStatus{
 			WireguardPublicKey: "foobar",
 		}, false),
-
-		// AWS source-destination-check.
-		Entry("should accept a valid AWSSrcDstCheck value 'DoNothing'", api.FelixConfigurationSpec{AWSSrcDstCheck: &awsCheckDoNothing}, true),
-		Entry("should accept a valid AWSSrcDstCheck value 'Enable'", api.FelixConfigurationSpec{AWSSrcDstCheck: &awsCheckEnable}, true),
-		Entry("should accept a valid AWSSrcDstCheck value 'Disable'", api.FelixConfigurationSpec{AWSSrcDstCheck: &awsCheckDisable}, true),
-		Entry("should reject an invalid AWSSrcDstCheck value 'enable'", api.FelixConfigurationSpec{AWSSrcDstCheck: &awsCheckenable}, false),
-		Entry("should reject an invalid AWSSrcDstCheck value 'badVal'", api.FelixConfigurationSpec{AWSSrcDstCheck: &awsCheckbadVal}, false),
 
 		// GlobalNetworkPolicy validation.
 		Entry("disallow name with invalid character", &api.GlobalNetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "t~!s.h.i.ng"}}, false),


### PR DESCRIPTION
## Description

Revert config change for AWS EC2 src-dst-check

With [Felix PR 2381](https://github.com/projectcalico/felix/pull/2381) waiting for review, config changes need to backed out from v3.15 branch.

## Todos
- [ ] Back-out CRDs from Doc repo
- [x] Release note

## Release Note
```release-note
Backing out -- Added configuration for setting source-destination-check value on AWS EC2 instances.
```
