### PR TITLE
Validate IP and Port in PeerIP

### DIFF
--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1343,15 +1343,33 @@ func init() {
 		}, true),
 		Entry("should reject BGPPeerSpec with invalid port in PeerIP (IPv4)", api.BGPPeerSpec{
 			PeerIP: "[192.168.0.0]:98956",
-		}, true),
+		}, false),
+		Entry("should reject BGPPeerSpec with invalid port in PeerIP (IPv4)", api.BGPPeerSpec{
+			PeerIP: "192.168.0.0:65536",
+		}, false),
+		Entry("should reject BGPPeerSpec with invalid port in PeerIP (IPv4)", api.BGPPeerSpec{
+			PeerIP: "192.168.0.0:0",
+		}, false),
+		Entry("should reject BGPPeerSpec with invalid IP in PeerIP (IPv4)", api.BGPPeerSpec{
+			PeerIP: "192.168.0.330:170",
+		}, false),
 		Entry("should reject BGPPeerSpec with invalid port in PeerIP (IPv6)", api.BGPPeerSpec{
 			PeerIP: "[9000::]:98956",
-		}, true),
+		}, false),
 		Entry("should reject invalid BGPPeerSpec without port set in PeerIP (IPv4)", api.BGPPeerSpec{
 			PeerIP: "192.168.0.0:",
 		}, false),
 		Entry("should reject invalid BGPPeerSpec without port set in PeerIP (IPv6)", api.BGPPeerSpec{
 			PeerIP: "[9000::]:",
+		}, false),
+		Entry("should reject BGPPeerSpec with invalid port in PeerIP (IPv6)", api.BGPPeerSpec{
+			PeerIP: "[9000::]:65536",
+		}, false),
+		Entry("should reject BGPPeerSpec with invalid port in PeerIP (IPv6)", api.BGPPeerSpec{
+			PeerIP: "[9000::]:0",
+		}, false),
+		Entry("should reject BGPPeerSpec with invalid IP in PeerIP (IPv6)", api.BGPPeerSpec{
+			PeerIP: "[9000::FFFFF]:170",
 		}, false),
 		Entry("should reject invalid BGPPeerSpec when port is set with empty IP in PeerIP (IPv4)", api.BGPPeerSpec{
 			PeerIP: ":8552",


### PR DESCRIPTION
## Description
Validate the IP and port set via BGPeer's PeerIP, `net.SplitHostPort` doesn't validate the IP and port values, it just splits them, this PR is to validate them after splitting.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
