### PR TITLE
Automated cherry pick of #1296: Add new FelixConfiguration knobs for disabling encap drop #1298: Add kubebuilder markers to FelixConfiguration encap knobs

### DIFF
--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -36,6 +36,16 @@ spec:
           spec:
             description: FelixConfigurationSpec contains the values of the Felix configuration.
             properties:
+              allowIPIPPacketsFromWorkloads:
+                description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop IPIP encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
+              allowVXLANPacketsFromWorkloads:
+                description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop VXLAN encapsulated traffic from workloads
+                  [Default: false]'
+                type: boolean
               bpfConnectTimeLoadBalancingEnabled:
                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
                   controls whether Felix installs the connection-time load balancer.  The

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -162,6 +162,13 @@ type FelixConfigurationSpec struct {
 	VXLANPort *int `json:"vxlanPort,omitempty"`
 	VXLANVNI  *int `json:"vxlanVNI,omitempty"`
 
+	// AllowVXLANPacketsFromWorkloads controls whether Felix will add a rule to drop VXLAN encapsulated traffic
+	// from workloads [Default: false]
+	AllowVXLANPacketsFromWorkloads *bool `json:"allowVXLANPacketsFromWorkloads,omitempty"`
+	// AllowIPIPPacketsFromWorkloads controls whether Felix will add a rule to drop IPIP encapsulated traffic
+	// from workloads [Default: false]
+	AllowIPIPPacketsFromWorkloads *bool `json:"allowIPIPPacketsFromWorkloads,omitempty"`
+
 	// ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.
 	// Must be non-zero in OpenStack deployments. [Default: 30s]
 	ReportingInterval *metav1.Duration `json:"reportingInterval,omitempty" configv1timescale:"seconds" confignamev1:"ReportingIntervalSecs"`

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -164,9 +164,11 @@ type FelixConfigurationSpec struct {
 
 	// AllowVXLANPacketsFromWorkloads controls whether Felix will add a rule to drop VXLAN encapsulated traffic
 	// from workloads [Default: false]
+	// +optional
 	AllowVXLANPacketsFromWorkloads *bool `json:"allowVXLANPacketsFromWorkloads,omitempty"`
 	// AllowIPIPPacketsFromWorkloads controls whether Felix will add a rule to drop IPIP encapsulated traffic
 	// from workloads [Default: false]
+	// +optional
 	AllowIPIPPacketsFromWorkloads *bool `json:"allowIPIPPacketsFromWorkloads,omitempty"`
 
 	// ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -655,6 +655,16 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.AllowVXLANPacketsFromWorkloads != nil {
+		in, out := &in.AllowVXLANPacketsFromWorkloads, &out.AllowVXLANPacketsFromWorkloads
+		*out = new(bool)
+		**out = **in
+	}
+	if in.AllowIPIPPacketsFromWorkloads != nil {
+		in, out := &in.AllowIPIPPacketsFromWorkloads, &out.AllowIPIPPacketsFromWorkloads
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ReportingInterval != nil {
 		in, out := &in.ReportingInterval, &out.ReportingInterval
 		*out = new(v1.Duration)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindBGPConfiguration,
 		Name: "node.bgpnode1",
 	}
-	numFelixConfigs := 85
+	numFelixConfigs := 87
 	numClusterConfigs := 5
 	numNodeClusterConfigs := 4
 	numBgpConfigs := 5


### PR DESCRIPTION
Cherry pick of #1296 #1298 on release-v3.15.

#1296: Add new FelixConfiguration knobs for disabling encap drop
#1298: Add kubebuilder markers to FelixConfiguration encap knobs

```release-note
Add FelixConfiguration parameters to explicitly allow encapsulated packets from workloads.
```
