### PR TITLE
Support peer with same IP but different port

### DIFF
--- a/lib/apis/v3/bgpconfig.go
+++ b/lib/apis/v3/bgpconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ type ServiceClusterIPBlock struct {
 // Community contains standard or large community value and its name.
 type Community struct {
 	// Name given to community value.
-	Name  string `json:"name,omitempty" validate:"required,name"`
+	Name string `json:"name,omitempty" validate:"required,name"`
 	// Value must be of format `aa:nn` or `aa:nn:mm`.
 	// For standard community use `aa:nn` format, where `aa` and `nn` are 16 bit number.
 	// For large community use `aa:nn:mm` format, where `aa`, `nn` and `mm` are 32 bit number.

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -36,6 +36,7 @@ var (
 type NodeBGPPeerKey struct {
 	Nodename string `json:"-" validate:"omitempty"`
 	PeerIP   net.IP `json:"-" validate:"required"`
+	Port     string `json:"-" validate:"omitempty"`
 }
 
 func (key NodeBGPPeerKey) defaultPath() (string, error) {
@@ -45,8 +46,12 @@ func (key NodeBGPPeerKey) defaultPath() (string, error) {
 	if key.Nodename == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "node"}
 	}
+	ipPort := key.PeerIP.String()
+	if key.Port != "" {
+		ipPort = ipPort + "-" + key.Port
+	}
 	e := fmt.Sprintf("/calico/bgp/v1/host/%s/peer_v%d/%s",
-		key.Nodename, key.PeerIP.Version(), key.PeerIP)
+		key.Nodename, key.PeerIP.Version(), ipPort)
 	return e, nil
 }
 
@@ -63,7 +68,7 @@ func (key NodeBGPPeerKey) valueType() (reflect.Type, error) {
 }
 
 func (key NodeBGPPeerKey) String() string {
-	return fmt.Sprintf("BGPPeer(node=%s, ip=%s)", key.Nodename, key.PeerIP)
+	return fmt.Sprintf("BGPPeer(node=%s, ip=%s, port=%s)", key.Nodename, key.PeerIP, key.Port)
 }
 
 type NodeBGPPeerListOptions struct {
@@ -113,14 +118,19 @@ func (options NodeBGPPeerListOptions) KeyFromDefaultPath(path string) Key {
 
 type GlobalBGPPeerKey struct {
 	PeerIP net.IP `json:"-" validate:"required"`
+	Port   string `json:"-" validate:"omitempty"`
 }
 
 func (key GlobalBGPPeerKey) defaultPath() (string, error) {
 	if key.PeerIP.IP == nil {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "peerIP"}
 	}
+	ipPort := key.PeerIP.String()
+	if key.Port != "" {
+		ipPort = ipPort + "-" + key.Port
+	}
 	e := fmt.Sprintf("/calico/bgp/v1/global/peer_v%d/%s",
-		key.PeerIP.Version(), key.PeerIP)
+		key.PeerIP.Version(), ipPort)
 	return e, nil
 }
 
@@ -137,11 +147,12 @@ func (key GlobalBGPPeerKey) valueType() (reflect.Type, error) {
 }
 
 func (key GlobalBGPPeerKey) String() string {
-	return fmt.Sprintf("BGPPeer(global, ip=%s)", key.PeerIP)
+	return fmt.Sprintf("BGPPeer(global, ip=%s, port=%s)", key.PeerIP, key.Port)
 }
 
 type GlobalBGPPeerListOptions struct {
 	PeerIP net.IP
+	Port   string
 }
 
 func (options GlobalBGPPeerListOptions) defaultPathRoot() string {

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -29,10 +29,11 @@ import (
 )
 
 var (
-	matchGlobalBGPPeer = regexp.MustCompile("^/?calico/bgp/v1/global/peer_v./([^/]+)$")
-	matchHostBGPPeer   = regexp.MustCompile("^/?calico/bgp/v1/host/([^/]+)/peer_v./([^/]+)$")
-	typeBGPPeer        = reflect.TypeOf(BGPPeer{})
-	ipPortSeparator    = "-"
+	matchGlobalBGPPeer        = regexp.MustCompile("^/?calico/bgp/v1/global/peer_v./([^/]+)$")
+	matchHostBGPPeer          = regexp.MustCompile("^/?calico/bgp/v1/host/([^/]+)/peer_v./([^/]+)$")
+	typeBGPPeer               = reflect.TypeOf(BGPPeer{})
+	ipPortSeparator           = "-"
+	defaultPort        uint16 = 179
 )
 
 type NodeBGPPeerKey struct {
@@ -211,15 +212,15 @@ func extractIPAndPort(ipPort string) ([]byte, uint16) {
 		port, err := strconv.ParseUint(arr[1], 0, 16)
 		if err != nil {
 			log.Warningf("Error extracting port. %#v", err)
-			return []byte(ipPort), 179
+			return []byte(ipPort), defaultPort
 		}
 		return []byte(arr[0]), uint16(port)
 	}
-	return []byte(ipPort), 179
+	return []byte(ipPort), defaultPort
 }
 
 func combineIPAndPort(ip net.IP, port uint16) string {
-	if port == 0 || port == 179 {
+	if port == 0 || port == defaultPort {
 		return ip.String()
 	} else {
 		strPort := strconv.Itoa(int(port))

--- a/lib/backend/model/bgppeer_test.go
+++ b/lib/backend/model/bgppeer_test.go
@@ -15,11 +15,13 @@
 package model_test
 
 import (
+	"net"
+
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	. "github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
-	"net"
 )
 
 var _ = DescribeTable(
@@ -40,31 +42,32 @@ var _ = DescribeTable(
 	Entry(
 		"global BGP peer without port",
 		"/calico/bgp/v1/global/peer_v4/10.0.0.5",
-		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}},
+		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port:179},
 		true,
 	),
 	Entry(
 		"global BGP peer with port",
 		"/calico/bgp/v1/global/peer_v4/10.0.0.5-500",
-		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: "500"},
+		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 500},
 		true,
 	),
 	Entry(
 		"node BGP peer without port",
 		"/calico/bgp/v1/host/random-node-1/peer_v4/10.0.0.5",
-		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}},
+		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port:179},
 		false,
 	),
 	Entry(
 		"node BGP peer with port",
 		"/calico/bgp/v1/host/random-node-2/peer_v4/10.0.0.5-500",
-		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: "500"},
+		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 500},
 		false,
 	),
 	Entry(
 		"node BGP IPv6 peer with port",
 		"/calico/bgp/v1/host/random-node-2/peer_v6/aabb:aabb::ffff-123",
-		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("aabb:aabb::ffff")}, Port: "123"},
+		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("aabb:aabb::ffff")}, Port: 123},
 		false,
 	),
 )
+

--- a/lib/backend/model/bgppeer_test.go
+++ b/lib/backend/model/bgppeer_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model_test
+
+import (
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/projectcalico/libcalico-go/lib/backend/model"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"net"
+)
+
+var _ = DescribeTable(
+	"BGP Peer key parsing",
+	func(strKey string, expected Key, isGlobalPeer bool) {
+		var key Key
+		if isGlobalPeer {
+			key = (GlobalBGPPeerListOptions{}).KeyFromDefaultPath(strKey)
+		} else {
+			key = (NodeBGPPeerListOptions{}).KeyFromDefaultPath(strKey)
+		}
+
+		Expect(key).To(Equal(expected))
+		serialized, err := KeyToDefaultPath(expected)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serialized).To(Equal(strKey))
+	},
+	Entry(
+		"global BGP peer without port",
+		"/calico/bgp/v1/global/peer_v4/10.0.0.5",
+		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}},
+		true,
+	),
+	Entry(
+		"global BGP peer with port",
+		"/calico/bgp/v1/global/peer_v4/10.0.0.5-500",
+		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: "500"},
+		true,
+	),
+	Entry(
+		"node BGP peer without port",
+		"/calico/bgp/v1/host/random-node-1/peer_v4/10.0.0.5",
+		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}},
+		false,
+	),
+	Entry(
+		"node BGP peer with port",
+		"/calico/bgp/v1/host/random-node-2/peer_v4/10.0.0.5-500",
+		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: "500"},
+		false,
+	),
+	Entry(
+		"node BGP IPv6 peer with port",
+		"/calico/bgp/v1/host/random-node-2/peer_v6/aabb:aabb::ffff-123",
+		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("aabb:aabb::ffff")}, Port: "123"},
+		false,
+	),
+)

--- a/lib/backend/model/bgppeer_test.go
+++ b/lib/backend/model/bgppeer_test.go
@@ -42,7 +42,7 @@ var _ = DescribeTable(
 	Entry(
 		"global BGP peer without port",
 		"/calico/bgp/v1/global/peer_v4/10.0.0.5",
-		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port:179},
+		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 179},
 		true,
 	),
 	Entry(
@@ -54,7 +54,7 @@ var _ = DescribeTable(
 	Entry(
 		"node BGP peer without port",
 		"/calico/bgp/v1/host/random-node-1/peer_v4/10.0.0.5",
-		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port:179},
+		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 179},
 		false,
 	),
 	Entry(
@@ -70,4 +70,3 @@ var _ = DescribeTable(
 		false,
 	),
 )
-

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -269,7 +269,7 @@ func KeyFromDefaultPath(path string) Key {
 		return k
 	} else if k := (ResourceListOptions{Kind: v3.KindBGPPeer}).KeyFromDefaultPath(path); k != nil {
 		return k
-	}  else if k := (ResourceListOptions{Kind: v3.KindBGPConfiguration}).KeyFromDefaultPath(path); k != nil {
+	} else if k := (ResourceListOptions{Kind: v3.KindBGPConfiguration}).KeyFromDefaultPath(path); k != nil {
 		return k
 	} else if k := (ResourceListOptions{Kind: v3.KindNetworkPolicy}).KeyFromDefaultPath(path); k != nil {
 		return k

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ func New(client api.Client, callbacks api.SyncerCallbacks, node string, cfg apic
 			UpdateProcessor: updateprocessors.NewIPPoolUpdateProcessor(),
 		},
 		{
-			ListInterface:   model.ResourceListOptions{Kind: apiv3.KindBGPConfiguration},
+			ListInterface: model.ResourceListOptions{Kind: apiv3.KindBGPConfiguration},
 		},
 		{
 			ListInterface: model.ResourceListOptions{Kind: apiv3.KindNode},

--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package bgpsyncer_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/lib/clientv3/bgpconfig.go
+++ b/lib/clientv3/bgpconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package clientv3
 
 import (
 	"context"
+
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/options"

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -2059,62 +2059,62 @@ func init() {
 
 		// BGP Communities validation in BGPConfigurationSpec
 		Entry("should not accept communities with value and without name", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Value: "536:785",},},
+			Communities: []api.Community{{Value: "536:785"}},
 		}, false),
 		Entry("should not accept communities with name and without value", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test",},},
+			Communities: []api.Community{{Name: "community-test"}},
 		}, false),
 		Entry("should accept communities with name and standard BGP community value", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "100:520",},},
+			Communities: []api.Community{{Name: "community-test", Value: "100:520"}},
 		}, true),
 		Entry("should accept communities with name and large BGP community value", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "100:520:56",},},
+			Communities: []api.Community{{Name: "community-test", Value: "100:520:56"}},
 		}, true),
 		Entry("should not accept communities with name and invalid community value/format", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "100",},},
+			Communities: []api.Community{{Name: "community-test", Value: "100"}},
 		}, false),
 		Entry("should not accept communities with name and invalid community value/format", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "ab-n",},},
+			Communities: []api.Community{{Name: "community-test", Value: "ab-n"}},
 		}, false),
 		Entry("should not accept communities with name and invalid standard community value(> 16 bit)", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "65536:999999",},},
+			Communities: []api.Community{{Name: "community-test", Value: "65536:999999"}},
 		}, false),
 		Entry("should not accept communities with name and invalid large community value(> 32 bit)", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "4147483647:999999",},},
+			Communities: []api.Community{{Name: "community-test", Value: "4147483647:999999"}},
 		}, false),
 		Entry("should not accept communities without CIDR in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{Communities: []string{"100:5964"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{Communities: []string{"100:5964"}}},
 		}, false),
 		Entry("should not accept CIDR without communities in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28",},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28"}},
 		}, false),
 		Entry("should accept IPv4 CIDR in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:5964:50",},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:5964:50"}}},
 		}, true),
 		Entry("should accept IPv6 CIDR in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964:50",},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964:50"}}},
 		}, true),
 		Entry("should accept standard BGP community value in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964", "200:594"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964", "200:594"}}},
 		}, true),
 		Entry("should accept large BGP community value in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964:1147483647"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964:1147483647"}}},
 		}, true),
 		Entry("should not accept invalid standard community value(> 16 bit) in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:1147483647"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:1147483647"}}},
 		}, false),
 		Entry("should not accept invalid large community value(> 32 bit) in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:100:5147483647"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:100:5147483647"}}},
 		}, false),
 		Entry("should accept combination of large and standard BGP community value in PrefixAdvertisement", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964:1147483647", "100:5223"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"100:5964:1147483647", "100:5223"}}},
 		}, true),
 		Entry("should not accept community name that is not defined", api.BGPConfigurationSpec{
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"non-existent-community"},},},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"non-existent-community"}}},
 		}, false),
 		Entry("should accept community name whose values are defined", api.BGPConfigurationSpec{
-			Communities:          []api.Community{{Name: "community-test", Value: "101:5695",},},
-			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"community-test", "8988:202"},},},
+			Communities:          []api.Community{{Name: "community-test", Value: "101:5695"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "2001:4860::/128", Communities: []string{"community-test", "8988:202"}}},
 		}, true),
 	)
 }


### PR DESCRIPTION
## Description
Extend GlobalBGPPeerKey and NodeBGPPeerKey to differentiate between peers with same IP but different ports.

https://github.com/projectcalico/confd/pull/341#discussion_r452835494

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
