### PR TITLE
remove spurious annotations and creationtimestamps from crds

### DIFF
--- a/config.patch
+++ b/config.patch
@@ -11,3 +11,183 @@ diff -Naur config.orig/crd/crd.projectcalico.org_ipamblocks.yaml config/crd/crd.
                  type: array
                attributes:
                  items:
+--- config.orig/crd/crd.projectcalico.org_bgpconfigurations.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_bgpconfigurations.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: bgpconfigurations.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_bgppeers.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_bgppeers.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: bgppeers.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_blockaffinities.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_blockaffinities.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: blockaffinities.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_clusterinformations.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_clusterinformations.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: clusterinformations.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_felixconfigurations.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_felixconfigurations.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: felixconfigurations.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_globalnetworkpolicies.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: globalnetworkpolicies.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_globalnetworksets.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_globalnetworksets.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: globalnetworksets.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_hostendpoints.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_hostendpoints.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: hostendpoints.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_ipamblocks.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_ipamblocks.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: ipamblocks.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_ipamconfigs.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_ipamconfigs.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: ipamconfigs.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_ipamhandles.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_ipamhandles.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: ipamhandles.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_ippools.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_ippools.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: ippools.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: kubecontrollersconfigurations.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_networkpolicies.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_networkpolicies.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: networkpolicies.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org
+--- config.orig/crd/crd.projectcalico.org_networksets.yaml	2020-09-15 17:41:44.686361905 +0000
++++ config/crd/crd.projectcalico.org_networksets.yaml	2020-09-15 17:43:02.428632997 +0000
+@@ -3,9 +3,6 @@
+ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: (devel)
+-  creationTimestamp: null
+   name: networksets.crd.projectcalico.org
+ spec:
+   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_bgppeers.yaml
+++ b/config/crd/crd.projectcalico.org_bgppeers.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_blockaffinities.yaml
+++ b/config/crd/crd.projectcalico.org_blockaffinities.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: blockaffinities.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_clusterinformations.yaml
+++ b/config/crd/crd.projectcalico.org_clusterinformations.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: clusterinformations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: felixconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_globalnetworksets.yaml
+++ b/config/crd/crd.projectcalico.org_globalnetworksets.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: globalnetworksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_hostendpoints.yaml
+++ b/config/crd/crd.projectcalico.org_hostendpoints.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: hostendpoints.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_ipamblocks.yaml
+++ b/config/crd/crd.projectcalico.org_ipamblocks.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: ipamblocks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_ipamconfigs.yaml
+++ b/config/crd/crd.projectcalico.org_ipamconfigs.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: ipamconfigs.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_ipamhandles.yaml
+++ b/config/crd/crd.projectcalico.org_ipamhandles.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: ipamhandles.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_ippools.yaml
+++ b/config/crd/crd.projectcalico.org_ippools.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: ippools.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: kubecontrollersconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_networkpolicies.yaml
+++ b/config/crd/crd.projectcalico.org_networkpolicies.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: networkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/config/crd/crd.projectcalico.org_networksets.yaml
+++ b/config/crd/crd.projectcalico.org_networksets.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: networksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org


### PR DESCRIPTION
## Description
Remove incorrect `annotations` and `creationTimestamp` from crds, added in https://github.com/projectcalico/calico/pull/3579. Requires cherry-pick back to `release-v3.15` and corresponding manifest changes in https://github.com/projectcalico/calico/.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
