### PR TITLE
Configure max blocks per-host in IPAMConfig

### DIFF
--- a/config/crd/crd.projectcalico.org_ipamconfigs.yaml
+++ b/config/crd/crd.projectcalico.org_ipamconfigs.yaml
@@ -38,6 +38,10 @@ spec:
             properties:
               autoAllocateBlocks:
                 type: boolean
+              maxBlocksPerHost:
+                description: MaxBlocksPerHost, if non-zero, is the max number of blocks
+                  that can be affine to each host.
+                type: integer
               strictAffinity:
                 type: boolean
             required:

--- a/lib/apis/v3/ipam_config.go
+++ b/lib/apis/v3/ipam_config.go
@@ -29,8 +29,10 @@ const (
 // IPAMConfig contains information about a block for IP address assignment.
 type IPAMConfig struct {
 	metav1.TypeMeta `json:",inline"`
+
 	// Standard object's metadata.
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+
 	// Specification of the IPAMConfig.
 	Spec IPAMConfigSpec `json:"spec,omitempty"`
 }
@@ -39,6 +41,11 @@ type IPAMConfig struct {
 type IPAMConfigSpec struct {
 	StrictAffinity     bool `json:"strictAffinity"`
 	AutoAllocateBlocks bool `json:"autoAllocateBlocks"`
+
+	// MaxBlocksPerHost, if non-zero, is the max number of blocks that can be
+	// affine to each host.
+	// +optional
+	MaxBlocksPerHost int `json:"maxBlocksPerHost,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/lib/backend/k8s/resources/ipam_config.go
+++ b/lib/backend/k8s/resources/ipam_config.go
@@ -70,6 +70,7 @@ func (c ipamConfigClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
 		Value: &model.IPAMConfig{
 			StrictAffinity:     v3obj.Spec.StrictAffinity,
 			AutoAllocateBlocks: v3obj.Spec.AutoAllocateBlocks,
+			MaxBlocksPerHost:   v3obj.Spec.MaxBlocksPerHost,
 		},
 		Revision: kvpv3.Revision,
 		UID:      &kvpv3.Value.(*apiv3.IPAMConfig).UID,
@@ -97,6 +98,7 @@ func (c ipamConfigClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
 			Spec: apiv3.IPAMConfigSpec{
 				StrictAffinity:     v1obj.StrictAffinity,
 				AutoAllocateBlocks: v1obj.AutoAllocateBlocks,
+				MaxBlocksPerHost:   v1obj.MaxBlocksPerHost,
 			},
 		},
 		Revision: kvpv1.Revision,

--- a/lib/backend/model/ipam_config.go
+++ b/lib/backend/model/ipam_config.go
@@ -51,4 +51,5 @@ func (key IPAMConfigKey) String() string {
 type IPAMConfig struct {
 	StrictAffinity     bool `json:"strict_affinity,omitempty"`
 	AutoAllocateBlocks bool `json:"auto_allocate_blocks,omitempty"`
+	MaxBlocksPerHost   int  `json:"maxBlocksPerHost,omitempty"`
 }

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -564,6 +564,19 @@ func (c ipamClient) autoAssign(ctx context.Context, num int, handleID *string, a
 		return nil, err
 	}
 
+	// Merge in any global config, if it exists. We use the more restrictive value between
+	// the global max block limit, and the limit provided on this particular request.
+	if config.MaxBlocksPerHost > 0 && maxNumBlocks > 0 && maxNumBlocks > config.MaxBlocksPerHost {
+		// The global config is more restrictive, so use it instead.
+		maxNumBlocks = config.MaxBlocksPerHost
+	} else if maxNumBlocks == 0 {
+		// No per-request value, so use the global one.
+		maxNumBlocks = config.MaxBlocksPerHost
+	}
+	if maxNumBlocks > 0 {
+		logCtx.Debugf("Host must not use more than %d blocks", maxNumBlocks)
+	}
+
 	s := &blockAssignState{
 		client:                c,
 		version:               version,
@@ -1522,7 +1535,11 @@ func (c ipamClient) GetIPAMConfig(ctx context.Context) (config *IPAMConfig, err 
 		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
 			// IPAMConfig has not been explicitly set.  Return
 			// a default IPAM configuration.
-			config = &IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: false}
+			config = &IPAMConfig{
+				AutoAllocateBlocks: true,
+				StrictAffinity:     false,
+				MaxBlocksPerHost:   0,
+			}
 			err = nil
 		} else {
 			log.Errorf("Error getting IPAMConfig: %v", err)
@@ -1591,6 +1608,7 @@ func (c ipamClient) convertIPAMConfigToBackend(cfg *IPAMConfig) *model.IPAMConfi
 	return &model.IPAMConfig{
 		StrictAffinity:     cfg.StrictAffinity,
 		AutoAllocateBlocks: cfg.AutoAllocateBlocks,
+		MaxBlocksPerHost:   cfg.MaxBlocksPerHost,
 	}
 }
 
@@ -1598,6 +1616,7 @@ func (c ipamClient) convertBackendToIPAMConfig(cfg *model.IPAMConfig) *IPAMConfi
 	return &IPAMConfig{
 		StrictAffinity:     cfg.StrictAffinity,
 		AutoAllocateBlocks: cfg.AutoAllocateBlocks,
+		MaxBlocksPerHost:   cfg.MaxBlocksPerHost,
 	}
 }
 

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -743,6 +743,110 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			err = ic.ReleaseByHandle(context.Background(), handle1)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should respect MaxBlocksPerHost", func() {
+			ctx := context.Background()
+			bc.Clean()
+			deleteAllPools()
+
+			err := applyNode(bc, kc, node1, map[string]string{"foo": "bar"})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = applyNode(bc, kc, node2, map[string]string{"foo": "bar"})
+			Expect(err).NotTo(HaveOccurred())
+
+			// StrictAffinity is false, max blocks per host is 2
+			cfg := IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: false, MaxBlocksPerHost: 2}
+			err = ic.SetIPAMConfig(ctx, cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Pool is a /28, with /30 blocks. e.g., 4 blocks with 4 addresses each.
+			applyPoolWithBlockSize("10.0.0.0/28", true, `foo == "bar"`, 30)
+
+			// We should be able to assign 8 addresses to node0, fully using its two blocks.
+			for i := 0; i < 8; i++ {
+				v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+					Num4:     1,
+					Num6:     0,
+					Hostname: node1,
+					HandleID: &node1,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(v4)).To(Equal(1))
+			}
+
+			// Attempting to allocate a ninth address should fail, since
+			// it would require allcoating a third block.
+			v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+				Num4:     1,
+				Num6:     0,
+				Hostname: node1,
+				HandleID: &node1,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(len(v4)).To(Equal(0))
+
+			// Allocate a block for the OTHER node with a single address.
+			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+				Num4:     1,
+				Num6:     0,
+				Hostname: node2,
+				HandleID: &node2,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(v4)).To(Equal(1))
+
+			// Attempting to allocate a ninth address should still fail, even though
+			// strict affinity is disabled, since max blocks takes precedence.
+			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+				Num4:     1,
+				Num6:     0,
+				Hostname: node1,
+				HandleID: &node1,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(len(v4)).To(Equal(0))
+
+			// And, we should respect the global config even if a per-request value is provided,
+			// if it is more restrictive.
+			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+				Num4:             1,
+				Num6:             0,
+				Hostname:         node1,
+				HandleID:         &node1,
+				MaxBlocksPerHost: 3,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(len(v4)).To(Equal(0))
+
+			// Increase the global limit.
+			cfg = IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: false, MaxBlocksPerHost: 3}
+			err = ic.SetIPAMConfig(ctx, cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Try again, but with a more restrictive per-request value that will still fail,
+			// since the more restrictive value takes precedence.
+			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+				Num4:             1,
+				Num6:             0,
+				Hostname:         node1,
+				HandleID:         &node1,
+				MaxBlocksPerHost: 2,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(len(v4)).To(Equal(0))
+
+			// Finally, send a request with no-limit. Now that the global value is higher,
+			// we should get a new block.
+			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+				Num4:     1,
+				Num6:     0,
+				Hostname: node1,
+				HandleID: &node1,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(v4)).To(Equal(1))
+		})
 	})
 
 	Describe("IPAM AutoAssign from any pool", func() {

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -755,8 +755,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			err = applyNode(bc, kc, node2, map[string]string{"foo": "bar"})
 			Expect(err).NotTo(HaveOccurred())
 
-			// StrictAffinity is false, max blocks per host is 2
-			cfg := IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: false, MaxBlocksPerHost: 2}
+			// StrictAffinity is true, max blocks per host is 2
+			cfg := IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: true, MaxBlocksPerHost: 2}
 			err = ic.SetIPAMConfig(ctx, cfg)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -796,8 +796,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(v4)).To(Equal(1))
 
-			// Attempting to allocate a ninth address should still fail, even though
-			// strict affinity is disabled, since max blocks takes precedence.
+			// Attempting to allocate a ninth address should still fail, due to
+			// strict affinity.
 			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
@@ -820,7 +820,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(v4)).To(Equal(0))
 
 			// Increase the global limit.
-			cfg = IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: false, MaxBlocksPerHost: 3}
+			cfg = IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: true, MaxBlocksPerHost: 3}
 			err = ic.SetIPAMConfig(ctx, cfg)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/lib/ipam/ipam_types.go
+++ b/lib/ipam/ipam_types.go
@@ -94,6 +94,10 @@ type IPAMConfig struct {
 	// allocate blocks of IP address to hosts as needed to assign addresses.
 	// If false, then StrictAffinity must be true.  The default value is true.
 	AutoAllocateBlocks bool
+
+	// If non-zero, MaxBlocksPerHost specifies the max number of blocks that may
+	// be affine to a node.
+	MaxBlocksPerHost int
 }
 
 // GetUtilizationArgs defines the set of arguments for requesting IP utilization.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Allows setting a global option for max blocks per-host. This is a nifty
tunable that, in conjunction with strict affinity, can help mitigate scenarios where one or more hosts end up
attempting to allocate more blocks than they should.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Support global configuration for max blocks per node
```