### PR TITLE
Change Unicode apostrophe in API comments to ASCII apostrophe

### DIFF
--- a/config/crd/crd.projectcalico.org_bgppeers.yaml
+++ b/config/crd/crd.projectcalico.org_bgppeers.yaml
@@ -67,7 +67,7 @@ spec:
                   peering between the local node and selected remote nodes, we configure
                   an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
                   and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
-                  remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
+                  remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
                   or the global default if that is not set.
                 type: string
             required:

--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -105,10 +105,10 @@ spec:
                   `tc exec bpf debug`. [Default: Off].'
                 type: string
               chainInsertMode:
-                description: 'ChainInsertMode controls whether Felix hooks the kernel’s
+                description: 'ChainInsertMode controls whether Felix hooks the kernel''s
                   top-level iptables chains by inserting a rule at the top of the
                   chain or by appending a rule at the bottom. insert is the safe default
-                  since it prevents Calico’s rules from being bypassed. If you switch
+                  since it prevents Calico''s rules from being bypassed. If you switch
                   to append mode, be sure that the other rules in the chains signal
                   acceptance by falling through to the Calico rules, otherwise the
                   Calico policy will be bypassed. [Default: insert]'
@@ -190,7 +190,7 @@ spec:
                   Each port should be specified as tcp:<port-number> or udp:<port-number>.
                   For back-compatibility, if the protocol is not specified, it defaults
                   to “tcp”. To disable all outbound host ports, use the value none.
-                  The default value opens etcd’s standard ports to ensure that Felix
+                  The default value opens etcd''s standard ports to ensure that Felix
                   does not get cut off from etcd as well as allowing DHCP and DNS.
                   [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
                   udp:53, udp:67]'
@@ -242,8 +242,8 @@ spec:
                   workload endpoints and so distinguishes them from host endpoint
                   interfaces. Note: in environments other than bare metal, the orchestrators
                   configure this appropriately. For example our Kubernetes and Docker
-                  integrations set the ‘cali’ value, and our OpenStack integration
-                  sets the ‘tap’ value. [Default: cali]'
+                  integrations set the ''cali'' value, and our OpenStack integration
+                  sets the ''tap'' value. [Default: cali]'
                 type: string
               interfaceRefreshInterval:
                 description: InterfaceRefreshInterval is the period at which Felix
@@ -259,7 +259,7 @@ spec:
               ipsetsRefreshInterval:
                 description: 'IpsetsRefreshInterval is the period at which Felix re-checks
                   all iptables state to ensure that no other process has accidentally
-                  broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
+                  broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
                   90s]'
                 type: string
               iptablesBackend:
@@ -271,7 +271,7 @@ spec:
               iptablesLockFilePath:
                 description: 'IptablesLockFilePath is the location of the iptables
                   lock file. You may need to change this if the lock file is not in
-                  its standard location (for example if you have mapped it into Felix’s
+                  its standard location (for example if you have mapped it into Felix''s
                   container at a different path). [Default: /run/xtables.lock]'
                 type: string
               iptablesLockProbeInterval:
@@ -303,16 +303,16 @@ spec:
                 description: 'IptablesPostWriteCheckInterval is the period after Felix
                   has done a write to the dataplane that it schedules an extra read
                   back in order to check the write was not clobbered by another process.
-                  This should only occur if another application on the system doesn’t
+                  This should only occur if another application on the system doesn''t
                   respect the iptables lock. [Default: 1s]'
                 type: string
               iptablesRefreshInterval:
                 description: 'IptablesRefreshInterval is the period at which Felix
                   re-checks the IP sets in the dataplane to ensure that no other process
-                  has accidentally broken Calico’s rules. Set to 0 to disable IP sets
-                  refresh. Note: the default for this value is lower than the other
-                  refresh intervals as a workaround for a Linux kernel bug that was
-                  fixed in kernel version 4.11. If you are using v4.11 or greater
+                  has accidentally broken Calico''s rules. Set to 0 to disable IP
+                  sets refresh. Note: the default for this value is lower than the
+                  other refresh intervals as a workaround for a Linux kernel bug that
+                  was fixed in kernel version 4.11. If you are using v4.11 or greater
                   you may want to set this to, a higher value to reduce Felix CPU
                   usage. [Default: 10s]'
                 type: string
@@ -363,8 +363,8 @@ spec:
                 type: string
               metadataPort:
                 description: 'MetadataPort is the port of the metadata server. This,
-                  combined with global.MetadataAddr (if not ‘None’), is used to set
-                  up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  combined with global.MetadataAddr (if not ''None''), is used to
+                  set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
                   In most cases this should not need to be changed [Default: 8775].'
                 type: integer
               natOutgoingAddress:
@@ -437,9 +437,9 @@ spec:
                   status reports. [Default: 90s]'
                 type: string
               routeRefreshInterval:
-                description: 'RouterefreshInterval is the period at which Felix re-checks
+                description: 'RouteRefreshInterval is the period at which Felix re-checks
                   the routes in the dataplane to ensure that no other process has
-                  accidentally broken Calico’s rules. Set to 0 to disable route refresh.
+                  accidentally broken Calico''s rules. Set to 0 to disable route refresh.
                   [Default: 90s]'
                 type: string
               routeSource:

--- a/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -208,7 +208,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:
@@ -237,7 +237,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:
@@ -539,7 +539,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:
@@ -568,7 +568,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:

--- a/config/crd/crd.projectcalico.org_networkpolicies.yaml
+++ b/config/crd/crd.projectcalico.org_networkpolicies.yaml
@@ -197,7 +197,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:
@@ -226,7 +226,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:
@@ -528,7 +528,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:
@@ -557,7 +557,7 @@ spec:
                         code:
                           description: Match on a specific ICMP code.  If specified,
                             the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
+                            limitation imposed by the kernel's iptables firewall,
                             which Calico uses to enforce the rule.
                           type: integer
                         type:

--- a/lib/apis/v3/bgppeer.go
+++ b/lib/apis/v3/bgppeer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ type BGPPeerSpec struct {
 	// selected remote nodes, we configure an IPv4 peering if both ends have
 	// NodeBGPSpec.IPv4Address specified, and an IPv6 peering if both ends have
 	// NodeBGPSpec.IPv6Address specified.  The remote AS number comes from the remote
-	// node’s NodeBGPSpec.ASNumber, or the global default if that is not set.
+	// node's NodeBGPSpec.ASNumber, or the global default if that is not set.
 	PeerSelector string `json:"peerSelector,omitempty" validate:"omitempty,selector"`
 	// Option to keep the original nexthop field when routes are sent to a BGP Peer.
 	// Setting "true" configures the selected BGP Peers node to use the "next hop keep;"

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -57,15 +57,15 @@ type FelixConfigurationSpec struct {
 
 	IPv6Support *bool `json:"ipv6Support,omitempty" confignamev1:"Ipv6Support"`
 
-	// RouterefreshInterval is the period at which Felix re-checks the routes
-	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.
+	// RouteRefreshInterval is the period at which Felix re-checks the routes
+	// in the dataplane to ensure that no other process has accidentally broken Calico's rules.
 	// Set to 0 to disable route refresh. [Default: 90s]
 	RouteRefreshInterval *metav1.Duration `json:"routeRefreshInterval,omitempty" configv1timescale:"seconds"`
 	// InterfaceRefreshInterval is the period at which Felix rescans local interfaces to verify their state.
 	// The rescan can be disabled by setting the interval to 0.
 	InterfaceRefreshInterval *metav1.Duration `json:"interfaceRefreshInterval,omitempty" configv1timescale:"seconds"`
 	// IptablesRefreshInterval is the period at which Felix re-checks the IP sets
-	// in the dataplane to ensure that no other process has accidentally broken Calico’s rules.
+	// in the dataplane to ensure that no other process has accidentally broken Calico's rules.
 	// Set to 0 to disable IP sets refresh. Note: the default for this value is lower than the
 	// other refresh intervals as a workaround for a Linux kernel bug that was fixed in kernel
 	// version 4.11. If you are using v4.11 or greater you may want to set this to, a higher value
@@ -74,10 +74,10 @@ type FelixConfigurationSpec struct {
 	// IptablesPostWriteCheckInterval is the period after Felix has done a write
 	// to the dataplane that it schedules an extra read back in order to check the write was not
 	// clobbered by another process. This should only occur if another application on the system
-	// doesn’t respect the iptables lock. [Default: 1s]
+	// doesn't respect the iptables lock. [Default: 1s]
 	IptablesPostWriteCheckInterval *metav1.Duration `json:"iptablesPostWriteCheckInterval,omitempty" configv1timescale:"seconds" confignamev1:"IptablesPostWriteCheckIntervalSecs"`
 	// IptablesLockFilePath is the location of the iptables lock file. You may need to change this
-	// if the lock file is not in its standard location (for example if you have mapped it into Felix’s
+	// if the lock file is not in its standard location (for example if you have mapped it into Felix's
 	// container at a different path). [Default: /run/xtables.lock]
 	IptablesLockFilePath string `json:"iptablesLockFilePath,omitempty"`
 	// IptablesLockTimeout is the time that Felix will wait for the iptables lock,
@@ -97,7 +97,7 @@ type FelixConfigurationSpec struct {
 	// auto-detected.
 	FeatureDetectOverride string `json:"featureDetectOverride,omitempty" validate:"omitempty,keyValueList"`
 	// IpsetsRefreshInterval is the period at which Felix re-checks all iptables
-	// state to ensure that no other process has accidentally broken Calico’s rules. Set to 0 to
+	// state to ensure that no other process has accidentally broken Calico's rules. Set to 0 to
 	// disable iptables refresh. [Default: 90s]
 	IpsetsRefreshInterval *metav1.Duration `json:"ipsetsRefreshInterval,omitempty" configv1timescale:"seconds"`
 	MaxIpsetSize          *int             `json:"maxIpsetSize,omitempty"`
@@ -117,7 +117,7 @@ type FelixConfigurationSpec struct {
 	// set up any NAT rule for the metadata path. [Default: 127.0.0.1]
 	MetadataAddr string `json:"metadataAddr,omitempty"`
 	// MetadataPort is the port of the metadata server. This, combined with global.MetadataAddr (if
-	// not ‘None’), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+	// not 'None'), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
 	// In most cases this should not need to be changed [Default: 8775].
 	MetadataPort *int `json:"metadataPort,omitempty"`
 
@@ -129,8 +129,8 @@ type FelixConfigurationSpec struct {
 
 	// InterfacePrefix is the interface name prefix that identifies workload endpoints and so distinguishes
 	// them from host endpoint interfaces. Note: in environments other than bare metal, the orchestrators
-	// configure this appropriately. For example our Kubernetes and Docker integrations set the ‘cali’ value,
-	// and our OpenStack integration sets the ‘tap’ value. [Default: cali]
+	// configure this appropriately. For example our Kubernetes and Docker integrations set the 'cali' value,
+	// and our OpenStack integration sets the 'tap' value. [Default: cali]
 	InterfacePrefix string `json:"interfacePrefix,omitempty"`
 	// InterfaceExclude is a comma-separated list of interfaces that Felix should exclude when monitoring for host
 	// endpoints. The default value ensures that Felix ignores Kubernetes' IPVS dummy interface, which is used
@@ -140,9 +140,9 @@ type FelixConfigurationSpec struct {
 	// 'veth1'. [Default: kube-ipvs0]
 	InterfaceExclude string `json:"interfaceExclude,omitempty"`
 
-	// ChainInsertMode controls whether Felix hooks the kernel’s top-level iptables chains by inserting a rule
+	// ChainInsertMode controls whether Felix hooks the kernel's top-level iptables chains by inserting a rule
 	// at the top of the chain or by appending a rule at the bottom. insert is the safe default since it prevents
-	// Calico’s rules from being bypassed. If you switch to append mode, be sure that the other rules in the chains
+	// Calico's rules from being bypassed. If you switch to append mode, be sure that the other rules in the chains
 	// signal acceptance by falling through to the Calico rules, otherwise the Calico policy will be bypassed.
 	// [Default: insert]
 	ChainInsertMode string `json:"chainInsertMode,omitempty"`
@@ -222,7 +222,7 @@ type FelixConfigurationSpec struct {
 	// FailsafeOutboundHostPorts is a comma-delimited list of UDP/TCP ports that Felix will allow outgoing traffic from host endpoints to
 	// irrespective of the security policy. This is useful to avoid accidentally cutting off a host with incorrect configuration. Each port
 	// should be specified as tcp:<port-number> or udp:<port-number>. For back-compatibility, if the protocol is not specified, it defaults
-	// to “tcp”. To disable all outbound host ports, use the value none. The default value opens etcd’s standard ports to ensure that Felix
+	// to “tcp”. To disable all outbound host ports, use the value none. The default value opens etcd's standard ports to ensure that Felix
 	// does not get cut off from etcd as well as allowing DHCP and DNS.
 	// [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667, udp:53, udp:67]
 	FailsafeOutboundHostPorts *[]ProtoPort `json:"failsafeOutboundHostPorts,omitempty"`

--- a/lib/apis/v3/hostendpoint.go
+++ b/lib/apis/v3/hostendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // HostEndpoint contains information about a HostEndpoint resource that represents a “bare-metal”
-// interface attached to the host that is running Calico’s agent, Felix. By default, Calico doesn’t
+// interface attached to the host that is running Calico's agent, Felix. By default, Calico doesn’t
 // apply any policy to such interfaces.
 type HostEndpoint struct {
 	metav1.TypeMeta `json:",inline"`

--- a/lib/apis/v3/policy.go
+++ b/lib/apis/v3/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018,2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ type ICMPFields struct {
 	// (i.e. pings).
 	Type *int `json:"type,omitempty" validate:"omitempty,gte=0,lte=254"`
 	// Match on a specific ICMP code.  If specified, the Type value must also be specified.
-	// This is a technical limitation imposed by the kernel’s iptables firewall, which
+	// This is a technical limitation imposed by the kernel's iptables firewall, which
 	// Calico uses to enforce the rule.
 	Code *int `json:"code,omitempty" validate:"omitempty,gte=0,lte=255"`
 }

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -93,7 +93,7 @@ func (c *WorkloadEndpointClient) patchInPodIPs(ctx context.Context, kvp *model.K
 
 	log.Debugf("PATCHing pod with IPs: %v", ips)
 	key := kvp.Key
-	
+
 	// Note: we drop the revision here because the CNI plugin can't handle a retry right now (and the kubelet
 	// ensures that only one CNI ADD for a given UID can be in progress).
 	return c.patchPodIPAnnotations(key, "", kvp.UID, ips)


### PR DESCRIPTION
These API comments are automatically propagated to CRD YAMLs, which
don't support Unicode apostrophes.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
