### PR TITLE
Calico-4373: default missing protocol to TCP; don't let single port overwrite all ports

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -391,18 +391,15 @@ func (c converter) k8sRuleToCalico(rPeers []networkingv1.NetworkPolicyPeer, rPor
 		if p.Port != nil {
 			portval := intstr.FromString(p.Port.String())
 			port.Port = &portval
-
-			// TCP is the implicit default (as per the definition of NetworkPolicyPort).
-			// Make the default explicit here because our data-model always requires
-			// the protocol to be specified if we're doing a port match.
-			port.Protocol = &protoTCP
 		}
 		if p.Protocol != nil {
 			protval := kapiv1.Protocol(fmt.Sprintf("%s", *p.Protocol))
 			port.Protocol = &protval
 		} else {
-			protval := kapiv1.ProtocolTCP
-			port.Protocol = &protval
+			// TCP is the implicit default (as per the definition of NetworkPolicyPort).
+			// Make the default explicit here because our data-model always requires
+			// the protocol to be specified if we're doing a port match.
+			port.Protocol = &protoTCP
 		}
 		ports = append(ports, &port)
 	}
@@ -423,7 +420,6 @@ func (c converter) k8sRuleToCalico(rPeers []networkingv1.NetworkPolicyPeer, rPor
 			return nil, fmt.Errorf("failed to parse k8s port: %s", err)
 		}
 
-		// These are either both present or both nil
 		if protocol == nil && calicoPorts == nil {
 			// If nil, no ports were specified, or an empty port struct was provided, which we translate to allowing all.
 			// We want to use a nil protocol and a nil list of ports, which will allow any destination (for ingress).

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -1034,7 +1034,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			apiv3.Rule{
 				Action:   "Allow",
 				Protocol: &tcp,
-				Source: apiv3.EntityRule{},
+				Source:   apiv3.EntityRule{},
 				Destination: apiv3.EntityRule{
 					Selector: "projectcalico.org/orchestrator == 'k8s' && k == 'v' && k2 == 'v2'",
 				},
@@ -1042,7 +1042,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			apiv3.Rule{
 				Action:   "Allow",
 				Protocol: &udp,
-				Source: apiv3.EntityRule{},
+				Source:   apiv3.EntityRule{},
 				Destination: apiv3.EntityRule{
 					Ports: []numorstring.Port{numorstring.SinglePort(53)},
 				},


### PR DESCRIPTION
## Description

Bug fix: fixes https://github.com/projectcalico/calico/issues/4373.  There were a couple problems with port parsing that this addresses:

 - missing protocols were not treated as TCP, contradicting the network policy spec
 - allowing a specific port for a protocol could cause an 'allow all ports' for a protocol to be lost

Test plan:

```
libcalico-go/lib/backend/k8s/conversion$ go test .

libcalico-go$ sudo make test
```

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
When interpreting Kubernetes NetworkPolicy ports, Calico now interprets an empty port struct as "all TCP" as per the NetworkPolicy spec.  Previously, empty structs were ignored. 
```
