### PR TITLE
Ensure that in dual stack environments, IPv4 addresses are not leaked…

### DIFF
--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -127,7 +127,7 @@ func (c ipamClient) AutoAssign(ctx context.Context, args AutoAssignArgs) ([]net.
 			log.Errorf("Error assigning IPV6 addresses: %v", err)
 		}
 
-		if len(v6list) == 0 {
+		if len(v6list) != args.Num6 {
 			if len(v4list) != 0 {
 				// Release any v4 IPs that were assigned when we were expecting to assign
 				// both v4 and v6 IPs and v6 IP assignment did not complete.

--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -108,6 +108,12 @@ func (c ipamClient) AutoAssign(ctx context.Context, args AutoAssignArgs) ([]net.
 		}
 	}
 
+	if len(v4list) != args.Num4 && args.Num6 != 0 {
+		// No need to assign any V6 if V4 has already failed.
+		log.Debugf("Skipping assignment of IPv6 addresses since IPv4 assignment has failed")
+		return v4list, nil, nil
+	}
+
 	if args.Num6 != 0 {
 		// If no err assigning V4, try to assign any V6.
 		log.Debugf("Assigning IPv6 addresses")
@@ -119,7 +125,24 @@ func (c ipamClient) AutoAssign(ctx context.Context, args AutoAssignArgs) ([]net.
 		v6list, err = c.autoAssign(ctx, args.Num6, args.HandleID, args.Attrs, args.IPv6Pools, 6, hostname, args.MaxBlocksPerHost, args.HostReservedAttrIPv6s)
 		if err != nil {
 			log.Errorf("Error assigning IPV6 addresses: %v", err)
-			return v4list, v6list, err
+		}
+
+		if len(v6list) == 0 {
+			if len(v4list) != 0 {
+				// Release any v4 IPs that were assigned when we were expecting to assign
+				// both v4 and v6 IPs and v6 IP assignment did not complete.
+				// This should only occur in dual stack environments.
+				// This prevents v4 IPs from being assigned when v6 assignment fails.
+				v4IPs := []net.IP{}
+				for _, v4 := range v4list {
+					v4IPs = append(v4IPs, *net.ParseIP(v4.IP.String()))
+				}
+				_, releaseErr := c.ReleaseIPs(ctx, v4IPs)
+				if releaseErr != nil {
+					log.Errorf("Error releasing IPv4 addresses %+v on IPv6 address assignment failure: %s", v4IPs, err)
+				}
+			}
+			return nil, v6list, err
 		}
 	}
 

--- a/lib/ipam/ipam_win_test.go
+++ b/lib/ipam/ipam_win_test.go
@@ -495,7 +495,7 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 		Entry("256 v4 256 v6", "testHost", true, []pool{
 			{cidr: "192.168.1.0/24", blockSize: 26, enabled: true},
 			{cidr: "fd80:24e2:f998:72d6::/120", blockSize: 122, enabled: true},
-		}, rsvdAttrWindows, "192.168.1.0/24", 256, 256, 240, 240, nil),
+		}, rsvdAttrWindows, "192.168.1.0/24", 256, 256, 240, 0, nil),
 
 		// Test 2: AutoAssign 257 IPv4, 0 IPv6 - expect 240 IPv4 addresses, no IPv6, and no error.
 		Entry("257 v4 0 v6", "testHost", true, []pool{{cidr: "192.168.1.0/24", blockSize: 26, enabled: true}}, rsvdAttrWindows, "192.168.1.0/24", 257, 0, 240, 0, nil),


### PR DESCRIPTION
… when IPv6 addresses are not available

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes cases where if both IPv4 and IPv6 addresses are attempted to be auto assigned and one of the assignments fails, the other address is cleaned up appropriately.

Fixes https://github.com/projectcalico/cni-plugin/issues/908

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix an IPAM auto assignment bug that caused IP addresses to be leaked in dual stack environments when assignment partially succeeded.
```
