### PR TITLE
Fix that SCTP named ports were not copied from Pod to WorkloadEndpoint.

### DIFF
--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -219,6 +219,11 @@ var _ = Describe("Test Pod conversion", func() {
 								ContainerPort: 432,
 							},
 							{
+								Name:          "sctp-proto",
+								Protocol:      kapiv1.ProtocolSCTP,
+								ContainerPort: 891,
+							},
+							{
 								Name:          "unkn-proto",
 								Protocol:      kapiv1.Protocol("unknown"),
 								ContainerPort: 567,
@@ -261,6 +266,7 @@ var _ = Describe("Test Pod conversion", func() {
 
 		nsProtoTCP := numorstring.ProtocolFromString("tcp")
 		nsProtoUDP := numorstring.ProtocolFromString("udp")
+		nsProtoSCTP := numorstring.ProtocolFromString("sctp")
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.Ports).To(ConsistOf(
 			// No proto defaults to TCP (as defined in k8s API spec)
 			apiv3.EndpointPort{Name: "no-proto", Port: 1234, Protocol: nsProtoTCP},
@@ -270,6 +276,8 @@ var _ = Describe("Test Pod conversion", func() {
 			apiv3.EndpointPort{Name: "tcp-proto-with-host-port", Port: 8080, Protocol: nsProtoTCP},
 			// UDP is also an option.
 			apiv3.EndpointPort{Name: "udp-proto", Port: 432, Protocol: nsProtoUDP},
+			// SCTP.
+			apiv3.EndpointPort{Name: "sctp-proto", Port: 891, Protocol: nsProtoSCTP},
 			// Unknown protocol port is ignored.
 		))
 

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -187,6 +187,8 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 				switch containerPort.Protocol {
 				case kapiv1.ProtocolUDP:
 					modelProto = numorstring.ProtocolFromString("udp")
+				case kapiv1.ProtocolSCTP:
+					modelProto = numorstring.ProtocolFromString("sctp")
 				case kapiv1.ProtocolTCP, kapiv1.Protocol("") /* K8s default is TCP. */ :
 					modelProto = numorstring.ProtocolFromString("tcp")
 				default:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When we added SCTP support in felix we included named ports support but we missed this crucial piece of conversion logic.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix support for Kubernetes named ports with SCTP.
```
