### PR TITLE
Handle deletion of weps in KDD

### DIFF
--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ const (
 	// duplicates the value of the Pod.Status.PodIP field, which is set by kubelet but,
 	// since we write it ourselves, we can make sure that it is written synchronously
 	// and quickly.
+	//
+	// We set this annotation to the empty string when the WEP is deleted by the CNI plugin.
+	// That signals that the IP no longer belongs to this pod.
 	AnnotationPodIP = "cni.projectcalico.org/podIP"
 	// AnnotationPodIPs is similar for the plural PodIPs field.
 	AnnotationPodIPs = "cni.projectcalico.org/podIPs"

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -157,8 +157,16 @@ const (
 )
 
 func IsFinished(pod *kapiv1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		// Pod is Terminating, check if it still has its IPs.
+		if pod.Annotations[AnnotationPodIP] == "" {
+			log.Debug("Pod is being deleted and IPs have been removed.")
+			return true
+		}
+	}
 	switch pod.Status.Phase {
 	case kapiv1.PodFailed, kapiv1.PodSucceeded, podCompleted:
+		log.Debug("Pod phase is failed/succeeded/completed.")
 		return true
 	}
 	return false

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -104,6 +104,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		// Pods with no IPs will get filtered out before they get to Felix in the watcher syncer cache layer.
 		// We can't pretend the workload endpoint is deleted _here_ because that would confuse users of the
 		// native v3 Watch() API.
+		log.Debug("Pod is in a 'finished' state so no longer owns its IP(s).")
 		podIPNets = nil
 	}
 

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -1802,6 +1802,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		})
 
 		By("Removing its IP", func() {
+			pod.Annotations = map[string]string{}
 			pod.Status.PodIP = ""
 			pod.Status.PodIPs = nil
 			pod, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(pod)

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -21,27 +21,26 @@ import (
 	"sync"
 	"time"
 
-	"github.com/projectcalico/libcalico-go/lib/names"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
-	"github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/projectcalico/libcalico-go/lib/testutils"
-
 	log "github.com/sirupsen/logrus"
+	k8sapi "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/names"
+	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
-
-	k8sapi "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
 var (
@@ -1535,6 +1534,10 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		})
 		By("Assigning an IP", func() {
 			// Update the Pod to have an IP and be running.
+			pod.Annotations = map[string]string{
+				conversion.AnnotationPodIP:  "192.168.1.1",
+				conversion.AnnotationPodIPs: "192.168.1.1",
+			}
 			pod.Status.PodIP = "192.168.1.1"
 			pod.Status.Phase = k8sapi.PodRunning
 			pod, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(pod)
@@ -1637,7 +1640,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 	})
 
 	// There are several states that we consider "finished", run the test for each one.
-	for _, finishPhase := range []k8sapi.PodPhase{k8sapi.PodSucceeded, k8sapi.PodFailed} {
+	for _, finishPhase := range []k8sapi.PodPhase{k8sapi.PodSucceeded, k8sapi.PodFailed, "Terminating"} {
 		finishPhase := finishPhase
 		It(fmt.Sprintf("should treat a finished Pod (%v) as a deletion", finishPhase), func() {
 			pod, wepName := createPodAndMarkAsRunning("finished-pod-" + strings.ToLower(string(finishPhase)))
@@ -1660,11 +1663,14 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 				})
 			})
 
+			var wepKV *model.KVPair
+			key := model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}
 			By("Checking the pod is visible before we mark it as finished", func() {
 				// Perform a Get and ensure no error in the Calico API.
-				wep, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}, "")
+				var err error
+				wepKV, err = c.Get(ctx, key, "")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(wep).NotTo(BeNil())
+				Expect(wepKV).NotTo(BeNil())
 
 				// Perform List and ensure it shows up in the Calico API.
 				weps, err := c.List(ctx, model.ResourceListOptions{Kind: apiv3.KindWorkloadEndpoint}, "")
@@ -1673,6 +1679,39 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			})
 
 			By(fmt.Sprintf("Marking the Pod as finished (%v)", finishPhase), func() {
+				if finishPhase == "Terminating" {
+					// The Terminating state isn't a real state; it means the pod is being deleted but hasn't
+					// finished yet. The CNI plugin calls through to DeleteKVP when it gets a DEL.
+					var gracePeriod int64 = 60
+					err = c.ClientSet.CoreV1().Pods("default").Delete(pod.Name,
+						&metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+
+					// Terminating alone shouldn't remove the IP (so that pods that are gracefully shutting down
+					// can finish).
+					wepKV, err = c.Get(ctx, key, "")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(wepKV.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).NotTo(HaveLen(0))
+
+					// Deleting in the Calico API with incorrect UID should fail.
+					realUID := wepKV.UID
+					badUID := types.UID("19e9c0f4-501d-429f-b581-8954440883f4")
+					wepKV.UID = &badUID
+					_, err = c.DeleteKVP(ctx, wepKV)
+					Expect(err).To(BeAssignableToTypeOf(cerrors.ErrorResourceDoesNotExist{}))
+					wepKV.UID = realUID
+					wepKV2, err := c.Get(ctx, key, "")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(wepKV2.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).NotTo(HaveLen(0))
+
+					// Successful deletion in the Calico API should make the IPs disappear.
+					_, err = c.DeleteKVP(ctx, wepKV)
+					Expect(err).NotTo(HaveOccurred())
+					wepKV2, err = c.Get(ctx, key, "")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(wepKV2.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(HaveLen(0))
+
+					return
+				}
 				pod.Status.Phase = finishPhase
 				pod, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(pod)
 				Expect(err).NotTo(HaveOccurred())
@@ -1687,6 +1726,18 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			// a "delete", we should now see a "new", rather than an "update".
 
 			By("Marking the Pod as running again", func() {
+				if finishPhase == "Terminating" {
+					// Revision is now out of date, create should fail.
+					_, err := c.Update(ctx, wepKV)
+					Expect(err).To(BeAssignableToTypeOf(cerrors.ErrorResourceUpdateConflict{}))
+
+					// Recreate the WEP (this puts the annotations back again).
+					wepKV.Revision = ""
+					wepKV.UID = nil
+					_, err = c.Create(ctx, wepKV)
+					Expect(err).NotTo(HaveOccurred())
+					return
+				}
 				pod.Status.Phase = k8sapi.PodRunning
 				pod, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(pod)
 				Expect(err).NotTo(HaveOccurred())
@@ -1700,7 +1751,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 
 			By("Checking the pod is gettable", func() {
 				// Perform a Get and ensure no error in the Calico API.
-				_, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: apiv3.KindWorkloadEndpoint}, "")
+				_, err := c.Get(ctx, key, "")
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/lib/backend/k8s/resources/errors.go
+++ b/lib/backend/k8s/resources/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016,2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ package resources
 import (
 	"strings"
 
-	"github.com/projectcalico/libcalico-go/lib/errors"
-
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/libcalico-go/lib/errors"
 )
 
 // K8sErrorToCalico returns the equivalent libcalico error for the given
@@ -57,6 +58,41 @@ func K8sErrorToCalico(ke error, id interface{}) error {
 		return errors.ErrorResourceUpdateConflict{
 			Err:        ke,
 			Identifier: id,
+		}
+	}
+	if keStat, ok := ke.(kerrors.APIStatus); ok {
+		// Look for the errors we get when we try to patch a resource but it has been recreated or revved.
+		if details := keStat.Status().Details; details != nil {
+			uidInvalid := false
+			revInvalid := false
+			somethingElse := false
+			for _, c := range details.Causes {
+				if c.Field == "metadata.uid" && c.Type == metav1.CauseTypeFieldValueInvalid {
+					uidInvalid = true
+					continue
+				}
+				if c.Field == "metadata.resourceVersion" && c.Type == metav1.CauseTypeFieldValueInvalid {
+					revInvalid = true
+					continue
+				}
+				somethingElse = true
+			}
+			if uidInvalid && !somethingElse {
+				// The UID in the patch was incorrect; this means that the resource we tried to update
+				// has been deleted and recreated with a new UID.
+				return errors.ErrorResourceDoesNotExist{
+					Err:        ke,
+					Identifier: id,
+				}
+			}
+			if revInvalid && !somethingElse {
+				// The revision in the patch was incorrect but the UID was OK; this means someone else modified
+				// the resource under our feet.
+				return errors.ErrorResourceUpdateConflict{
+					Err:        ke,
+					Identifier: id,
+				}
+			}
 		}
 	}
 	return errors.ErrorDatastoreError{

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -60,7 +60,7 @@ func (c *WorkloadEndpointClient) Create(ctx context.Context, kvp *model.KVPair) 
 	// Note: it's a bit odd to do this in the Create, but the CNI plugin uses CreateOrUpdate().  Doing it
 	// here makes sure that, if the update fails: we retry here, and, we don't report success without
 	// making the patch.
-	return c.patchPodIP(ctx, kvp)
+	return c.patchInPodIPs(ctx, kvp)
 }
 
 func (c *WorkloadEndpointClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -68,7 +68,7 @@ func (c *WorkloadEndpointClient) Update(ctx context.Context, kvp *model.KVPair) 
 	// As a special case for the CNI plugin, try to patch the Pod with the IP that we've calculated.
 	// This works around a bug in kubelet that causes it to delay writing the Pod IP for a long time:
 	// https://github.com/kubernetes/kubernetes/issues/39113.
-	return c.patchPodIP(ctx, kvp)
+	return c.patchInPodIPs(ctx, kvp)
 }
 
 func (c *WorkloadEndpointClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -76,37 +76,49 @@ func (c *WorkloadEndpointClient) DeleteKVP(ctx context.Context, kvp *model.KVPai
 }
 
 func (c *WorkloadEndpointClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
-	log.Warn("Operation Delete is not supported on WorkloadEndpoint type")
-	return nil, cerrors.ErrorOperationNotSupported{
-		Identifier: key,
-		Operation:  "Delete",
-	}
+	log.Debug("Delete for WorkloadEndpoint, patching out annotations.")
+	return c.patchOutPodIPs(ctx, key)
 }
 
-// patchPodIP PATCHes the Kubernetes Pod associated with the given KVPair with the IP addresses it contains.
+// patchInPodIPs PATCHes the Kubernetes Pod associated with the given KVPair with the IP addresses it contains.
 // This is a no-op if there is no IP address.
 //
 // We store the IP addresses in annotations because patching the PodStatus directly races with changes that
 // kubelet makes so kubelet can undo our changes.
-func (c *WorkloadEndpointClient) patchPodIP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+func (c *WorkloadEndpointClient) patchInPodIPs(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	ips := kvp.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks
 	if len(ips) == 0 {
 		return kvp, nil
 	}
 
 	log.Debugf("PATCHing pod with IPs: %v", ips)
-	wepID, err := c.converter.ParseWorkloadEndpointName(kvp.Key.(model.ResourceKey).Name)
+	key := kvp.Key
+	return c.patchPodIPAnnotations(key, ips)
+}
+
+// patchOutPodIPs sets our pod IP annotations to empty strings; this is used to signal that the IP has been removed
+// from the pod at teardown.
+func (c *WorkloadEndpointClient) patchOutPodIPs(ctx context.Context, key model.Key) (*model.KVPair, error) {
+	return c.patchPodIPAnnotations(key, nil)
+}
+
+func (c *WorkloadEndpointClient) patchPodIPAnnotations(key model.Key, ips []string) (*model.KVPair, error) {
+	wepID, err := c.converter.ParseWorkloadEndpointName(key.(model.ResourceKey).Name)
 	if err != nil {
 		return nil, err
 	}
 	if wepID.Pod == "" {
-		return nil, cerrors.ErrorInsufficientIdentifiers{Name: kvp.Key.(model.ResourceKey).Name}
+		return nil, cerrors.ErrorInsufficientIdentifiers{Name: key.(model.ResourceKey).Name}
 	}
 	// Write the IP addresses into annotations.  This generates an event more quickly than
 	// waiting for kubelet to update the PodStatus PodIP and PodIPs fields.
-	ns := kvp.Key.(model.ResourceKey).Namespace
+	ns := key.(model.ResourceKey).Namespace
+	firstIP := ""
+	if len(ips) > 0 {
+		firstIP = ips[0]
+	}
 	patch, err := calculateAnnotationPatch(
-		conversion.AnnotationPodIP, ips[0],
+		conversion.AnnotationPodIP, firstIP,
 		conversion.AnnotationPodIPs, strings.Join(ips, ","),
 	)
 	if err != nil {
@@ -115,7 +127,7 @@ func (c *WorkloadEndpointClient) patchPodIP(ctx context.Context, kvp *model.KVPa
 	}
 	pod, err := c.clientSet.CoreV1().Pods(ns).Patch(wepID.Pod, types.StrategicMergePatchType, patch, "status")
 	if err != nil {
-		return nil, K8sErrorToCalico(err, kvp.Key)
+		return nil, K8sErrorToCalico(err, key)
 	}
 	log.Debugf("Successfully PATCHed pod to add podIP annotation: %+v", pod)
 

--- a/lib/clientv3/resources.go
+++ b/lib/clientv3/resources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -173,7 +173,13 @@ func (c *resources) Delete(ctx context.Context, opts options.DeleteOptions, kind
 		Name:      name,
 		Namespace: ns,
 	}
-	kvp, err := c.backend.Delete(ctx, key, opts.ResourceVersion)
+	// Wrap the Key in a KVPair so we can pass the UID through.
+	kvpIn := model.KVPair{
+		Key:      key,
+		Revision: opts.ResourceVersion,
+		UID:      opts.UID,
+	}
+	kvp, err := c.backend.DeleteKVP(ctx, &kvpIn)
 	if kvp != nil {
 		return c.kvPairToResource(kvp), err
 	}

--- a/lib/options/delete.go
+++ b/lib/options/delete.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
 
 package options
 
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
 // DeleteOptions is the standard options for deleting a resource through the Calico API.
 type DeleteOptions struct {
 	// When specified:
@@ -21,4 +25,8 @@ type DeleteOptions struct {
 	// - if set to non zero, then the result is at least as fresh as given rv.
 	// +optional
 	ResourceVersion string
+
+	// If non-nil and supported by the backend (only KDD WorkloadEndpoints at the time of writing),
+	// only delete the resource if its UID matches.
+	UID *types.UID
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This fixes handling of pods that get stuck in Terminating state _after_ the CNI plugin has been called:

- Pod delete sets the deletion timestamp on the resource but the resource is not actually deleted until it has been torn down.
- Pod gets its grace period to shut down.
- After the grace period, `kubelet` issues a CNI DEL, which succeeds, removes the interface and returns the IP to the pool.
- One of the following phases of teardown fails; the pod get stuck in Terminating state, with a deletion timestamp but `kubelet` is unable to clean it up.
- To libcalico-go, the pod looks to still be alive with its old IP so we include it in policy and workload endpoint calculations.
- The IP is free and it ends up getting allocated to another pod.  This confuses policy and makes felix think it has duplicate endpoints.

Fix:
* Zero out the annotations used for signaling in the pod IP and use deletion timestamp + zero annotation to signal that the IP is gone.
* Leave the podIP alone since it's the Kubernetes norm to preserve that.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In Kubernetes API Datastore mode, record when a pod is deleted from the network; this prevents pods that are stuck in Terminating state from being treated as active pods, resulting in duplicate IP errors and incorrect IP set calculation.
```
