### PR TITLE
select a prefix to build interface name in legal size

### DIFF
--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -56,12 +56,28 @@ var _ = Describe("Test parsing strings", func() {
 		Expect(weid.Pod).To(Equal("pod-name"))
 	})
 
-	It("generate a veth name with the right prefix", func() {
+	It("generate a veth name with the first prefix in right env", func() {
 		os.Setenv("FELIX_INTERFACEPREFIX", "eni,veth,foo")
 		defer os.Setenv("FELIX_INTERFACEPREFIX", "")
 
 		name := c.VethNameForWorkload("namespace", "podname")
 		Expect(name).To(Equal("eni82111e10a96"))
+	})
+
+	It("generate a veth name with the default prefix in illegal env", func() {
+		os.Setenv("FELIX_INTERFACEPREFIX", "vreni,veth,foo")
+		defer os.Setenv("FELIX_INTERFACEPREFIX", "")
+
+		name := c.VethNameForWorkload("namespace", "podname")
+		Expect(name).To(Equal("cali82111e10a96"))
+	})
+
+	It("generate a veth name with the default prefix in empty env", func() {
+		os.Setenv("FELIX_INTERFACEPREFIX", "")
+		defer os.Setenv("FELIX_INTERFACEPREFIX", "")
+
+		name := c.VethNameForWorkload("namespace", "podname")
+		Expect(name).To(Equal("cali82111e10a96"))
 	})
 
 	It("should parse valid profile names", func() {


### PR DESCRIPTION
## Description
network interfece name's max-size is 15, with self-specificed prefix, we should make sure our veth name size <= 15
ref: https://github.com/projectcalico/libcalico-go/pull/1359 (which will be close)

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

Will choose a suitable prefix from environment: `FELIX_INTERFACEPREFIX` which is not empty and has a length< 5.