### PR TITLE
Revert "Add ownerref / finalizer to IPAM handles (#1303)"

### DIFF
--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -72,10 +72,6 @@ type KubeClient struct {
 	clientsByListType map[reflect.Type]resources.K8sResourceClient
 }
 
-func (kc *KubeClient) GetCRDClient() *rest.RESTClient {
-	return kc.crdClientV1
-}
-
 func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 	config, cs, err := CreateKubernetesClientset(ca)
 	if err != nil {

--- a/lib/backend/k8s/resources/customresource.go
+++ b/lib/backend/k8s/resources/customresource.go
@@ -132,6 +132,8 @@ func (c *customK8sResourceClient) Update(ctx context.Context, kvp *model.KVPair)
 		Name(name).
 		Do().Into(resOut)
 	if updateError != nil {
+		// Failed to update the resource.
+		logContext.WithError(updateError).Error("Error updating resource")
 		return nil, K8sErrorToCalico(updateError, kvp.Key)
 	}
 

--- a/lib/backend/k8s/resources/ipam_handle.go
+++ b/lib/backend/k8s/resources/ipam_handle.go
@@ -35,7 +35,6 @@ import (
 const (
 	IPAMHandleResourceName = "IPAMHandles"
 	IPAMHandleCRDName      = "ipamhandles.crd.projectcalico.org"
-	IPAMFinalizer          = "ipam.projectcalico.org"
 )
 
 func NewIPAMHandleClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
@@ -70,17 +69,15 @@ type ipamHandleClient struct {
 func (c ipamHandleClient) toV1(kvpv3 *model.KVPair) *model.KVPair {
 	handle := kvpv3.Value.(*apiv3.IPAMHandle).Spec.HandleID
 	block := kvpv3.Value.(*apiv3.IPAMHandle).Spec.Block
-	refs := kvpv3.Value.(*apiv3.IPAMHandle).OwnerReferences
 	del := kvpv3.Value.(*apiv3.IPAMHandle).Spec.Deleted
 	return &model.KVPair{
 		Key: model.IPAMHandleKey{
 			HandleID: handle,
 		},
 		Value: &model.IPAMHandle{
-			HandleID:        handle,
-			Block:           block,
-			OwnerReferences: refs,
-			Deleted:         del,
+			HandleID: handle,
+			Block:    block,
+			Deleted:  del,
 		},
 		Revision: kvpv3.Revision,
 		UID:      kvpv3.UID,
@@ -95,19 +92,11 @@ func (c ipamHandleClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
 	name := c.parseKey(kvpv1.Key)
 	handle := kvpv1.Key.(model.IPAMHandleKey).HandleID
 	block := kvpv1.Value.(*model.IPAMHandle).Block
-	ownerRef := kvpv1.Value.(*model.IPAMHandle).OwnerReferences
 	del := kvpv1.Value.(*model.IPAMHandle).Deleted
 
 	var uid types.UID
 	if kvpv1.UID != nil {
 		uid = *kvpv1.UID
-	}
-
-	var finalizers []string
-	if len(ownerRef) != 0 {
-		// Add a finalizer so that when the parent is deleted, we have an
-		// opportunity to take action on related resources (e.g. blocks).
-		finalizers = []string{IPAMFinalizer}
 	}
 
 	return &model.KVPair{
@@ -123,8 +112,6 @@ func (c ipamHandleClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            name,
 				ResourceVersion: kvpv1.Revision,
-				Finalizers:      finalizers,
-				OwnerReferences: ownerRef,
 				UID:             uid,
 			},
 			Spec: apiv3.IPAMHandleSpec{
@@ -162,7 +149,6 @@ func (c *ipamHandleClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*m
 	kvp.Value.(*model.IPAMHandle).Deleted = true
 	v1kvp, err := c.Update(ctx, kvp)
 	if err != nil {
-		log.WithError(err).Debug("Error marking IPAM handle as deleted")
 		return nil, err
 	}
 
@@ -172,36 +158,7 @@ func (c *ipamHandleClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*m
 	if err != nil {
 		return nil, err
 	}
-
-	// If needed, remove finalizers.
-	kvp, err = c.finalizeDeletion(ctx, kvp)
-	if err != nil {
-		log.WithError(err).Debug("Error finalizing deletion")
-		return nil, err
-	}
 	return c.toV1(kvp), nil
-}
-
-func (c *ipamHandleClient) finalizeDeletion(ctx context.Context, v3kvp *model.KVPair) (*model.KVPair, error) {
-	// Get current state.
-	kvp, err := c.rc.Get(ctx, v3kvp.Key, v3kvp.Revision)
-	if err != nil {
-		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
-			// Resource doesn't exist, no need to finalize.
-			return v3kvp, nil
-		}
-		log.WithError(err).Debug("Error querying IPAM handle")
-		return v3kvp, err
-	}
-
-	// Remove finalizers.
-	kvp.Value.(*apiv3.IPAMHandle).Finalizers = nil
-	kvp, err = c.rc.Update(ctx, kvp)
-	if err != nil {
-		log.WithError(err).Debug("Error removing finalizers")
-		return nil, err
-	}
-	return kvp, nil
 }
 
 func (c *ipamHandleClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
@@ -230,7 +187,7 @@ func (c *ipamHandleClient) Get(ctx context.Context, key model.Key, revision stri
 		if _, err := c.DeleteKVP(ctx, v1kvp); err != nil {
 			return nil, err
 		}
-		return nil, cerrors.ErrorResourceDoesNotExist{Err: fmt.Errorf("Resource was deleted"), Identifier: key}
+		return nil, cerrors.ErrorResourceDoesNotExist{fmt.Errorf("Resource was deleted"), key}
 	}
 
 	return v1kvp, nil

--- a/lib/backend/k8s/resources/resources.go
+++ b/lib/backend/k8s/resources/resources.go
@@ -160,8 +160,6 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
 	meta.UID = rom.GetUID()
-	meta.Finalizers = rom.GetFinalizers()
-	meta.OwnerReferences = rom.GetOwnerReferences()
 
 	resOut := resIn.DeepCopyObject().(Resource)
 	romOut := resOut.GetObjectMeta()
@@ -205,8 +203,6 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.Labels = rom.GetLabels()
 	meta.Annotations = annotations
 	meta.UID = rom.GetUID()
-	meta.Finalizers = rom.GetFinalizers()
-	meta.OwnerReferences = rom.GetOwnerReferences()
 
 	// Overwrite the K8s metadata with the Calico metadata.
 	meta.DeepCopyInto(rom.(*metav1.ObjectMeta))

--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -36,7 +36,6 @@ const (
 	IPAMBlockAttributeTypeIPIP      = "ipipTunnelAddress"
 	IPAMBlockAttributeTypeVXLAN     = "vxlanTunnelAddress"
 	IPAMBlockAttributeTypeWireguard = "wireguardTunnelAddress"
-	IPAMBlockAttributeTypeUID       = "uid"
 )
 
 var (

--- a/lib/backend/model/ipam_handle.go
+++ b/lib/backend/model/ipam_handle.go
@@ -19,11 +19,8 @@ import (
 	"reflect"
 	"regexp"
 
-	log "github.com/sirupsen/logrus"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -83,8 +80,4 @@ type IPAMHandle struct {
 	HandleID string         `json:"-"`
 	Block    map[string]int `json:"block"`
 	Deleted  bool           `json:"deleted"`
-
-	// OwnerReferences are used by the Kubernetes backend but not the etcd
-	// backend. They don't need to be stored, so nil the json tag.
-	OwnerReferences []metav1.OwnerReference `json:"-"`
 }

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -22,8 +22,6 @@ import (
 	"runtime"
 
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/set"
@@ -50,7 +48,6 @@ const (
 	AttributeTypeIPIP      = model.IPAMBlockAttributeTypeIPIP
 	AttributeTypeVXLAN     = model.IPAMBlockAttributeTypeVXLAN
 	AttributeTypeWireguard = model.IPAMBlockAttributeTypeWireguard
-	AttributeTypeUID       = model.IPAMBlockAttributeTypeUID
 )
 
 var (
@@ -786,7 +783,7 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 
 		// Increment handle.
 		if args.HandleID != nil {
-			c.incrementHandle(ctx, *args.HandleID, blockCIDR, 1, args.Attrs)
+			c.incrementHandle(ctx, *args.HandleID, blockCIDR, 1)
 		}
 
 		// Update the block using the original KVPair to do a CAS.  No need to
@@ -965,9 +962,7 @@ func (c ipamClient) assignFromExistingBlock(ctx context.Context, block *model.KV
 	// Increment handle count.
 	if handleID != nil {
 		logCtx.Debug("Incrementing handle")
-		if err = c.incrementHandle(ctx, *handleID, blockCIDR, num, attrs); err != nil {
-			return nil, err
-		}
+		c.incrementHandle(ctx, *handleID, blockCIDR, num)
 	}
 
 	// Update the block using CAS by passing back the original
@@ -1333,20 +1328,9 @@ func (c ipamClient) ReleaseByHandle(ctx context.Context, handleID string) error 
 	}
 	handle := allocationHandle{obj.Value.(*model.IPAMHandle)}
 
-	for blockStr := range handle.Block {
+	for blockStr, _ := range handle.Block {
 		_, blockCIDR, _ := net.ParseCIDR(blockStr)
 		if err := c.releaseByHandle(ctx, handleID, *blockCIDR); err != nil {
-			return err
-		}
-	}
-
-	// Defensively delete the handle itself. This may have already happened as a side-effect of
-	// decrementing the handle. However, if for some reason there are no IPs allocated with this handle,
-	// we will never decrement it and thus it will never otherwise be deleted.
-	if err = c.blockReaderWriter.deleteHandle(ctx, obj); err != nil {
-		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-			// We expect the handle to either not exist, or be deleted cleanly.
-			// If it's not either of these things, return an error.
 			return err
 		}
 	}
@@ -1428,55 +1412,7 @@ func (c ipamClient) releaseByHandle(ctx context.Context, handleID string, blockC
 	return errors.New("Hit max retries")
 }
 
-func buildOwnerReferencesFromAttrs(attrs map[string]string) *v1.OwnerReference {
-	// Determine who owns this handle, if possible.
-	var ownerKind, ownerName, ownerUID string
-	if _, ok := attrs[model.IPAMBlockAttributePod]; ok {
-		// This is a pod.
-		ownerKind = "Pod"
-		ownerName = attrs[model.IPAMBlockAttributePod]
-	} else if _, ok := attrs[model.IPAMBlockAttributeNode]; ok {
-		// Pod attr not defined, but node attr is. This is a node.
-		ownerKind = "Node"
-		ownerName = attrs[model.IPAMBlockAttributeNode]
-	}
-	ownerUID = attrs[model.IPAMBlockAttributeTypeUID]
-
-	// Check if we have enough information to add a reference to the owner
-	// of this IPAM allocation. Currently, we only do this for IPs belong to pods
-	// and IPs belonging to nodes.
-	if ownerKind != "" && ownerName != "" && ownerUID != "" {
-		// Add a reference to the parent object so it is automatically
-		// cleaned up when the parent is deleted.
-		return &v1.OwnerReference{
-			APIVersion: "v1",
-			UID:        types.UID(ownerUID),
-			Kind:       ownerKind,
-			Name:       ownerName,
-		}
-	}
-	return nil
-}
-
-// mergeOwnerReferences ensures the given IPAM handle has owner references for the given attrs.
-func mergeOwnerReferences(kvp *model.KVPair, attrs map[string]string) {
-	ref := buildOwnerReferencesFromAttrs(attrs)
-	if ref == nil {
-		return
-	}
-
-	// Make sure the ref doesn't already exist.
-	h := kvp.Value.(*model.IPAMHandle)
-	for _, r := range h.OwnerReferences {
-		if ref.UID == r.UID {
-			// Already present.
-			return
-		}
-	}
-	h.OwnerReferences = append(h.OwnerReferences, *ref)
-}
-
-func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockCIDR net.IPNet, num int, attrs map[string]string) error {
+func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockCIDR net.IPNet, num int) error {
 	var obj *model.KVPair
 	var err error
 	for i := 0; i < datastoreRetries; i++ {
@@ -1498,9 +1434,6 @@ func (c ipamClient) incrementHandle(ctx context.Context, handleID string, blockC
 				return err
 			}
 		}
-
-		// Merge in owner references from this particular allocation.
-		mergeOwnerReferences(obj, attrs)
 
 		// Get the handle from the KVPair.
 		handle := allocationHandle{obj.Value.(*model.IPAMHandle)}

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"sort"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -42,7 +41,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // Implement an IP pools accessor for the IPAM client.  This is a "mock" version
@@ -129,7 +127,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 	var bc bapi.Client
 	var ic Interface
 	var kc *kubernetes.Clientset
-	var crdClient *rest.RESTClient
 	BeforeEach(func() {
 		var err error
 		bc, err = backend.NewClient(config)
@@ -139,7 +136,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		// If running in KDD mode, extract the k8s clientset.
 		if config.Spec.DatastoreType == "kubernetes" {
 			kc = bc.(*k8s.KubeClient).ClientSet
-			crdClient = bc.(*k8s.KubeClient).GetCRDClient()
 		}
 	})
 
@@ -361,187 +357,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(handle).To(BeNil())
 			})
 		})
-	})
-
-	Describe("Allocation with owner reference and finalizer", func() {
-		var hostname string
-		sentinelIP := net.ParseIP("10.0.0.1")
-
-		BeforeEach(func() {
-			// Remove all data in the datastore.
-			bc.Clean()
-
-			// Create an IP pool
-			applyPool("10.0.0.0/24", true, "all()")
-
-			// Create the node object.
-			hostname = "test-ipam-ownerref-node"
-			applyNode(bc, kc, hostname, nil)
-		})
-
-		AfterEach(func() {
-			bc.Clean()
-		})
-
-		It("should assign a pod IP address when a UID is given", func() {
-			handle := "ipam-with-uid-test-handle"
-			uid := "e9040fd2-cb0c-2bcf-51e9-2b5ad1fb9b9b"
-			ipAttr := map[string]string{
-				AttributeNode:    hostname,
-				AttributePod:     "test-pod",
-				AttributeTypeUID: uid,
-			}
-			args := AssignIPArgs{
-				IP:       cnet.IP{IP: sentinelIP},
-				Hostname: hostname,
-				Attrs:    ipAttr,
-				HandleID: &handle,
-			}
-			err := ic.AssignIP(context.Background(), args)
-			Expect(err).NotTo(HaveOccurred())
-
-			attrs, returnedHandle, err := ic.GetAssignmentAttributes(context.Background(), cnet.IP{IP: sentinelIP})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(attrs).To(Equal(ipAttr))
-			Expect(returnedHandle).NotTo(BeNil())
-			Expect(*returnedHandle).To(Equal(handle))
-
-			// We should be able to see the ownerreference and finalizer in the k8s object
-			// when running in kdd mode.
-			if config.Spec.DatastoreType == "kubernetes" {
-				// Get the actual CRD.
-				h := v3.NewIPAMHandle()
-				err = crdClient.Get().
-					Context(context.Background()).
-					Resource("ipamhandles").
-					Name(handle).
-					Do().Into(h)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect the IPAM handle to have proper owner references.
-				Expect(h.OwnerReferences).To(HaveLen(1))
-				Expect(string(h.OwnerReferences[0].UID)).To(Equal(uid))
-				Expect(h.OwnerReferences[0].Kind).To(Equal("Pod"))
-				Expect(h.OwnerReferences[0].Name).To(Equal("test-pod"))
-
-				// Expect the IPAM handle to have proper finalizers.
-				Expect(h.Finalizers).To(HaveLen(1))
-				Expect(h.Finalizers[0]).To(Equal("ipam.projectcalico.org"))
-			}
-
-			// Part 2: Test support for multiple addresses with the same handle. This is a
-			// rare scenario that probably never happens in Kubernetes but our IPAM data model
-			// does support it.
-			By("Allocating a second address with the same handle")
-			uid2 := "f9151ae3-cb0c-2bcf-51e9-2b5ad000000c"
-			ipAttr2 := map[string]string{
-				AttributeNode:    hostname,
-				AttributePod:     "test-pod-2",
-				AttributeTypeUID: uid2,
-			}
-			ip2 := net.ParseIP("10.0.0.2")
-			args = AssignIPArgs{
-				IP:       cnet.IP{IP: ip2},
-				Hostname: hostname,
-				Attrs:    ipAttr2,
-				HandleID: &handle,
-			}
-			err = ic.AssignIP(context.Background(), args)
-			Expect(err).NotTo(HaveOccurred())
-			if config.Spec.DatastoreType == "kubernetes" {
-				// Get the actual CRD.
-				h := v3.NewIPAMHandle()
-				err = crdClient.Get().
-					Context(context.Background()).
-					Resource("ipamhandles").
-					Name(handle).
-					Do().Into(h)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect the IPAM handle to have proper owner references.
-				// There should be two now.
-				Expect(h.OwnerReferences).To(HaveLen(2))
-				Expect(string(h.OwnerReferences[0].UID)).To(Equal(uid))
-				Expect(h.OwnerReferences[0].Kind).To(Equal("Pod"))
-				Expect(h.OwnerReferences[0].Name).To(Equal("test-pod"))
-				Expect(string(h.OwnerReferences[1].UID)).To(Equal(uid2))
-				Expect(h.OwnerReferences[1].Kind).To(Equal("Pod"))
-				Expect(h.OwnerReferences[1].Name).To(Equal("test-pod-2"))
-
-				// Expect the IPAM handle to have proper finalizers.
-				Expect(h.Finalizers).To(HaveLen(1))
-				Expect(h.Finalizers[0]).To(Equal("ipam.projectcalico.org"))
-			}
-		})
-
-		It("should assign a node IP address when a UID is given", func() {
-			handle := "ipam-with-uid-test-handle"
-			uid := "e9040fd2-cb0c-2bcf-51e9-2b5ad1fb9b9b"
-			ipAttr := map[string]string{
-				AttributeNode:    hostname,
-				AttributeType:    AttributeTypeVXLAN,
-				AttributeTypeUID: uid,
-			}
-			args := AssignIPArgs{
-				IP:       cnet.IP{IP: sentinelIP},
-				Hostname: hostname,
-				Attrs:    ipAttr,
-				HandleID: &handle,
-			}
-			err := ic.AssignIP(context.Background(), args)
-			Expect(err).NotTo(HaveOccurred())
-
-			attrs, returnedHandle, err := ic.GetAssignmentAttributes(context.Background(), cnet.IP{IP: sentinelIP})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(attrs).To(Equal(ipAttr))
-			Expect(returnedHandle).NotTo(BeNil())
-			Expect(*returnedHandle).To(Equal(handle))
-
-			// We should be able to see the ownerreference and finalizer in the k8s object
-			// when running in kdd mode.
-			if config.Spec.DatastoreType == "kubernetes" {
-				// Get the actual CRD.
-				h := v3.NewIPAMHandle()
-				err = crdClient.Get().
-					Context(context.Background()).
-					Resource("ipamhandles").
-					Name(handle).
-					Do().Into(h)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect the IPAM handle to have proper owner references.
-				Expect(h.OwnerReferences).To(HaveLen(1))
-				Expect(string(h.OwnerReferences[0].UID)).To(Equal(uid))
-				Expect(h.OwnerReferences[0].Kind).To(Equal("Node"))
-				Expect(h.OwnerReferences[0].Name).To(Equal(hostname))
-
-				// Expect the IPAM handle to have proper finalizers.
-				Expect(h.Finalizers).To(HaveLen(1))
-				Expect(h.Finalizers[0]).To(Equal("ipam.projectcalico.org"))
-
-				// Delete the node in the k8s API.
-				Expect(deleteNode(bc, kc, hostname)).NotTo(HaveOccurred())
-
-				// Deleting the node should trigger the handle to go into "finalizing" state,
-				// setting the deletion timestamp.
-				h = v3.NewIPAMHandle()
-				Eventually(func() error {
-					err = crdClient.Get().
-						Context(context.Background()).
-						Resource("ipamhandles").
-						Name(handle).
-						Do().Into(h)
-					if err != nil {
-						return err
-					}
-					if h.DeletionTimestamp == nil {
-						return fmt.Errorf("Expected non-nil deletion timestamp")
-					}
-					return nil
-				}, 10*time.Second).Should(BeNil())
-			}
-		})
-
 	})
 
 	Describe("Affinity FV tests", func() {
@@ -2538,12 +2353,10 @@ func applyNode(c bapi.Client, kc *kubernetes.Clientset, host string, labels map[
 	return nil
 }
 
-func deleteNode(c bapi.Client, kc *kubernetes.Clientset, host string) error {
-	var err error
+func deleteNode(c bapi.Client, kc *kubernetes.Clientset, host string) {
 	if kc != nil {
-		err = kc.CoreV1().Nodes().Delete(host, &metav1.DeleteOptions{})
+		kc.CoreV1().Nodes().Delete(host, &metav1.DeleteOptions{})
 	} else {
-		_, err = c.Delete(context.Background(), &model.ResourceKey{Name: host, Kind: v3.KindNode}, "")
+		c.Delete(context.Background(), &model.ResourceKey{Name: host, Kind: v3.KindNode}, "")
 	}
-	return err
 }


### PR DESCRIPTION
This reverts commit 890268f01ec212d83b5fb3e336abc4bd86e9858d.

Added in this PR: https://github.com/projectcalico/libcalico-go/pull/1303

Unfortunately, this was working "accidentally" and isn't actually
supported by upstream Kubernetes. 

It was not intended that cluster-scoped resources can have an
ownerReference to a namespace-scoped resource. Work is in progress
to prevent this explicitly. 

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```