### PR TITLE
Fix libcalico returning a generic kubernetes error

### DIFF
--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -209,7 +209,7 @@ func (c *WorkloadEndpointClient) Get(ctx context.Context, key model.Key, revisio
 		}
 	}
 
-	return nil, kerrors.NewNotFound(apiv3.Resource("WorkloadEndpoint"), key.String())
+	return nil, cerrors.ErrorResourceDoesNotExist{Identifier: k}
 }
 
 func (c *WorkloadEndpointClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {


### PR DESCRIPTION
## Description
In case of a missing WorkloadEndpoint object, libcalico returns a generic Kubernetes error rather than a specific Calico one, which can result in consumers of the library not being able to identify it as a "Not Found" error, and properly ignore it where they need to do so.
An example of such bug is shown in projectcalico/calico#4235 and this change has fixed the issue that is described there.

```release-note
Properly report not found when WorkloadEndpoint doesn't exist. Fixes https://github.com/projectcalico/calico/issues/4235
```