### PR TITLE
Concurrent operations on handles via UID / revision

### DIFF
--- a/lib/backend/k8s/resources/customresource.go
+++ b/lib/backend/k8s/resources/customresource.go
@@ -386,7 +386,9 @@ func (c *customK8sResourceClient) convertResourceToKVPair(r Resource) (*model.KV
 		return kvp, err
 	}
 
+	uid := r.GetObjectMeta().GetUID()
 	kvp.Value = r
+	kvp.UID = &uid
 	return kvp, nil
 }
 

--- a/lib/backend/model/ipam_handle.go
+++ b/lib/backend/model/ipam_handle.go
@@ -35,7 +35,7 @@ type IPAMHandleKey struct {
 
 func (key IPAMHandleKey) defaultPath() (string, error) {
 	if key.HandleID == "" {
-		return "", errors.ErrorInsufficientIdentifiers{}
+		return "", errors.ErrorInsufficientIdentifiers{Name: "HandleID"}
 	}
 	e := fmt.Sprintf("/calico/ipam/v2/handle/%s", key.HandleID)
 	return e, nil

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ipam.Interface has methods to perform IP address management.
@@ -53,7 +54,7 @@ type Interface interface {
 	// ReleaseByHandle releases all IP addresses that have been assigned
 	// using the provided handle.  Returns an error if no addresses
 	// are assigned with the given handle.
-	ReleaseByHandle(ctx context.Context, handleID string) error
+	ReleaseByHandle(ctx context.Context, handleID, revision string, uid *types.UID) error
 
 	// ClaimAffinity claims affinity to the given host for all blocks
 	// within the given CIDR.  The given CIDR must fall within a configured

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -56,6 +56,9 @@ type Interface interface {
 	// are assigned with the given handle.
 	ReleaseByHandle(ctx context.Context, handle *model.KVPair) error
 
+	// GetHandle returns the handle with the given ID.
+	GetHandle(ctx context.Context, handleID string) (*model.KVPair, error)
+
 	// ClaimAffinity claims affinity to the given host for all blocks
 	// within the given CIDR.  The given CIDR must fall within a configured
 	// pool. If an empty string is passed as the host, then the value returned by os.Hostname is used.

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -17,8 +17,8 @@ package ipam
 import (
 	"context"
 
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // ipam.Interface has methods to perform IP address management.
@@ -54,7 +54,7 @@ type Interface interface {
 	// ReleaseByHandle releases all IP addresses that have been assigned
 	// using the provided handle.  Returns an error if no addresses
 	// are assigned with the given handle.
-	ReleaseByHandle(ctx context.Context, handleID, revision string, uid *types.UID) error
+	ReleaseByHandle(ctx context.Context, handle *model.KVPair) error
 
 	// ClaimAffinity claims affinity to the given host for all blocks
 	// within the given CIDR.  The given CIDR must fall within a configured

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -59,6 +59,9 @@ type Interface interface {
 	// GetHandle returns the handle with the given ID.
 	GetHandle(ctx context.Context, handleID string) (*model.KVPair, error)
 
+	// ListHandles returns all IPAM handles.
+	ListHandles(ctx context.Context) (*model.KVPairList, error)
+
 	// ClaimAffinity claims affinity to the given host for all blocks
 	// within the given CIDR.  The given CIDR must fall within a configured
 	// pool. If an empty string is passed as the host, then the value returned by os.Hostname is used.

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	libapiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
@@ -852,8 +853,17 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 		}
 
 		// Increment handle.
+		var h *model.KVPair
 		if args.HandleID != nil {
-			c.incrementHandle(ctx, *args.HandleID, blockCIDR, 1)
+			h, err = c.incrementHandle(ctx, *args.HandleID, blockCIDR, 1)
+			if err != nil {
+				if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
+					log.WithError(err).Debug("CAS error incrementing handle - retry")
+					continue
+				}
+				log.WithError(err).Errorf("Failed to increment handle")
+				return err
+			}
 		}
 
 		// Update the block using the original KVPair to do a CAS.  No need to
@@ -861,16 +871,17 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 		// in the KVPair.
 		_, err = c.blockReaderWriter.updateBlock(ctx, obj)
 		if err != nil {
+			log.WithError(err).Warningf("Update failed on block %s", block.CIDR.String())
+			if h != nil {
+				// Attempt to decrement the handle that was incremented above, so the handle stays
+				// consistent with allocation state.
+				if _, decErr := c.decrementHandle(ctx, h, blockCIDR, 1); decErr != nil {
+					log.WithError(decErr).Warn("Failed to decrement handle")
+				}
+			}
 			if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
 				log.WithError(err).Debug("CAS error assigning IP - retry")
 				continue
-			}
-
-			log.WithError(err).Warningf("Update failed on block %s", block.CIDR.String())
-			if args.HandleID != nil {
-				if err := c.decrementHandle(ctx, *args.HandleID, blockCIDR, 1, nil); err != nil {
-					log.WithError(err).Warn("Failed to decrement handle")
-				}
 			}
 			return err
 		}
@@ -1063,7 +1074,7 @@ func (c ipamClient) releaseIPsFromBlock(ctx context.Context, handleMap map[strin
 		// Success - decrement handles.
 		logCtx.Debugf("Decrementing handles: %v", handles)
 		for handleID, amount := range handles {
-			if err := c.decrementHandle(ctx, handleID, blockCIDR, amount, handleMap[handleID]); err != nil {
+			if _, err := c.decrementHandle(ctx, handleMap[handleID], blockCIDR, amount); err != nil {
 				logCtx.WithError(err).Warn("Failed to decrement handle")
 			}
 		}
@@ -1099,21 +1110,24 @@ func (c ipamClient) assignFromExistingBlock(ctx context.Context, block *model.KV
 	}
 
 	// Increment handle count.
+	var h *model.KVPair
 	if handleID != nil {
 		logCtx.Debug("Incrementing handle")
-		c.incrementHandle(ctx, *handleID, blockCIDR, num)
+		h, err = c.incrementHandle(ctx, *handleID, blockCIDR, num)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Update the block using CAS by passing back the original
-	// KVPair.
+	// Update the block using CAS by passing back the original KVPair.
 	logCtx.Info("Writing block in order to claim IPs")
 	block.Value = b.AllocationBlock
 	_, err = c.blockReaderWriter.updateBlock(ctx, block)
 	if err != nil {
 		logCtx.WithError(err).Infof("Failed to update block")
-		if handleID != nil {
+		if h != nil {
 			logCtx.Debug("Decrementing handle since we failed to allocate IP(s)")
-			if err := c.decrementHandle(ctx, *handleID, blockCIDR, num, nil); err != nil {
+			if _, err := c.decrementHandle(ctx, h, blockCIDR, num); err != nil {
 				logCtx.WithError(err).Warnf("Failed to decrement handle")
 			}
 		}
@@ -1457,27 +1471,50 @@ func (c ipamClient) IPsByHandle(ctx context.Context, handleID string) ([]net.IP,
 	return assignments, nil
 }
 
-// ReleaseByHandle releases all IP addresses that have been assigned
-// using the provided handle.
-func (c ipamClient) ReleaseByHandle(ctx context.Context, handleID string) error {
+// ReleaseByHandle releases addresses with the given handle using the given revision information.
+func (c ipamClient) ReleaseByHandle(ctx context.Context, handleID, revision string, uid *types.UID) error {
+	// Get the existing handle and populate the given revision and UID information.
 	handleID = sanitizeHandle(handleID)
 	log.Debugf("Releasing all IPs with handle '%s'", handleID)
-	obj, err := c.blockReaderWriter.queryHandle(ctx, handleID, "")
+	obj, err := c.blockReaderWriter.queryHandle(ctx, handleID, revision)
 	if err != nil {
 		return err
 	}
-	handle := allocationHandle{obj.Value.(*model.IPAMHandle)}
+	if revision != "" {
+		obj.Revision = revision
+	}
+	if uid != nil {
+		obj.UID = uid
+	}
 
-	for blockStr := range handle.Block {
+	log.Infof("Releasing all IPs with handle '%s', RV=%s; UID=%v", handleID, obj.Revision, obj.UID)
+	h := allocationHandle{obj.Value.(*model.IPAMHandle)}
+	for blockStr := range h.Block {
 		_, blockCIDR, _ := net.ParseCIDR(blockStr)
-		if err := c.releaseByHandle(ctx, handleID, *blockCIDR); err != nil {
+		if obj, err = c.releaseByHandle(ctx, obj, *blockCIDR); err != nil {
 			return err
+		}
+	}
+
+	if obj != nil {
+		// Delete the handle itself. This normally would have happened as a side-effect of
+		// decrementing the handle. However, if for some reason there are no IPs allocated with this handle,
+		// we will never decrement it and thus it will never otherwise be deleted.
+		if err = c.blockReaderWriter.deleteHandle(ctx, obj); err != nil {
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+				// We expect the handle to either not exist, or be deleted cleanly.
+				// If it's not either of these things, return an error.
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-func (c ipamClient) releaseByHandle(ctx context.Context, handleID string, blockCIDR net.IPNet) error {
+// releaseByHandle releases all addresses with the given handle object, and returns an updated handle object or nil if
+// the handle was deleted, or nil and an error if an error was encountered.
+func (c ipamClient) releaseByHandle(ctx context.Context, handle *model.KVPair, blockCIDR net.IPNet) (*model.KVPair, error) {
+	handleID := handle.Key.(model.IPAMHandleKey).HandleID
 	logCtx := log.WithFields(log.Fields{"handle": handleID, "cidr": blockCIDR})
 	for i := 0; i < datastoreRetries; i++ {
 		logCtx.Debug("Querying block so we can release IPs by handle")
@@ -1487,10 +1524,17 @@ func (c ipamClient) releaseByHandle(ctx context.Context, handleID string, blockC
 				// Block doesn't exist, so all addresses are already
 				// unallocated.  This can happen when a handle is
 				// overestimating the number of assigned addresses.
-				return nil
+				return handle, nil
 			} else {
-				return err
+				return nil, err
 			}
+		}
+
+		// Write the handle to invalidate any other potential clients.
+		handle, err = c.blockReaderWriter.updateHandle(ctx, handle)
+		if err != nil {
+			log.WithError(err).Debug("Failed to confirm handle")
+			return nil, err
 		}
 
 		// Release the IP by handle.
@@ -1500,7 +1544,7 @@ func (c ipamClient) releaseByHandle(ctx context.Context, handleID string, blockC
 			// Block has no addresses with this handle, so
 			// all addresses are already unallocated.
 			logCtx.Debug("Block has no addresses with the given handle")
-			return nil
+			return handle, nil
 		}
 		logCtx.Debugf("Block has %d IPs with the given handle", num)
 
@@ -1516,7 +1560,7 @@ func (c ipamClient) releaseByHandle(ctx context.Context, handleID string, blockC
 				// Return the error unless the resource does not exist.
 				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
 					logCtx.Errorf("Error deleting block: %v", err)
-					return err
+					return nil, err
 				}
 			}
 			logCtx.Info("Successfully deleted empty block")
@@ -1534,25 +1578,26 @@ func (c ipamClient) releaseByHandle(ctx context.Context, handleID string, blockC
 				} else {
 					// Something else - return the error.
 					logCtx.Errorf("Error updating block '%s': %v", block.CIDR.String(), err)
-					return err
+					return nil, err
 				}
 			}
 			logCtx.Debug("Successfully released IPs from block")
 		}
-		if err = c.decrementHandle(ctx, handleID, blockCIDR, num, nil); err != nil {
+		if handle, err = c.decrementHandle(ctx, handle, blockCIDR, num); err != nil {
 			logCtx.WithError(err).Warn("Failed to decrement handle")
+			return nil, err
 		}
 
 		// Determine whether or not the block's pool still matches the node.
 		if err = c.ensureConsistentAffinity(ctx, block.AllocationBlock); err != nil {
 			logCtx.WithError(err).Warn("Error ensuring consistent affinity but IP already released. Returning no error.")
 		}
-		return nil
+		return handle, nil
 	}
-	return errors.New("Hit max retries")
+	return nil, errors.New("Hit max retries")
 }
 
-func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockCIDR net.IPNet, num int) error {
+func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockCIDR net.IPNet, num int) (*model.KVPair, error) {
 	var obj *model.KVPair
 	var err error
 	for i := 0; i < datastoreRetries; i++ {
@@ -1571,7 +1616,7 @@ func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockC
 				}
 			} else {
 				// Unexpected error reading handle.
-				return err
+				return nil, err
 			}
 		}
 
@@ -1584,76 +1629,59 @@ func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockC
 		// Compare and swap the handle using the KVPair from above.  We've been
 		// manipulating the structure in the KVPair, so pass straight back to
 		// apply the changes.
+		var newObj *model.KVPair
 		if obj.Revision != "" {
 			// This is an existing handle - update it.
-			_, err = c.blockReaderWriter.updateHandle(ctx, obj)
+			newObj, err = c.blockReaderWriter.updateHandle(ctx, obj)
 			if err != nil {
 				log.WithError(err).Warning("Failed to update handle, retry")
 				continue
 			}
 		} else {
 			// This is a new handle - create it.
-			_, err = c.client.Create(ctx, obj)
+			newObj, err = c.client.Create(ctx, obj)
 			if err != nil {
 				log.WithError(err).Warning("Failed to create handle, retry")
 				continue
 			}
+			log.WithField("uid", newObj.UID).Debug("Created new handle")
 		}
-		return nil
+		return newObj, nil
 	}
-	return errors.New("Max retries hit - excessive concurrent IPAM requests")
-
+	return nil, errors.New("Max retries hit - excessive concurrent IPAM requests")
 }
 
-func (c ipamClient) decrementHandle(ctx context.Context, handleID string, blockCIDR net.IPNet, num int, obj *model.KVPair) error {
-	for i := 0; i < datastoreRetries; i++ {
-		var err error
-		// Query the handle if either of these conditions is true:
-		// - This is the first iteration, and the caller did not provide the current handle.
-		// - This is a retry.
-		if (i == 0 && obj == nil) || i != 0 {
-			obj, err = c.blockReaderWriter.queryHandle(ctx, handleID, "")
-			if err != nil {
-				return err
-			}
-		}
-		handle := allocationHandle{obj.Value.(*model.IPAMHandle)}
-
-		_, err = handle.decrementBlock(blockCIDR, num)
-		if err != nil {
-			return err
-		}
-
-		// Update / Delete as appropriate.  Since we have been manipulating the
-		// data in the KVPair, just pass this straight back to the client.
-		if handle.empty() {
-			log.Debugf("Deleting handle: %s", handleID)
-			if err = c.blockReaderWriter.deleteHandle(ctx, obj); err != nil {
-				if err != nil {
-					if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
-						// Update conflict - retry.
-						continue
-					} else if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-						return err
-					}
-					// Already deleted.
-				}
-			}
-		} else {
-			log.Debugf("Updating handle: %s", handleID)
-			if _, err = c.blockReaderWriter.updateHandle(ctx, obj); err != nil {
-				if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
-					// Update conflict - retry.
-					continue
-				}
-				return err
-			}
-		}
-
-		log.Debugf("Decremented handle '%s' by %d", handleID, num)
-		return nil
+func (c ipamClient) decrementHandle(ctx context.Context, obj *model.KVPair, blockCIDR net.IPNet, num int) (*model.KVPair, error) {
+	handle := allocationHandle{obj.Value.(*model.IPAMHandle)}
+	_, err := handle.decrementBlock(blockCIDR, num)
+	if err != nil {
+		return nil, err
 	}
-	return errors.New("Max retries hit - excessive concurrent IPAM requests")
+	handleID := handle.HandleID
+	var newObj *model.KVPair
+
+	// Update / Delete as appropriate.  Since we have been manipulating the
+	// data in the KVPair, just pass this straight back to the client.
+	if handle.empty() {
+		log.Debugf("Deleting handle: %s", handleID)
+		if err = c.blockReaderWriter.deleteHandle(ctx, obj); err != nil {
+			if err != nil {
+				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+					return nil, err
+				}
+				// Already deleted.
+				log.WithError(err).Debugf("Handle '%s' already deleted", handleID)
+			}
+		}
+	} else {
+		log.Debugf("Updating handle: %s", handleID)
+		if newObj, err = c.blockReaderWriter.updateHandle(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
+
+	log.Debugf("Decremented handle '%s' by %d", handleID, num)
+	return newObj, nil
 }
 
 // GetAssignmentAttributes returns the attributes stored with the given IP address

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -1493,7 +1493,7 @@ func (c ipamClient) ReleaseByHandle(ctx context.Context, obj *model.KVPair) erro
 	var err error
 
 	// Sanitize the handle ID of the given object.
-	handleID := obj.Value.(*model.IPAMHandle).HandleID
+	handleID := obj.Key.(model.IPAMHandleKey).HandleID
 	handleID = sanitizeHandle(handleID)
 	obj.Key = model.IPAMHandleKey{HandleID: handleID}
 	obj.Value.(*model.IPAMHandle).HandleID = handleID

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -82,6 +82,11 @@ type ipamClient struct {
 	blockReaderWriter blockReaderWriter
 }
 
+// ListHandles returns all IPAM handles.
+func (c *ipamClient) ListHandles(ctx context.Context) (*model.KVPairList, error) {
+	return c.client.List(ctx, model.IPAMHandleListOptions{}, "")
+}
+
 // GetHandle returns the handle with the given ID.
 func (c *ipamClient) GetHandle(ctx context.Context, handleID string) (*model.KVPair, error) {
 	return c.client.Get(ctx, model.IPAMHandleKey{HandleID: handleID}, "")

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -1492,10 +1492,11 @@ func (c ipamClient) IPsByHandle(ctx context.Context, handleID string) ([]net.IP,
 func (c ipamClient) ReleaseByHandle(ctx context.Context, obj *model.KVPair) error {
 	var err error
 
-	// TODO: What is the equivalent of this now?
-	// handleID = sanitizeHandle(handleID)
-
+	// Sanitize the handle ID of the given object.
 	handleID := obj.Value.(*model.IPAMHandle).HandleID
+	handleID = sanitizeHandle(handleID)
+	obj.Key = model.IPAMHandleKey{HandleID: handleID}
+	obj.Value.(*model.IPAMHandle).HandleID = handleID
 	log.Debugf("Releasing all IPs with handle '%s', RV=%s; UID=%v", handleID, obj.Revision, obj.UID)
 	h := allocationHandle{obj.Value.(*model.IPAMHandle)}
 	for blockStr := range h.Block {

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -82,6 +82,11 @@ type ipamClient struct {
 	blockReaderWriter blockReaderWriter
 }
 
+// GetHandle returns the handle with the given ID.
+func (c *ipamClient) GetHandle(ctx context.Context, handleID string) (*model.KVPair, error) {
+	return c.client.Get(ctx, model.IPAMHandleKey{HandleID: handleID}, "")
+}
+
 // AutoAssign automatically assigns one or more IP addresses as specified by the
 // provided AutoAssignArgs.  AutoAssign returns the list of the assigned IPv4 addresses,
 // and the list of the assigned IPv6 addresses.

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -475,7 +475,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(*blocks.KVPairs[0].Value.(*model.AllocationBlock).Affinity).To(Equal(fmt.Sprintf("host:%s", hostname)))
 
 			// Release the IP.
-			err = ic.ReleaseByHandle(context.Background(), handle)
+			err = ic.ReleaseByHandle(context.Background(), handle, "", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Try to release the block's affinity, requiring it to be empty. This time, the block is empty
@@ -501,7 +501,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			// Release them all, leaving just the empty blocks.
-			err := ic.ReleaseByHandle(context.Background(), handle)
+			err = ic.ReleaseByHandle(context.Background(), handle, "", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect three empty blocks.
@@ -526,7 +526,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(blocks.KVPairs)).To(Equal(1))
 		})
 
-		It("should release host affinifies even if the pool has been deleted", func() {
+		It("should release host affinities even if the pool has been deleted", func() {
 			// Allocate several blocks to the node. The pool is a /30, so 4 addresses
 			// per each block.
 			handle := "test-handle"
@@ -560,7 +560,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(blocks.KVPairs)).To(Equal(3))
 
 			// Release the addresses, triggering deletion of the blocks.
-			err = ic.ReleaseByHandle(context.Background(), handle)
+			err = ic.ReleaseByHandle(context.Background(), handle, "", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect no blocks.
@@ -751,7 +751,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			})
 
 			By("Releasing the IP address using its handle", func() {
-				err := ic.ReleaseByHandle(ctx, handle)
+				err := ic.ReleaseByHandle(ctx, handle, "", nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -759,6 +759,72 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				_, err := ic.IPsByHandle(ctx, handle)
 				Expect(err).To(HaveOccurred())
 			})
+		})
+
+		It("should reject requests with invalid RV/UID", func() {
+			By("creating a node", func() {
+				applyNode(bc, kc, "test-host", nil)
+			})
+
+			By("setting up an IP pool", func() {
+				deleteAllPools()
+				applyPool("10.0.0.0/24", true, "")
+			})
+
+			handle := "test-handle"
+			ctx := context.Background()
+
+			// Assign an IP address with handle.
+			args := AutoAssignArgs{Num4: 1, HandleID: &handle, Hostname: "test-host"}
+			assn, _, err := ic.AutoAssign(context.Background(), args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(assn.IPs)).To(Equal(1))
+
+			// Get the handle that was created.
+			h1, err := bc.Get(ctx, model.IPAMHandleKey{HandleID: handle}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Assign a second IP address to the handle.
+			assn, _, err = ic.AutoAssign(context.Background(), args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(assn.IPs)).To(Equal(1))
+
+			// Expect the original handle revision information to be invalidated.
+			err = ic.ReleaseByHandle(ctx, handle, h1.Revision, h1.UID)
+			Expect(err).To(HaveOccurred())
+
+			// Get the latest handle.
+			h2, err := bc.Get(ctx, model.IPAMHandleKey{HandleID: handle}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			// We should be able to release with the new revision info.
+			err = ic.ReleaseByHandle(ctx, handle, h2.Revision, h2.UID)
+			Expect(err).NotTo(HaveOccurred())
+
+			// This should delete the handle object itself.
+			_, err = bc.Get(ctx, model.IPAMHandleKey{HandleID: handle}, "")
+			Expect(err).To(HaveOccurred())
+
+			// The following assertions are only valid for the k8s datastore,
+			// since etcdv3 doesn't respect UID.
+			if config.Spec.DatastoreType == "kubernetes" {
+				// Assign a new IP, thus re-creating the handle with a new UID.
+				assn, _, err = ic.AutoAssign(context.Background(), args)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(assn.IPs)).To(Equal(1))
+
+				// Get the latest handle.
+				h3, err := bc.Get(ctx, model.IPAMHandleKey{HandleID: handle}, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				// Attempt to release with an outdated UID. It should fail.
+				err = ic.ReleaseByHandle(ctx, handle, "", h2.UID)
+				Expect(err).To(HaveOccurred())
+
+				// Release with the latest UID. It should work.
+				err = ic.ReleaseByHandle(ctx, handle, "", h3.UID)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		})
 	})
 
@@ -906,10 +972,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(v4iaNode1).ToNot(BeNil())
 			Expect(len(v4iaNode1.IPs)).To(Equal(1))
 
-			err = ic.ReleaseByHandle(context.Background(), handle2)
+			err = ic.ReleaseByHandle(context.Background(), handle2, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = ic.ReleaseByHandle(context.Background(), handle1)
+			err = ic.ReleaseByHandle(context.Background(), handle1, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1435,7 +1501,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(pool1.IPNet.Contains(v4ia3.IPs[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4ia3.IPs[0].IP, pool1))
 
 			// Release one of the IPs.
-			err = ic.ReleaseByHandle(context.Background(), handleID1)
+			err = ic.ReleaseByHandle(context.Background(), handleID1, "", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should still have one affine block to this host.
@@ -1446,7 +1512,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool1.String(), true, `foo != "bar"`)
 
 			// Release another one of the IPs.
-			err = ic.ReleaseByHandle(context.Background(), handleID2)
+			err = ic.ReleaseByHandle(context.Background(), handleID2, "", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block still have an affinity to this host.
@@ -1459,7 +1525,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(out.KVPairs)).To(Equal(1))
 
 			// Release the last IP.
-			err = ic.ReleaseByHandle(context.Background(), handleID3)
+			err = ic.ReleaseByHandle(context.Background(), handleID3, "", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block now has no affinity, and no IPs, so it should be deleted.

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -1515,6 +1515,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			// Release one of the IPs.
 			h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handleID1}, "")
 			Expect(err).NotTo(HaveOccurred())
+			Expect(h.Key.(model.IPAMHandleKey).HandleID).To(Equal(handleID1))
 			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -475,7 +475,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(*blocks.KVPairs[0].Value.(*model.AllocationBlock).Affinity).To(Equal(fmt.Sprintf("host:%s", hostname)))
 
 			// Release the IP.
-			err = ic.ReleaseByHandle(context.Background(), handle, "", nil)
+			h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handle}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Try to release the block's affinity, requiring it to be empty. This time, the block is empty
@@ -501,7 +503,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			// Release them all, leaving just the empty blocks.
-			err = ic.ReleaseByHandle(context.Background(), handle, "", nil)
+			h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handle}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect three empty blocks.
@@ -560,7 +564,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(blocks.KVPairs)).To(Equal(3))
 
 			// Release the addresses, triggering deletion of the blocks.
-			err = ic.ReleaseByHandle(context.Background(), handle, "", nil)
+			h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handle}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect no blocks.
@@ -751,7 +757,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			})
 
 			By("Releasing the IP address using its handle", func() {
-				err := ic.ReleaseByHandle(ctx, handle, "", nil)
+				h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handle}, "")
+				Expect(err).NotTo(HaveOccurred())
+				err = ic.ReleaseByHandle(context.Background(), h)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -790,7 +798,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(assn.IPs)).To(Equal(1))
 
 			// Expect the original handle revision information to be invalidated.
-			err = ic.ReleaseByHandle(ctx, handle, h1.Revision, h1.UID)
+			err = ic.ReleaseByHandle(ctx, h1)
 			Expect(err).To(HaveOccurred())
 
 			// Get the latest handle.
@@ -798,7 +806,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(err).NotTo(HaveOccurred())
 
 			// We should be able to release with the new revision info.
-			err = ic.ReleaseByHandle(ctx, handle, h2.Revision, h2.UID)
+			err = ic.ReleaseByHandle(ctx, h2)
 			Expect(err).NotTo(HaveOccurred())
 
 			// This should delete the handle object itself.
@@ -818,11 +826,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(err).NotTo(HaveOccurred())
 
 				// Attempt to release with an outdated UID. It should fail.
-				err = ic.ReleaseByHandle(ctx, handle, "", h2.UID)
+				err = ic.ReleaseByHandle(ctx, h2)
 				Expect(err).To(HaveOccurred())
 
 				// Release with the latest UID. It should work.
-				err = ic.ReleaseByHandle(ctx, handle, "", h3.UID)
+				err = ic.ReleaseByHandle(ctx, h3)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
@@ -972,10 +980,14 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(v4iaNode1).ToNot(BeNil())
 			Expect(len(v4iaNode1.IPs)).To(Equal(1))
 
-			err = ic.ReleaseByHandle(context.Background(), handle2, "", nil)
+			h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handle2}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = ic.ReleaseByHandle(context.Background(), handle1, "", nil)
+			h, err = bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handle1}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1501,7 +1513,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(pool1.IPNet.Contains(v4ia3.IPs[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4ia3.IPs[0].IP, pool1))
 
 			// Release one of the IPs.
-			err = ic.ReleaseByHandle(context.Background(), handleID1, "", nil)
+			h, err := bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handleID1}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should still have one affine block to this host.
@@ -1512,7 +1526,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool1.String(), true, `foo != "bar"`)
 
 			// Release another one of the IPs.
-			err = ic.ReleaseByHandle(context.Background(), handleID2, "", nil)
+			h, err = bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handleID2}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block still have an affinity to this host.
@@ -1525,7 +1541,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(out.KVPairs)).To(Equal(1))
 
 			// Release the last IP.
-			err = ic.ReleaseByHandle(context.Background(), handleID3, "", nil)
+			h, err = bc.Get(context.Background(), model.IPAMHandleKey{HandleID: handleID3}, "")
+			Expect(err).NotTo(HaveOccurred())
+			err = ic.ReleaseByHandle(context.Background(), h)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block now has no affinity, and no IPs, so it should be deleted.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Found some race conditions that exist when using ReleaseByHandle. This code does a few things:

- Correctly returns UID on resources backed by CRDs. 
- Updates ReleaseByHandle to take revision and UID information.

I originally raised this PR to address a scenario I found while working on the IPAM handle GC controller using finalizers (this approach was abandoned, but the race condition still exists in the API). In my hacking, I encountered a race condition where:

1. CNI plugin goes to allocate an IP address, creates a handle
1. CNI plugin attempts to write the block, but gets a CAS error
1. CNI plugin deletes handle in preparation for a retry.
1. CNI plugin retries the above steps 1-3, successfully allocates the IP. Handle gets a new UID.

In this scenario, the IPAM handle would enter finalizing state in step 3 above, kube-controllers would see that finalizing handle, and call `ReleaseByHandle`. This would race with the retry attempt, thus releasing the IP after the CNI plugin successfully allocates it on the second attempt. TL;DR - ReleaseByHandle releases IPs that might have been allocated after the calling code decided it was safe to release the IPs. 

Despite ultimately taking a different approach on the IPAM GC controller, I think this PR is probably still useful. Here is another related PR that showcases an existing race condition with handles which results in us accidentally releasing an IP address that is still in use: https://github.com/projectcalico/kube-controllers/pull/489

The changes in this PR prevent the race condition by allowing users of the API to provide revision and UID information on the ReleaseByHandle API.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```