### PR TITLE
Change default datastoretype

### DIFF
--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -41,7 +41,7 @@ type CalicoAPIConfig struct {
 
 // CalicoAPIConfigSpec contains the specification for a Calico CalicoAPIConfig resource.
 type CalicoAPIConfigSpec struct {
-	DatastoreType DatastoreType `json:"datastoreType" envconfig:"DATASTORE_TYPE" default:"etcdv3"`
+	DatastoreType DatastoreType `json:"datastoreType" envconfig:"DATASTORE_TYPE"`
 	// Inline the ectd config fields
 	EtcdConfig
 	// Inline the k8s config fields.

--- a/lib/apiconfig/load.go
+++ b/lib/apiconfig/load.go
@@ -43,9 +43,8 @@ func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
 	} else if c.Spec.DatastoreType == "" {
 		c.Spec.DatastoreType = Kubernetes
 	}
-	// Changing Kubeconfig prevents a default error attitude
-	// when user has set no configuration.
-	if c.Spec.DatastoreType == Kubernetes && c.Spec.Kubeconfig == "" {
+
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" && c.Spec.DatastoreType == Kubernetes && c.Spec.Kubeconfig == "" {
 		c.Spec.Kubeconfig = filepath.Join(os.Getenv("HOME"),".kube","config")
 	}
 

--- a/lib/apiconfig/load.go
+++ b/lib/apiconfig/load.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
@@ -15,6 +17,8 @@ import (
 // LoadClientConfig loads the ClientConfig from the specified file (if specified)
 // or from environment variables (if the file is not specified).
 func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
+	var c *CalicoAPIConfig
+	var err error
 
 	// Override / merge with values loaded from the specified file.
 	if filename != "" {
@@ -23,13 +27,29 @@ func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
 			return nil, err
 		}
 
-		c, err := LoadClientConfigFromBytes(b)
+		c, err = LoadClientConfigFromBytes(b)
 		if err != nil {
 			return nil, fmt.Errorf("syntax error in %s: %v", filename, err)
 		}
-		return c, nil
+
+	} else {
+		c,err = LoadClientConfigFromEnvironment()
 	}
-	return LoadClientConfigFromEnvironment()
+
+	// If EtcdEndpoints is set and DatastoreType is missing set it to EtcdV3
+	// otherwise set default Datastoretype to Kubernetes
+	if c.Spec.DatastoreType == "" && c.Spec.EtcdEndpoints != "" {
+		c.Spec.DatastoreType = EtcdV3
+	} else if c.Spec.DatastoreType == "" {
+		c.Spec.DatastoreType = Kubernetes
+	}
+	// Changing Kubeconfig prevents a default error attitude
+	// when user has set no configuration.
+	if c.Spec.DatastoreType == Kubernetes && c.Spec.Kubeconfig == "" {
+		c.Spec.Kubeconfig = filepath.Join(os.Getenv("HOME"),".kube","config")
+	}
+
+	return c, err
 }
 
 // LoadClientConfig loads the ClientConfig from the supplied bytes containing
@@ -37,14 +57,7 @@ func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
 func LoadClientConfigFromBytes(b []byte) (*CalicoAPIConfig, error) {
 	var c CalicoAPIConfig
 
-	// Default the backend type to be etcd v3.  This will be overridden if
-	// explicitly specified in the file.
 	log.Debug("Loading config from JSON or YAML data")
-	c = CalicoAPIConfig{
-		Spec: CalicoAPIConfigSpec{
-			DatastoreType: EtcdV3,
-		},
-	}
 
 	if err := yaml.UnmarshalStrict(b, &c); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
This PR changes datastore type to `kubernetes` if `etcd` is not specified by user.[successor to this PR](https://github.com/projectcalico/calicoctl/pull/2159)

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Default to Kubernetes datastore
```
@robbrockbank @caseydavenport 