### PR TITLE
[v3.15] Backport fix for nil Node resource

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -183,11 +183,14 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 			Revision: kvp.Revision,
 		},
 		{
+			// Include the original node KVP info as a separate update. Note we do not use the node value here because
+			// a nil interface is different to a nil pointer. Felix and other code assumes a nil Value is a delete, so
+			// preserve that relationship here.
 			Key: model.ResourceKey{
 				Name: name,
 				Kind: apiv3.KindNode,
 			},
-			Value:    node,
+			Value:    kvp.Value,
 			Revision: kvp.Revision,
 		},
 		{

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
@@ -359,6 +359,17 @@ var _ = Describe("Test the (Felix) Node update processor with USE_POD_CIDR=true"
 		up.OnSyncerStarting()
 	})
 
+	It("should contain updates with nil values for a delete", func() {
+		kvps, err := up.Process(&model.KVPair{
+			Key:   v3NodeKey1,
+			Value: nil,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		for i := range kvps {
+			Expect(kvps[i].Value == nil).To(BeTrue(), kvps[i].Key.String())
+		}
+	})
+
 	It("should properly convert nodes into blocks for Felix", func() {
 		By("converting a node with PodCIDRs set")
 		res := apiv3.NewNode()


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Backport #1288 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that libcalico-go could emit a nil Node resource resulting in a memory leak in Typha and errors in Felix.
```
