### PR TITLE
Fix missing ipv6 route with assign_ipv4 and assign_ipv6 set to true

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -180,22 +180,23 @@ func (c converter) HasIPAddress(pod *kapiv1.Pod) bool {
 
 // getPodIPs extracts the IP addresses from a Kubernetes Pod.  We support a single IPv4 address
 // and/or a single IPv6.  getPodIPs loads the IPs either from the PodIPs and PodIP field, if
-// present, or the calico podIP annotation.
+// present, or the calico podIP annotation. Note that fields supporting both protocols have
+// precedent over those that do not.
 func getPodIPs(pod *kapiv1.Pod) ([]*cnet.IPNet, error) {
 	var podIPs []string
 	if ips := pod.Status.PodIPs; len(ips) != 0 {
-		log.WithField("ips", ips).Debug("PodIPs field filled in")
+		log.WithField("ips", ips).Debug("Check PodIPs status field")
 		for _, ip := range ips {
 			podIPs = append(podIPs, ip.IP)
 		}
-	} else if ip := pod.Status.PodIP; ip != "" {
-		log.WithField("ip", ip).Debug("PodIP field filled in")
-		podIPs = append(podIPs, ip)
 	} else if ips := pod.Annotations[AnnotationPodIPs]; ips != "" {
-		log.WithField("ips", ips).Debug("No PodStatus IPs, use Calico plural annotation")
+		log.WithField("ips", ips).Debug("Check Calico plural annotation")
 		podIPs = append(podIPs, strings.Split(ips, ",")...)
+	} else if ip := pod.Status.PodIP; ip != "" {
+		log.WithField("ip", ip).Debug("Check PodIP status field")
+		podIPs = append(podIPs, ip)
 	} else if ip := pod.Annotations[AnnotationPodIP]; ip != "" {
-		log.WithField("ip", ip).Debug("No PodStatus IPs, use Calico singular annotation")
+		log.WithField("ip", ip).Debug("Check Calico singular annotation")
 		podIPs = append(podIPs, ip)
 	} else {
 		log.Debug("Pod has no IP")


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->
The ipv6 route on the host for the pod's cali interface is missing when dual stack is configured.

## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
Calico should retain a route like the following on the host:
```
REDACTED:2f1:bac7 dev cali19427926173 metric 1024 pref medium
```

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
With the following CNI config:

```
    {
      "name": "k8s-pod-network",
      "cniVersion": "0.3.1",
      "plugins": [
        {
          "type": "calico",
          "log_level": "info",
          "datastore_type": "kubernetes",
          "nodename": "__KUBERNETES_NODE_NAME__",
          "mtu": __CNI_MTU__,
          "ipam": {
              "type": "calico-ipam",
              "assign_ipv4": "true",
              "assign_ipv6": "true"
          },
          "policy": {
              "type": "k8s"
          },
          "kubernetes": {
              "kubeconfig": "__KUBECONFIG_FILEPATH__"
          }
        },
        {
          "type": "portmap",
          "snat": true,
          "capabilities": {"portMappings": true}
        },
        {
          "type": "bandwidth",
          "capabilities": {"bandwidth": true}
        }
      ]
    }
```
and given a created pod such as:

```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    cni.projectcalico.org/podIP: 172.18.194.200/32
    cni.projectcalico.org/podIPs: 172.18.194.200/32,REDACTED:2f1:bac7/128
  creationTimestamp: "2020-06-16T21:55:38Z"
  name: dualstack-129
  namespace: test-net
  resourceVersion: "1229970"
  selfLink: /api/v1/namespaces/test-net/pods/dualstack-129
  uid: 1cfe85b4-b01c-11ea-9d4b-2c600cad305a
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchFields:
          - key: metadata.name
            operator: In
            values:
            - REDACTED
  containers:
  - command:
    - sleep
    - infinity
    image: quay.io/muff1nman/debug-image
    imagePullPolicy: Always
    name: debug
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-r9k7s
      readOnly: true
  dnsPolicy: ClusterFirst
  nodeName: REDACTED
  priority: 0
  restartPolicy: Never
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: default-token-r9k7s
    secret:
      defaultMode: 420
      secretName: default-token-r9k7s
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2020-06-16T21:55:38Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2020-06-16T21:55:41Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2020-06-16T21:55:41Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2020-06-16T21:55:38Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://cb7fbf020588c9a1611ba527b17bcdb40424fd843c98072d0edc7e04ed5f95b5
    image: quay.io/muff1nman/debug-image:latest
    imageID: docker-pullable://quay.io/muff1nman/debug-image@sha256:87d95f7222630a1c64b3317dfc754e01e9512ac223eeb6240ee3707e046ffdb2
    lastState: {}
    name: debug
    ready: true
    restartCount: 0
    state:
      running:
        startedAt: "2020-06-16T21:55:40Z"
  hostIP: 10.36.10.64
  phase: Running
  podIP: 172.18.194.200
  qosClass: BestEffort
  startTime: "2020-06-16T21:55:38Z"
```
The node is missing an ipv6 route for this interface:

```
$ ip -6 route
::1 dev lo proto kernel metric 256 pref medium
REDACTED:1001::/64 dev vlan100 proto kernel metric 256 pref medium
REDACTED:2f1:bac9 dev cali6c2ecc3577c metric 1024 pref medium
blackhole REDACTED:2f1:bac0/122 dev lo proto bird metric 1024 pref medium
fe80::/64 dev vlan10 proto kernel metric 256 pref medium
fe80::/64 dev vlan100 proto kernel metric 256 pref medium
fe80::/64 dev bond0 proto kernel metric 256 pref medium
fe80::/64 dev docker0 proto kernel metric 256 linkdown pref medium
fe80::/64 dev cali3646a2ac13c proto kernel metric 256 pref medium
fe80::/64 dev cali19427926173 proto kernel metric 256 pref medium
fe80::/64 dev cali6c2ecc3577c proto kernel metric 256 pref medium
default via REDACTED:1001::1 dev vlan100 src REDACTED:a29e:4529 metric 1024 mtu 1280 pref medium
```
Note that the `cali6c2ecc3577c` interface is for a pod that was created when the CNI config was changed to have `assign_ipv4` to `"false"` and a route for the dualstack `cali19427926173` interface is missing.

Here are the ipv4 routes:
```
$ ip route
default via REDACTED dev vlan100 proto static src REDACTED
10.36.0.0/16 via 10.36.10.1 dev vlan10 proto static src 10.36.10.64 
10.36.10.0/24 dev vlan10 proto kernel scope link src 10.36.10.64 
REDACTED/26 dev vlan100 proto kernel scope link src REDACTED
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown 
172.18.6.0/26 via 10.36.10.40 dev tunl0 proto bird onlink 
172.18.173.192/26 via 10.36.68.17 dev tunl0 proto bird onlink 
blackhole 172.18.194.192/26 proto bird 
172.18.194.195 dev cali3646a2ac13c scope link 
172.18.194.200 dev cali19427926173 scope link
```

## Possible Solution
This PR. I've been able to confirm this patch will fix the issue.

## Steps to Reproduce (for bugs)
1. Deploy a k8s cluster < 1.16
2. Deploy calico 3.14.1
3. Set `assign_ipv4` and `assign_ipv6` to true
4. Create pod definition from above

## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
We are looking to upgrade to Calico 3.14.1 (from Calico 2.x) on a fresh cluster and retain a setup similar to what we had on Calico 2.x. One other change is that we are experimenting with using the kubernetes datastore where previously the etcd datastore was used.

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Calico 3.14.1
* Kubernetes < 1.16
* Operating System and version: Debian 4.19.88

## PR Description
This PR fixes the aforementioned bug by preferring dualstack fields that back the k8s datastore over the singular fields. It has been tested via the bug reproduction steps above. This PR will affect both calico node and typha assuming the dependency is updated.

## Todos
- [ ] Tests
- [ ] Documentation
- [X] Release note

## Release Note
```
For the K8S datastore, prefer the plural pod ips (the pod status and the calico annotation) over the singular fields.
```
