### PR TITLE
Maintaining original next hop on specific bgppeer

### DIFF
--- a/config/crd/crd.projectcalico.org_bgppeers.yaml
+++ b/config/crd/crd.projectcalico.org_bgppeers.yaml
@@ -64,6 +64,12 @@ spec:
                   remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
                   or the global default if that is not set.
                 type: string
+              keepOriginalNextHop:
+                description: 'Option to keep the original nexthop field when routes are sent to
+                  a BGP Peer. Setting "true" configures the selected BGP Peers node to use the
+                  "next hop keep;" instead of "next hop self;"(default) in the specific branch
+                  of the Node on "bird.cfg".'
+                type: boolean
             required:
             - asNumber
             - peerIP

--- a/lib/apis/v3/bgppeer.go
+++ b/lib/apis/v3/bgppeer.go
@@ -61,6 +61,10 @@ type BGPPeerSpec struct {
 	// NodeBGPSpec.IPv6Address specified.  The remote AS number comes from the remote
 	// node’s NodeBGPSpec.ASNumber, or the global default if that is not set.
 	PeerSelector string `json:"peerSelector,omitempty" validate:"omitempty,selector"`
+	// Option to keep the original nexthop field when routes are sent to a BGP Peer.
+	// Setting "true" configures the selected BGP Peers node to use the "next hop keep;"
+	// instead of "next hop self;"(default) in the specific branch of the Node on "bird.cfg".
+	KeepOriginalNextHop bool `json:"keepOriginalNextHop,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Description
An option to keep the original nexthop field when routes are sent to a BGP Peer. Setting "true" configures the selected BGP Peers node to use the "next hop keep;" instead of "next hop self;"(default) in the specific branch of the Node on "bird.cfg". Thus routes will be send to the external Router maintaining the BGP Original Next Hop. So traffic incoming from external Router can be forwarded directly to the Nodes, without through the Route Reflector.

This is a **New Feature** that target:
 - (https://github.com/projectcalico/calico/issues/3666)
 - (https://github.com/projectcalico/confd/issues/308)
 - (https://github.com/projectcalico/node/issues/279)
 - (https://github.com/projectcalico/confd/pull/257#issuecomment-567058423)
and others discussions...

This PR affects basically **projectcalico/confd** adding a new field in BGPpeer: `KeepOriginalNextHop` and generate a new Boolean Key in `bird.cfg.template` defined by `next_hop_key` per BGPpeer Node, with default value equal to `False`.

Also, I have extended kubernetes CRD (that is include in libcalico-go) and installed it in my Cluster to test. The last step was recompile `calicoctl` with the new `libcalico-go` to help to create new objects with the new field.

A simple use case is create a new BGPpeer using the Route Reflectors to communicate with external BGPpeer ("my-global-peer"):
```bash
## Disable the default BGP node-to-node mesh 
calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": “false”}}'
```
Make BGPpeers (Route Reflector and BGPpeer):
```yaml
kind: BGPPeerList
apiVersion: projectcalico.org/v3
items:
- apiVersion: projectcalico.org/v3
  kind: BGPPeer
  metadata:
    name: bgppeer-rr
  spec:
    nodeSelector: all()
    peerSelector: route-reflector == 'true'
- apiVersion: projectcalico.org/v3
  kind: BGPPeer
  metadata:
    name: my-global-peer
  spec:
    asNumber: 65000
    nodeSelector: route-reflector == "true"
    peerIP: 10.79.63.42
    keepOriginalNextHop: true
```
So, is expect the Nodes send theirs routes to RR ( "bgppeer-rr") and this one sends all of routes keeping original Next Hopes to external BGP peer ("my-global-peer").
```
        [-----------]                        [---------------]
        [  Node01   ]   w/ next hop keep     [External Router]
        [bgppeer-rr ]  ------------------>   [my-global-peer ]
        [-----------]                        [---------------]
          ^   ^   ^                                 |
    ------|   |   |-------                          |
    |         |          |          Directly Fwd    |
[Node02]   [Node03]   [NodeXX]  <--------------------
```

IMPORTANT: I did very few tests with and without the reflecting router.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note