### PR TITLE
Fill internal or external IP for HostIPKey if BGP is disabled

### DIFF
--- a/lib/apis/v3/node.go
+++ b/lib/apis/v3/node.go
@@ -64,6 +64,7 @@ type NodeSpec struct {
 type NodeAddress struct {
 	// Address is a string representation of the actual address.
 	Address string `json:"address" validate:"net"`
+	Type string `json:"type" validate:"omitempty"`
 }
 
 type NodeStatus struct {

--- a/lib/apis/v3/node.go
+++ b/lib/apis/v3/node.go
@@ -23,6 +23,9 @@ import (
 const (
 	KindNode     = "Node"
 	KindNodeList = "NodeList"
+	CalicoNodeIP = "CalicoNodeIP"
+	InternalIP   = "InternalIP"
+	ExternalIP   = "ExternalIP"
 )
 
 // +genclient
@@ -64,7 +67,9 @@ type NodeSpec struct {
 type NodeAddress struct {
 	// Address is a string representation of the actual address.
 	Address string `json:"address" validate:"net"`
-	Type string `json:"type" validate:"omitempty"`
+
+	// Type is the node IP type
+	Type string `json:"type,omitempty" validate:"omitempty,ipType"`
 }
 
 type NodeStatus struct {

--- a/lib/apis/v3/openapi_generated.go
+++ b/lib/apis/v3/openapi_generated.go
@@ -5216,8 +5216,14 @@ func schema_libcalico_go_lib_apis_v3_NodeAddress(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
-				Required: []string{"address"},
+				Required: []string{"address", "type"},
 			},
 		},
 	}

--- a/lib/apis/v3/openapi_generated.go
+++ b/lib/apis/v3/openapi_generated.go
@@ -5218,12 +5218,13 @@ func schema_libcalico_go_lib_apis_v3_NodeAddress(ref common.ReferenceCallback) c
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Type is the node IP type",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
-				Required: []string{"address", "type"},
+				Required: []string{"address"},
 			},
 		},
 	}

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -306,17 +306,19 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 func fillAllAddresses(calicoNode *apiv3.Node, k8sNode *kapiv1.Node) {
 	if bgp := calicoNode.Spec.BGP; bgp != nil {
 		if addr := bgp.IPv4Address; addr != "" {
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr})
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr, Type: "bgp"})
 		}
 		if addr := bgp.IPv6Address; addr != "" {
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr})
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr, Type: "bgp"})
 		}
 	}
 
 	for _, kaddr := range k8sNode.Status.Addresses {
 		switch kaddr.Type {
-		case kapiv1.NodeInternalIP, kapiv1.NodeExternalIP:
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address})
+		case kapiv1.NodeInternalIP:
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address, Type: "int"})
+		case kapiv1.NodeExternalIP:
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address, Type: "ext"})
 		default:
 			continue
 		}

--- a/lib/backend/k8s/resources/node.go
+++ b/lib/backend/k8s/resources/node.go
@@ -306,19 +306,19 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 func fillAllAddresses(calicoNode *apiv3.Node, k8sNode *kapiv1.Node) {
 	if bgp := calicoNode.Spec.BGP; bgp != nil {
 		if addr := bgp.IPv4Address; addr != "" {
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr, Type: "bgp"})
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr, Type: apiv3.CalicoNodeIP})
 		}
 		if addr := bgp.IPv6Address; addr != "" {
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr, Type: "bgp"})
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: addr, Type: apiv3.CalicoNodeIP})
 		}
 	}
 
 	for _, kaddr := range k8sNode.Status.Addresses {
 		switch kaddr.Type {
 		case kapiv1.NodeInternalIP:
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address, Type: "int"})
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address, Type: apiv3.InternalIP})
 		case kapiv1.NodeExternalIP:
-			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address, Type: "ext"})
+			calicoNode.Spec.Addresses = append(calicoNode.Spec.Addresses, apiv3.NodeAddress{Address: kaddr.Address, Type: apiv3.ExternalIP})
 		default:
 			continue
 		}

--- a/lib/backend/k8s/resources/node_test.go
+++ b/lib/backend/k8s/resources/node_test.go
@@ -278,8 +278,8 @@ var _ = Describe("Test Node conversion", func() {
 		calicoNodeWithMergedLabels.Annotations[nodeK8sLabelAnnotation] = "{\"net.beta.kubernetes.io/role\":\"master\"}"
 		calicoNodeWithMergedLabels.Labels["net.beta.kubernetes.io/role"] = "master"
 		calicoNodeWithMergedLabels.Spec.Addresses = []apiv3.NodeAddress{
-			apiv3.NodeAddress{Address: "172.17.17.10/24",Type: "bgp"},
-			apiv3.NodeAddress{Address: "aa:bb:cc::ffff/120", Type: "bgp"},
+			apiv3.NodeAddress{Address: "172.17.17.10/24", Type: apiv3.CalicoNodeIP},
+			apiv3.NodeAddress{Address: "aa:bb:cc::ffff/120", Type: apiv3.CalicoNodeIP},
 		}
 		Expect(newCalicoNode.Value).To(Equal(calicoNodeWithMergedLabels))
 	})
@@ -540,10 +540,10 @@ var _ = Describe("Test Node conversion", func() {
 
 		addrs := n.Value.(*apiv3.Node).Spec.Addresses
 		Expect(addrs).To(ConsistOf([]apiv3.NodeAddress{
-			{Address: "fd10::10",Type: "bgp"},
-			{Address: "172.17.17.10", Type: "bgp"}, // from BGP
-			{Address: "172.17.17.10", Type: "int"}, // from k8s InternalIP
-			{Address: "192.168.1.100", Type: "ext"},
+			{Address: "fd10::10", Type: apiv3.CalicoNodeIP},
+			{Address: "172.17.17.10", Type: apiv3.CalicoNodeIP}, // from BGP
+			{Address: "172.17.17.10", Type: apiv3.InternalIP},   // from k8s InternalIP
+			{Address: "192.168.1.100", Type: apiv3.ExternalIP},
 		}))
 	})
 })

--- a/lib/backend/k8s/resources/node_test.go
+++ b/lib/backend/k8s/resources/node_test.go
@@ -278,8 +278,8 @@ var _ = Describe("Test Node conversion", func() {
 		calicoNodeWithMergedLabels.Annotations[nodeK8sLabelAnnotation] = "{\"net.beta.kubernetes.io/role\":\"master\"}"
 		calicoNodeWithMergedLabels.Labels["net.beta.kubernetes.io/role"] = "master"
 		calicoNodeWithMergedLabels.Spec.Addresses = []apiv3.NodeAddress{
-			apiv3.NodeAddress{Address: "172.17.17.10/24"},
-			apiv3.NodeAddress{Address: "aa:bb:cc::ffff/120"},
+			apiv3.NodeAddress{Address: "172.17.17.10/24",Type: "bgp"},
+			apiv3.NodeAddress{Address: "aa:bb:cc::ffff/120", Type: "bgp"},
 		}
 		Expect(newCalicoNode.Value).To(Equal(calicoNodeWithMergedLabels))
 	})
@@ -540,10 +540,10 @@ var _ = Describe("Test Node conversion", func() {
 
 		addrs := n.Value.(*apiv3.Node).Spec.Addresses
 		Expect(addrs).To(ConsistOf([]apiv3.NodeAddress{
-			{Address: "fd10::10"},
-			{Address: "172.17.17.10"}, // from BGP
-			{Address: "172.17.17.10"}, // from k8s InternalIP
-			{Address: "192.168.1.100"},
+			{Address: "fd10::10",Type: "bgp"},
+			{Address: "172.17.17.10", Type: "bgp"}, // from BGP
+			{Address: "172.17.17.10", Type: "int"}, // from k8s InternalIP
+			{Address: "192.168.1.100", Type: "ext"},
 		}))
 	})
 })

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -92,6 +92,36 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 					err = fmt.Errorf("failed to parsed IPv4IPIPTunnelAddr as an IP address")
 				}
 			}
+		} else {
+			var ip *cnet.IP
+			var cidr *cnet.IPNet
+
+			for _,addr := range node.Spec.Addresses {
+				if addr.Type == "int" {
+					ip, cidr, err = cnet.ParseCIDROrIP(addr.Address)
+					if err == nil {
+						log.WithFields(log.Fields{"ip": ip, "cidr": cidr}).Debug("Parsed IPv4 address")
+						ipv4 = ip
+						break
+					} else {
+						log.WithError(err).WithField("IPv4Address", addr.Address).Warn("Failed to parse IPv4Address")
+					}
+				}
+			}
+			if ipv4 == nil {
+				for _,addr := range node.Spec.Addresses {
+					if addr.Type == "ext" {
+						ip, cidr, err = cnet.ParseCIDROrIP(addr.Address)
+						if err == nil {
+							log.WithFields(log.Fields{"ip": ip, "cidr": cidr}).Debug("Parsed IPv4 address")
+							ipv4 = ip
+							break
+						} else {
+							log.WithError(err).WithField("IPv4Address", addr.Address).Warn("Failed to parse IPv4Address")
+						}
+					}
+				}
+			}
 		}
 
 		// Parse the IPv4 VXLAN tunnel address, Felix expects this as a HostConfigKey.  If we fail to parse then

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -92,10 +92,11 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 					err = fmt.Errorf("failed to parsed IPv4IPIPTunnelAddr as an IP address")
 				}
 			}
-		} else {
+		}
+		// Look for internal node address, if BGP is not running
+		if ipv4 == nil {
 			var ip *cnet.IP
 			var cidr *cnet.IPNet
-
 			for _,addr := range node.Spec.Addresses {
 				if addr.Type == "int" {
 					ip, cidr, err = cnet.ParseCIDROrIP(addr.Address)

--- a/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -95,10 +95,16 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 		}
 		// Look for internal node address, if BGP is not running
 		if ipv4 == nil {
-			ipv4 = c.findNodeAddress(node, apiv3.InternalIP)
+			ip := c.findNodeAddress(node, apiv3.InternalIP)
+			if ip != nil {
+				ipv4 = ip
+			}
 		}
 		if ipv4 == nil {
-			ipv4 = c.findNodeAddress(node, apiv3.ExternalIP)
+			ip := c.findNodeAddress(node, apiv3.ExternalIP)
+			if ip != nil {
+				ipv4 = ip
+			}
 		}
 
 		// Parse the IPv4 VXLAN tunnel address, Felix expects this as a HostConfigKey.  If we fail to parse then

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -84,6 +84,7 @@ var (
 	routeSource           = regexp.MustCompile("^(WorkloadIPs|CalicoIPAM)$")
 	dropAcceptReturnRegex = regexp.MustCompile("^(Drop|Accept|Return)$")
 	acceptReturnRegex     = regexp.MustCompile("^(Accept|Return)$")
+	ipTypeRegex           = regexp.MustCompile("^(CalicoNodeIP|InternalIP|ExternalIP)$")
 	standardCommunity     = regexp.MustCompile(`^(\d+):(\d+)$`)
 	largeCommunity        = regexp.MustCompile(`^(\d+):(\d+):(\d+)$`)
 	number                = regexp.MustCompile(`(\d+)`)
@@ -165,6 +166,7 @@ func init() {
 	registerFieldValidator("iptablesBackend", validateIptablesBackend)
 	registerFieldValidator("keyValueList", validateKeyValueList)
 	registerFieldValidator("prometheusHost", validatePrometheusHost)
+	registerFieldValidator("ipType", validateIPType)
 
 	registerFieldValidator("sourceAddress", RegexValidator("SourceAddress", SourceAddressRegex))
 	registerFieldValidator("regexp", validateRegexp)
@@ -328,6 +330,12 @@ func validateIPIPMode(fl validator.FieldLevel) bool {
 	s := fl.Field().String()
 	log.Debugf("Validate IPIP Mode: %s", s)
 	return ipipModeRegex.MatchString(s)
+}
+
+func validateIPType(fl validator.FieldLevel) bool {
+	s := fl.Field().String()
+	log.Debugf("Validate IPType: %s", s)
+	return ipTypeRegex.MatchString(s)
 }
 
 func validateVXLANMode(fl validator.FieldLevel) bool {


### PR DESCRIPTION
HostIPKey is filled with bgp address. If BGP is disabled, the hostIP we pass to the BPF programs is nil and the host end point programs fail to attach. Hence as a fallback, fill in the internal ip or external IP.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
