### PR TITLE
set workload endpoint veth name with a legal size

### DIFF
--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -33,6 +33,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
+const linuxInterfaceMaxSize = 15
+
 type defaultWorkloadEndpointConverter struct{}
 
 // VethNameForWorkload returns a deterministic veth name
@@ -52,7 +54,8 @@ func (wc defaultWorkloadEndpointConverter) VethNameForWorkload(namespace, podnam
 		prefix = splits[0]
 	}
 	log.WithField("prefix", prefix).Debugf("Using prefix to create a WorkloadEndpoint veth name")
-	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
+	surfixLen := linuxInterfaceMaxSize-len(prefix)
+	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:surfixLen])
 }
 
 func (wc defaultWorkloadEndpointConverter) PodToWorkloadEndpoints(pod *kapiv1.Pod) ([]*model.KVPair, error) {


### PR DESCRIPTION
network interfece name's max-size is 15, with self-specificed prefix, we should make sure our veth name size <= 15

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
