### PR TITLE
Automated cherry pick of #1259: Fix wireguard IPv4 address capitalization

### DIFF
--- a/lib/apis/v3/node.go
+++ b/lib/apis/v3/node.go
@@ -95,7 +95,7 @@ type NodeBGPSpec struct {
 // NodeWireguardSpec contains the specification for the Node wireguard configuration.
 type NodeWireguardSpec struct {
 	// InterfaceIPv4Address is the IPv4 address for the Wireguard interface.
-	InterfaceIPv4Address string `json:"interfaceIpv4Address,omitempty" validate:"omitempty,ipv4"`
+	InterfaceIPv4Address string `json:"interfaceIPv4Address,omitempty" validate:"omitempty,ipv4"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Cherry pick of #1259 on release-v3.15.

#1259: Fix wireguard IPv4 address capitalization

```release-note
Fixed capitalization of WireGuard `interfaceIPv4Address` (was `interfaceIpv4Address`)
```