### PR TITLE
Handle malformed handle IDs

### DIFF
--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -1321,6 +1321,7 @@ func (c ipamClient) IPsByHandle(ctx context.Context, handleID string) ([]net.IP,
 // ReleaseByHandle releases all IP addresses that have been assigned
 // using the provided handle.
 func (c ipamClient) ReleaseByHandle(ctx context.Context, handleID string) error {
+	handleID = sanitizeHandle(handleID)
 	log.Infof("Releasing all IPs with handle '%s'", handleID)
 	obj, err := c.blockReaderWriter.queryHandle(ctx, handleID, "")
 	if err != nil {

--- a/lib/ipam/ipam_block.go
+++ b/lib/ipam/ipam_block.go
@@ -337,11 +337,18 @@ func (b allocationBlock) attributeRefCounts() map[int]int {
 func (b allocationBlock) attributeIndexesByHandle(handleID string) []int {
 	indexes := []int{}
 	for i, attr := range b.Attributes {
-		if attr.AttrPrimary != nil && *attr.AttrPrimary == handleID {
+		if attr.AttrPrimary != nil && sanitizeHandle(*attr.AttrPrimary) == handleID {
 			indexes = append(indexes, i)
 		}
 	}
 	return indexes
+}
+
+// sanitizeHandle fixes any improperly formatted handles that we might come across.
+// Malformed handles were written as part of host-local to Calico IPAM migration after
+// host-local IPAM changed its file format: https://github.com/projectcalico/cni-plugin/issues/821.
+func sanitizeHandle(handleID string) string {
+	return strings.Split(handleID, "\r")[0]
 }
 
 func (b *allocationBlock) releaseByHandle(handleID string) int {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In https://github.com/projectcalico/cni-plugin/issues/821 we introduced
a bug that caused some handles to be written to the datastore using the
wrong format. Namely, `k8s-pod-network.<id>\r\neth0`. 

This resulted in an inability to properly release these handles, because
the IPAM handle name doesn't match the name for the handle in the IPAM
block. 

This PR introduces santization logic which is intended to remove the
bugged suffix from handles before release, so that we properly match.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix releasing of improperly formatted handles as a result of host-local IPAM migration bug. 
```