### PR TITLE
Automated cherry pick of #1363: Fix libcalico returning a generic kubernetes error

### DIFF
--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -209,7 +209,7 @@ func (c *WorkloadEndpointClient) Get(ctx context.Context, key model.Key, revisio
 		}
 	}
 
-	return nil, kerrors.NewNotFound(apiv3.Resource("WorkloadEndpoint"), key.String())
+	return nil, cerrors.ErrorResourceDoesNotExist{Identifier: k}
 }
 
 func (c *WorkloadEndpointClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {


### PR DESCRIPTION
Cherry pick of #1363 on release-v3.18.

#1363: Fix libcalico returning a generic kubernetes error

```release-note
Properly report not found when WorkloadEndpoint doesn't exist. Fixes https://github.com/projectcalico/calico/issues/4235 @tommasopozzetti 
```