### PR TITLE
Use a spec field on WEPs for ServiceAccount name

### DIFF
--- a/lib/apis/v3/openapi_generated.go
+++ b/lib/apis/v3/openapi_generated.go
@@ -6394,6 +6394,13 @@ func schema_libcalico_go_lib_apis_v3_WorkloadEndpointSpec(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccountName, if specified, is the name of the k8s ServiceAccount  for this pod.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"ipNetworks": {
 						SchemaProps: spec.SchemaProps{
 							Description: "IPNetworks is a list of subnets allocated to this endpoint. IP packets will only be allowed to leave this interface if they come from an address in one of these subnets. Currently only /32 for IPv4 and /128 for IPv6 networks are supported.",

--- a/lib/apis/v3/workloadendpoint.go
+++ b/lib/apis/v3/workloadendpoint.go
@@ -48,6 +48,8 @@ type WorkloadEndpointSpec struct {
 	Pod string `json:"pod,omitempty" validate:"omitempty,name"`
 	// The Endpoint name.
 	Endpoint string `json:"endpoint,omitempty" validate:"omitempty,name"`
+	// ServiceAccountName, if specified, is the name of the k8s ServiceAccount  for this pod.
+	ServiceAccountName string `json:"serviceAccountName,omitempty" validate:"omitempty,name"`
 	// IPNetworks is a list of subnets allocated to this endpoint. IP packets will only be
 	// allowed to leave this interface if they come from an address in one of these subnets.
 	// Currently only /32 for IPv4 and /128 for IPv6 networks are supported.

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -128,7 +128,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 
 	if pod.Spec.ServiceAccountName != "" && len(pod.Spec.ServiceAccountName) < 63 {
 		// For backwards compatibility, include the label if less than 63 characters.
-		labels[apiv3.LabelNamespace] = pod.Spec.ServiceAccountName
+		labels[apiv3.LabelServiceAccount] = pod.Spec.ServiceAccountName
 	}
 
 	// Pull out floating IP annotation

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -126,8 +126,9 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 	labels[apiv3.LabelNamespace] = pod.Namespace
 	labels[apiv3.LabelOrchestrator] = apiv3.OrchestratorKubernetes
 
-	if pod.Spec.ServiceAccountName != "" {
-		labels[apiv3.LabelServiceAccount] = pod.Spec.ServiceAccountName
+	if pod.Spec.ServiceAccountName != "" && len(pod.Spec.ServiceAccountName) < 63 {
+		// For backwards compatibility, include the label if less than 63 characters.
+		labels[apiv3.LabelNamespace] = pod.Spec.ServiceAccountName
 	}
 
 	// Pull out floating IP annotation
@@ -220,15 +221,16 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		GenerateName:      pod.GenerateName,
 	}
 	wep.Spec = apiv3.WorkloadEndpointSpec{
-		Orchestrator:  "k8s",
-		Node:          pod.Spec.NodeName,
-		Pod:           pod.Name,
-		Endpoint:      "eth0",
-		InterfaceName: interfaceName,
-		Profiles:      profiles,
-		IPNetworks:    ipNets,
-		Ports:         endpointPorts,
-		IPNATs:        floatingIPs,
+		Orchestrator:       "k8s",
+		Node:               pod.Spec.NodeName,
+		Pod:                pod.Name,
+		Endpoint:           "eth0",
+		InterfaceName:      interfaceName,
+		Profiles:           profiles,
+		IPNetworks:         ipNets,
+		Ports:              endpointPorts,
+		IPNATs:             floatingIPs,
+		ServiceAccountName: pod.Spec.ServiceAccountName,
 	}
 
 	// Embed the workload endpoint into a KVPair.

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -139,6 +139,16 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		}
 	}
 
+	// Add a label for the WEP's serviceaccount if present. We only do this in the syncer
+	// because it is possible that a serviceaccount name is longer than the allowable character limit
+	// for a label. See https://github.com/projectcalico/calico/issues/4529.
+	if v3res.Spec.ServiceAccountName != "" {
+		// It's possible that this label is already set, because earlier version of the code set this
+		// label explicitly. If it is, it should be safe to override it with the new spec field
+		// since the values will be the same.
+		v3res.Labels[apiv3.LabelServiceAccount] = v3res.Spec.ServiceAccountName
+	}
+
 	v1value := &model.WorkloadEndpoint{
 		State:        "active",
 		Name:         v3res.Spec.InterfaceName,

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -115,7 +115,7 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		cmac = &cnet.MAC{mac}
+		cmac = &cnet.MAC{HardwareAddr: mac}
 	}
 
 	// Convert the EndpointPort type from the API pkg to the v1 model equivalent type
@@ -139,14 +139,15 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		}
 	}
 
-	// Add a label for the WEP's serviceaccount if present. We only do this in the syncer
-	// because it is possible that a serviceaccount name is longer than the allowable character limit
-	// for a label. See https://github.com/projectcalico/calico/issues/4529.
+	// Add a label for the WEP's serviceaccount if present. We do this in the syncer rather than on the
+	// workload endpoint when we create it, because it is possible that a serviceaccount name is longer than
+	// the allowable character limit for a label.
+	// See https://github.com/projectcalico/calico/issues/4529.
 	if v3res.Spec.ServiceAccountName != "" {
 		// It's possible that this label is already set, because earlier version of the code set this
-		// label explicitly. If it is, it should be safe to override it with the new spec field
-		// since the values will be the same.
-		v3res.Labels[apiv3.LabelServiceAccount] = v3res.Spec.ServiceAccountName
+		// label on the WorkloadEndpoint directly. If it is, it should be safe to override it
+		// with the new spec field since the values will be the same.
+		labels[apiv3.LabelServiceAccount] = v3res.Spec.ServiceAccountName
 	}
 
 	v1value := &model.WorkloadEndpoint{


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

A third option for fixing https://github.com/projectcalico/calico/issues/4529

Fixes https://github.com/projectcalico/calico/issues/4529

Idea is:
- Stop setting serviceaccount as a label on the WEP 
- Instead include it as a spec field. Convert to a label on Syncer API
to Felix so selection still works the same.

In kdd mode, this alone will be enough. The CNI plugin will stop sending
the label through, and since Felix reads directly from the Pod API will
keep receiving the same info over the Syncer.

For etcd mode, we need to make an additional change so that
kube-controllers properly updates old WEPs in the data store to include
the new spec field.

Alternatively, for etcd mode we could have kube-controllers add the
projectcalico.org/serviceaccount label itself. Any existing clusters
will not have any labels > 63 characters, and any new workloads that do
have such a long serviceaccount will be handled by the new CNI plugin
populating the spec field. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix issue with serviceaccount names larger than 63 characters.
```