### PR TITLE
Fix defaulting of config params when in a scratch container.

### DIFF
--- a/lib/apiconfig/load.go
+++ b/lib/apiconfig/load.go
@@ -109,8 +109,7 @@ func applyConfigDefaults(c *CalicoAPIConfig) {
 			log.WithField("kubeconfig", c.Spec.Kubeconfig).Debug("kubeconfig provided.")
 		case c.Spec.K8sAPIEndpoint != "":
 			log.WithField("apiEndpoint", c.Spec.K8sAPIEndpoint).Debug("API endpoint provided.")
-		case os.Getenv("HOME") == "",
-			os.Getenv("HOME") == "/" /* scratch container */ :
+		case os.Getenv("HOME") == "":
 			// No home directory, can't build a default config path.
 			log.Debug("No home directory, default path doesn't apply.")
 		default:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Handle `HOME=/` explictly as we see in a scratch container and only pick up `~/.kube/config` if it actually exists.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
