### PR TITLE
Add new config field: RouteProtocol

### DIFF
--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -458,6 +458,10 @@ spec:
                 description: 'ReportingTTL is the time-to-live setting for process-wide
                   status reports. [Default: 90s]'
                 type: string
+              routeProtocol:
+                description: This defines the route protocol added to programmed routes,
+                  by default this will be 202 (or 0xCA) when left blank.
+                type: integer
               routeRefreshInterval:
                 description: 'RouteRefreshInterval is the period at which Felix re-checks
                   the routes in the dataplane to ensure that no other process has

--- a/lib/apis/v3/felixconfig.go
+++ b/lib/apis/v3/felixconfig.go
@@ -269,6 +269,9 @@ type FelixConfigurationSpec struct {
 	// This defines the route protocol added to programmed device routes, by default this will be RTPROT_BOOT
 	// when left blank.
 	DeviceRouteProtocol *int `json:"deviceRouteProtocol,omitempty"`
+	// This defines the route protocol added to programmed routes, by default this will be 202 (or 0xCA)
+	// when left blank.
+	RouteProtocol *int `json:"routeProtocol,omitempty"`
 	// Whether or not to remove device routes that have not been programmed by Felix. Disabling this will allow external
 	// applications to also add device routes. This is enabled by default which means we will remove externally added routes.
 	RemoveExternalRoutes *bool `json:"removeExternalRoutes,omitempty"`

--- a/lib/apis/v3/openapi_generated.go
+++ b/lib/apis/v3/openapi_generated.go
@@ -3301,6 +3301,13 @@ func schema_libcalico_go_lib_apis_v3_FelixConfigurationSpec(ref common.Reference
 							Format:      "int32",
 						},
 					},
+					"routeProtocol": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This defines the route protocol added to programmed routes, by default this will be 202 (or 0xCA) when left blank.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"removeExternalRoutes": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether or not to remove device routes that have not been programmed by Felix. Disabling this will allow external applications to also add device routes. This is enabled by default which means we will remove externally added routes.",

--- a/lib/apis/v3/zz_generated.deepcopy.go
+++ b/lib/apis/v3/zz_generated.deepcopy.go
@@ -847,6 +847,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.RouteProtocol != nil {
+		in, out := &in.RouteProtocol, &out.RouteProtocol
+		*out = new(int)
+		**out = **in
+	}
 	if in.RemoveExternalRoutes != nil {
 		in, out := &in.RemoveExternalRoutes, &out.RemoveExternalRoutes
 		*out = new(bool)

--- a/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	numBaseFelixConfigs = 92
+	numBaseFelixConfigs = 93
 )
 
 var _ = Describe("Test the generic configuration update processor and the concrete implementations", func() {


### PR DESCRIPTION
## Description

On felix, we're adding a new config field `RouteProtocol` to add configuration for programmed routes' protocol number


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
