### PR TITLE
Automated cherry pick of #1345: Handle malformed handle IDs

### DIFF
--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -1321,6 +1321,7 @@ func (c ipamClient) IPsByHandle(ctx context.Context, handleID string) ([]net.IP,
 // ReleaseByHandle releases all IP addresses that have been assigned
 // using the provided handle.
 func (c ipamClient) ReleaseByHandle(ctx context.Context, handleID string) error {
+	handleID = sanitizeHandle(handleID)
 	log.Infof("Releasing all IPs with handle '%s'", handleID)
 	obj, err := c.blockReaderWriter.queryHandle(ctx, handleID, "")
 	if err != nil {

--- a/lib/ipam/ipam_block.go
+++ b/lib/ipam/ipam_block.go
@@ -337,11 +337,18 @@ func (b allocationBlock) attributeRefCounts() map[int]int {
 func (b allocationBlock) attributeIndexesByHandle(handleID string) []int {
 	indexes := []int{}
 	for i, attr := range b.Attributes {
-		if attr.AttrPrimary != nil && *attr.AttrPrimary == handleID {
+		if attr.AttrPrimary != nil && sanitizeHandle(*attr.AttrPrimary) == handleID {
 			indexes = append(indexes, i)
 		}
 	}
 	return indexes
+}
+
+// sanitizeHandle fixes any improperly formatted handles that we might come across.
+// Malformed handles were written as part of host-local to Calico IPAM migration after
+// host-local IPAM changed its file format: https://github.com/projectcalico/cni-plugin/issues/821.
+func sanitizeHandle(handleID string) string {
+	return strings.Split(handleID, "\r")[0]
 }
 
 func (b *allocationBlock) releaseByHandle(handleID string) int {


### PR DESCRIPTION
Cherry pick of #1345 on release-v3.17.

#1345: Handle malformed handle IDs

```release-note
Fix releasing of improperly formatted handles as a result of host-local IPAM migration bug. 
```