### PR TITLE
Additional validation for BGP communities

### DIFF
--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -1412,9 +1412,13 @@ func validateBGPConfigurationSpec(structLevel validator.StructLevel) {
 		}
 	}
 
+	if (len(spec.PrefixAdvertisements) == 0) && (len(communities) != 0) {
+		structLevel.ReportError(reflect.ValueOf(communities), "Spec.Communities[]", "",
+			reason("communities are defined but not used in Spec.PrefixAdvertisement[]."), "")
+	}
+
 	// check if Spec.PrefixAdvertisement.Communities are valid
-	pas := spec.PrefixAdvertisements
-	for _, pa := range pas {
+	for _, pa := range spec.PrefixAdvertisements {
 		_, _, err := cnet.ParseCIDROrIP(pa.CIDR)
 		if err != nil {
 			log.Warningf("CIDR value is invalid: %v", pa.CIDR)

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -2058,29 +2058,40 @@ func init() {
 		),
 
 		// BGP Communities validation in BGPConfigurationSpec
+		Entry("should not accept community when PrefixAdvertisement is empty", api.BGPConfigurationSpec{
+			Communities: []api.Community{{Name: "community-test", Value: "101:5695"}},
+		}, false),
 		Entry("should not accept communities with value and without name", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Value: "536:785"}},
+			Communities:          []api.Community{{Value: "536:785"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, false),
 		Entry("should not accept communities with name and without value", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test"}},
+			Communities:          []api.Community{{Name: "community-test"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, false),
 		Entry("should accept communities with name and standard BGP community value", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "100:520"}},
+			Communities:          []api.Community{{Name: "community-test", Value: "100:520"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, true),
 		Entry("should accept communities with name and large BGP community value", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "100:520:56"}},
+			Communities:          []api.Community{{Name: "community-test", Value: "100:520:56"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, true),
 		Entry("should not accept communities with name and invalid community value/format", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "100"}},
+			Communities:          []api.Community{{Name: "community-test", Value: "100"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, false),
 		Entry("should not accept communities with name and invalid community value/format", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "ab-n"}},
+			Communities:          []api.Community{{Name: "community-test", Value: "ab-n"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, false),
 		Entry("should not accept communities with name and invalid standard community value(> 16 bit)", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "65536:999999"}},
+			Communities:          []api.Community{{Name: "community-test", Value: "65536:999999"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, false),
 		Entry("should not accept communities with name and invalid large community value(> 32 bit)", api.BGPConfigurationSpec{
-			Communities: []api.Community{{Name: "community-test", Value: "4147483647:999999"}},
+			Communities:          []api.Community{{Name: "community-test", Value: "4147483647:999999"}},
+			PrefixAdvertisements: []api.PrefixAdvertisement{{CIDR: "192.168.10.0/28", Communities: []string{"100:100"}}},
 		}, false),
 		Entry("should not accept communities without CIDR in PrefixAdvertisement", api.BGPConfigurationSpec{
 			PrefixAdvertisements: []api.PrefixAdvertisement{{Communities: []string{"100:5964"}}},


### PR DESCRIPTION
## Description

This is mainly to address the misunderstanding where if `communities` are set, user should use them in `prefixAdvertisements` or else they will not be advertised. During user testing we figured it wasn't obvious that `prefixAdvertisements` and `communities` should be used in tandem. 

This PR simply makes sure that if `spec.communities` are set `spec.prefixAdvertisements` should not be empty. It would help avoid human error where user adds entries in communities field and think it will get propagated, but they in fact missed a step in the configuration. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
