### PR TITLE
ippool Spec.CIDR support ipv6 full representation, ipv4 with host bit set

### DIFF
--- a/lib/ipam/ipam.go
+++ b/lib/ipam/ipam.go
@@ -248,12 +248,18 @@ func (c ipamClient) determinePools(ctx context.Context, requestedPoolNets []net.
 	// Build a map so we can lookup existing pools.
 	pm := map[string]v3.IPPool{}
 
+	var cidr *net.IPNet
 	for _, p := range enabledPools {
 		if p.Spec.BlockSize > maxPrefixLen {
 			log.Warningf("skipping pool %v due to blockSize %d bigger than %d", p, p.Spec.BlockSize, maxPrefixLen)
 			continue
 		}
-		pm[p.Spec.CIDR] = p
+		_, cidr, err = net.ParseCIDR(p.Spec.CIDR)
+		if err != nil {
+			log.WithError(err).Errorf("Pool %s has invalid CIDR %s", p.Name, p.Spec.CIDR)
+			return
+		}
+		pm[cidr.String()] = p
 	}
 
 	if len(pm) == 0 {
@@ -266,9 +272,10 @@ func (c ipamClient) determinePools(ctx context.Context, requestedPoolNets []net.
 	// that each one actually exists and is enabled for IPAM.
 	requestedPools := []v3.IPPool{}
 	for _, rp := range requestedPoolNets {
-		if pool, ok := pm[rp.String()]; !ok {
+		cidr := rp.Network()
+		if pool, ok := pm[cidr.String()]; !ok {
 			// The requested pool doesn't exist.
-			err = fmt.Errorf("the given pool (%s) does not exist, or is not enabled", rp.IPNet.String())
+			err = fmt.Errorf("the given pool (%s) does not exist, or is not enabled", cidr.String())
 			return
 		} else {
 			requestedPools = append(requestedPools, pool)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
bugfix
Currently calico always assumes ipv6 ippool's CIDR field in ipv6 short form. Otherwise, there will throw an error. This pr support ipv6 full representation.

IPPool spec
```
spec:
  blockSize: 122
  cidr: 5001:0000:0000:001a:0000:0000:0000:0000/64
  ipipMode: Always
  natOutgoing: true
  nodeSelector: all()
  vxlanMode: Never
```

pod event
```
  Normal   SandboxChanged          15m (x140 over 20m)  kubelet            Pod sandbox changed, it will be killed and re-created.
  Warning  FailedCreatePodSandBox  14s (x545 over 19m)  kubelet            (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container "c3aaff37d841f3d9385cd9a1adb0e76a09d1d9dde04e15f7f5189b3a2fa246fb" network for pod "hello-qaimages-7bb455fdf8-dz755": networkPlugin cni failed to set up pod "hello-qaimages-7bb455fdf8-dz755_test" network: the given pool (5001:0:0:1a::/64) does not exist, or is not enabled
```

This pr also permits ipv4 cidr with the host bit set. Eg 10.0.0.1/24

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
IPPool CIDR permits ipv6 full representation and ipv4 with host bit set.
```
