### PR TITLE
context support to k8s backend and apiconfig

### DIFF
--- a/lib/apiconfig/apiconfig.go
+++ b/lib/apiconfig/apiconfig.go
@@ -82,6 +82,8 @@ type KubeConfig struct {
 	KubeconfigInline string `json:"kubeconfigInline" ignored:"true"`
 	// K8sClientQPS overrides the QPS for the Kube client.
 	K8sClientQPS float32 `json:"k8sClientQPS"`
+	// K8sCurrentContext provides a context override for kubeconfig.
+	K8sCurrentContext string `json:"k8sCurrentContext" envconfig:"K8S_CURRENT_CONTEXT" default:""`
 }
 
 // NewCalicoAPIConfig creates a new (zeroed) CalicoAPIConfig struct with the

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -217,6 +217,7 @@ func CreateKubernetesClientset(ca *apiconfig.CalicoAPIConfigSpec) (*rest.Config,
 		variable *string
 		value    string
 	}{
+		{&configOverrides.CurrentContext, ca.K8sCurrentContext},
 		{&configOverrides.ClusterInfo.Server, ca.K8sAPIEndpoint},
 		{&configOverrides.AuthInfo.ClientCertificate, ca.K8sCertFile},
 		{&configOverrides.AuthInfo.ClientKey, ca.K8sKeyFile},


### PR DESCRIPTION
This PR adds context selection to libcalico.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Support for K8S_CURRENT_CONTEXT
```
