### PR TITLE
Work around: Drop the resource version when patching pods to add IPs.

### DIFF
--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -1727,10 +1727,6 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 
 			By("Marking the Pod as running again", func() {
 				if finishPhase == "Terminating" {
-					// Revision is now out of date, create should fail.
-					_, err := c.Update(ctx, wepKV)
-					Expect(err).To(BeAssignableToTypeOf(cerrors.ErrorResourceUpdateConflict{}))
-
 					// Recreate the WEP (this puts the annotations back again).
 					wepKV.Revision = ""
 					wepKV.UID = nil

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -93,7 +93,10 @@ func (c *WorkloadEndpointClient) patchInPodIPs(ctx context.Context, kvp *model.K
 
 	log.Debugf("PATCHing pod with IPs: %v", ips)
 	key := kvp.Key
-	return c.patchPodIPAnnotations(key, kvp.Revision, kvp.UID, ips)
+	
+	// Note: we drop the revision here because the CNI plugin can't handle a retry right now (and the kubelet
+	// ensures that only one CNI ADD for a given UID can be in progress).
+	return c.patchPodIPAnnotations(key, "", kvp.UID, ips)
 }
 
 // patchOutPodIPs sets our pod IP annotations to empty strings; this is used to signal that the IP has been removed


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The CNI plugin can't handle the version conflict and I think kubelet ensures
that more than one CNI plugin can't run at once so any conflicts are spurious.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
