### PR TITLE
Restore defaulting to LoadConfigFromXXX methods.

### DIFF
--- a/lib/apiconfig/load.go
+++ b/lib/apiconfig/load.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package apiconfig
 
 import (
@@ -17,60 +31,38 @@ import (
 // LoadClientConfig loads the ClientConfig from the specified file (if specified)
 // or from environment variables (if the file is not specified).
 func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
-	var c *CalicoAPIConfig
-	var err error
-
 	// Override / merge with values loaded from the specified file.
 	if filename != "" {
-		b, err := ioutil.ReadFile(filename)
-		if err != nil {
-			return nil, err
-		}
-
-		c, err = LoadClientConfigFromBytes(b)
-		if err != nil {
-			return nil, fmt.Errorf("syntax error in %s: %v", filename, err)
-		}
-
+		return LoadClientConfigFromFile(filename)
 	} else {
-		c, err = LoadClientConfigFromEnvironment()
+		return LoadClientConfigFromEnvironment()
 	}
-
-	// If EtcdEndpoints is set and DatastoreType is missing set it to EtcdV3
-	// otherwise set default Datastoretype to Kubernetes
-	if c.Spec.DatastoreType == "" && c.Spec.EtcdEndpoints != "" {
-		c.Spec.DatastoreType = EtcdV3
-	} else if c.Spec.DatastoreType == "" {
-		c.Spec.DatastoreType = Kubernetes
-	}
-
-	if c.Spec.DatastoreType == Kubernetes {
-		// Default to using $(HOME)/.kube/config, unless another means has been configured.
-		switch {
-		case c.Spec.Kubeconfig != "":
-			// A kubeconfig has already been provided.
-		case c.Spec.K8sAPIEndpoint != "":
-			// A k8s API endpoint has been specified explicitly.
-		case os.Getenv("HOME") == "":
-			// No home directory, can't build a default config path.
-		default:
-			// Default the kubeconfig.
-			c.Spec.Kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		}
-	}
-
-	return c, err
 }
 
-// LoadClientConfig loads the ClientConfig from the supplied bytes containing
-// YAML or JSON format data.
+// LoadClientConfigFromFile loads the ClientConfig from the specified file, which must exist.
+// The datastore type is defaulted if not specified.
+func LoadClientConfigFromFile(filename string) (*CalicoAPIConfig, error) {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := LoadClientConfigFromBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("syntax error in %s: %v", filename, err)
+	}
+
+	return c, nil
+}
+
+// LoadClientConfig loads the ClientConfig from the supplied bytes containing YAML or JSON format data.
+// The datastore type is defaulted if not specified.
 func LoadClientConfigFromBytes(b []byte) (*CalicoAPIConfig, error) {
 	var c CalicoAPIConfig
 
 	log.Debug("Loading config from JSON or YAML data")
-
 	if err := yaml.UnmarshalStrict(b, &c); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse config as YAML/JSON: %w", err)
 	}
 
 	// Validate the version and kind.
@@ -81,20 +73,49 @@ func LoadClientConfigFromBytes(b []byte) (*CalicoAPIConfig, error) {
 		return nil, errors.New("invalid config file: expected kind '" + KindCalicoAPIConfig + "', got '" + c.Kind + "'")
 	}
 
+	applyConfigDefaults(&c)
 	log.Debug("Datastore type: ", c.Spec.DatastoreType)
 	return &c, nil
 }
 
-// LoadClientConfig loads the ClientConfig from the specified file (if specified)
-// or from environment variables (if the file is not specified).
+// LoadClientConfigFromEnvironment loads a client config from the environment.
+// The datastore type is defaulted if not specified.
 func LoadClientConfigFromEnvironment() (*CalicoAPIConfig, error) {
 	c := NewCalicoAPIConfig()
-
-	// Load client config from environment variables.
-	log.Debug("Loading config from environment")
 	if err := envconfig.Process("calico", &c.Spec); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load config from env vars: %w", err)
+	}
+	applyConfigDefaults(c)
+	return c, nil
+}
+
+// applyConfigDefaults tries to detect the correct datastore type and config parameters.
+func applyConfigDefaults(c *CalicoAPIConfig) {
+	if c.Spec.DatastoreType == "" {
+		log.Debug("Datastore type isn't set, trying to detect it")
+		if c.Spec.EtcdEndpoints != "" {
+			log.Debug("EtcdEndpoints specified, detected etcdv3.")
+			c.Spec.DatastoreType = EtcdV3
+		} else {
+			log.Debug("No EtcdEndpoints specified, defaulting to kubernetes.")
+			c.Spec.DatastoreType = Kubernetes
+		}
 	}
 
-	return c, nil
+	if c.Spec.DatastoreType == Kubernetes {
+		// Default to using $(HOME)/.kube/config, unless another means has been configured.
+		switch {
+		case c.Spec.Kubeconfig != "":
+			log.WithField("kubeconfig", c.Spec.Kubeconfig).Debug("kubeconfig provided.")
+		case c.Spec.K8sAPIEndpoint != "":
+			log.WithField("apiEndpoint", c.Spec.K8sAPIEndpoint).Debug("API endpoint provided.")
+		case os.Getenv("HOME") == "":
+			// No home directory, can't build a default config path.
+			log.Debug("No home directory, default path doesn't apply.")
+		default:
+			// Default the kubeconfig.
+			c.Spec.Kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+			log.WithField("kubeconfig", c.Spec.Kubeconfig).Debug("Using default kubeconfig path.")
+		}
+	}
 }

--- a/lib/apiconfig/load.go
+++ b/lib/apiconfig/load.go
@@ -55,7 +55,7 @@ func LoadClientConfigFromFile(filename string) (*CalicoAPIConfig, error) {
 	return c, nil
 }
 
-// LoadClientConfig loads the ClientConfig from the supplied bytes containing YAML or JSON format data.
+// LoadClientConfigFromBytes loads the ClientConfig from the supplied bytes containing YAML or JSON format data.
 // The datastore type is defaulted if not specified.
 func LoadClientConfigFromBytes(b []byte) (*CalicoAPIConfig, error) {
 	var c CalicoAPIConfig


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

#1279 change the default datastore type to kubernetes but, as a side effect, it also stopped LoadConfigFromEnvironment from defaulting the datastore type.  This broke Typha, calicoctl and Node, which use that method on the assumption that it does defaulting.

This PR refactors the code to make sure that defaulting happens in all the public LoadConfigXXX functions.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
