### PR TITLE
Automated cherry pick of #1422: Use a spec field on WEPs for ServiceAccount name

### DIFF
--- a/lib/apis/v3/openapi_generated.go
+++ b/lib/apis/v3/openapi_generated.go
@@ -6394,6 +6394,13 @@ func schema_libcalico_go_lib_apis_v3_WorkloadEndpointSpec(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccountName, if specified, is the name of the k8s ServiceAccount  for this pod.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"ipNetworks": {
 						SchemaProps: spec.SchemaProps{
 							Description: "IPNetworks is a list of subnets allocated to this endpoint. IP packets will only be allowed to leave this interface if they come from an address in one of these subnets. Currently only /32 for IPv4 and /128 for IPv6 networks are supported.",

--- a/lib/apis/v3/workloadendpoint.go
+++ b/lib/apis/v3/workloadendpoint.go
@@ -48,6 +48,8 @@ type WorkloadEndpointSpec struct {
 	Pod string `json:"pod,omitempty" validate:"omitempty,name"`
 	// The Endpoint name.
 	Endpoint string `json:"endpoint,omitempty" validate:"omitempty,name"`
+	// ServiceAccountName, if specified, is the name of the k8s ServiceAccount  for this pod.
+	ServiceAccountName string `json:"serviceAccountName,omitempty" validate:"omitempty,name"`
 	// IPNetworks is a list of subnets allocated to this endpoint. IP packets will only be
 	// allowed to leave this interface if they come from an address in one of these subnets.
 	// Currently only /32 for IPv4 and /128 for IPv6 networks are supported.

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -128,7 +128,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 
 	if pod.Spec.ServiceAccountName != "" && len(pod.Spec.ServiceAccountName) < 63 {
 		// For backwards compatibility, include the label if less than 63 characters.
-		labels[apiv3.LabelNamespace] = pod.Spec.ServiceAccountName
+		labels[apiv3.LabelServiceAccount] = pod.Spec.ServiceAccountName
 	}
 
 	// Pull out floating IP annotation

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -126,8 +126,9 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 	labels[apiv3.LabelNamespace] = pod.Namespace
 	labels[apiv3.LabelOrchestrator] = apiv3.OrchestratorKubernetes
 
-	if pod.Spec.ServiceAccountName != "" {
-		labels[apiv3.LabelServiceAccount] = pod.Spec.ServiceAccountName
+	if pod.Spec.ServiceAccountName != "" && len(pod.Spec.ServiceAccountName) < 63 {
+		// For backwards compatibility, include the label if less than 63 characters.
+		labels[apiv3.LabelNamespace] = pod.Spec.ServiceAccountName
 	}
 
 	// Pull out floating IP annotation
@@ -220,15 +221,16 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		GenerateName:      pod.GenerateName,
 	}
 	wep.Spec = apiv3.WorkloadEndpointSpec{
-		Orchestrator:  "k8s",
-		Node:          pod.Spec.NodeName,
-		Pod:           pod.Name,
-		Endpoint:      "eth0",
-		InterfaceName: interfaceName,
-		Profiles:      profiles,
-		IPNetworks:    ipNets,
-		Ports:         endpointPorts,
-		IPNATs:        floatingIPs,
+		Orchestrator:       "k8s",
+		Node:               pod.Spec.NodeName,
+		Pod:                pod.Name,
+		Endpoint:           "eth0",
+		InterfaceName:      interfaceName,
+		Profiles:           profiles,
+		IPNetworks:         ipNets,
+		Ports:              endpointPorts,
+		IPNATs:             floatingIPs,
+		ServiceAccountName: pod.Spec.ServiceAccountName,
 	}
 
 	// Embed the workload endpoint into a KVPair.

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -139,6 +139,16 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		}
 	}
 
+	// Add a label for the WEP's serviceaccount if present. We only do this in the syncer
+	// because it is possible that a serviceaccount name is longer than the allowable character limit
+	// for a label. See https://github.com/projectcalico/calico/issues/4529.
+	if v3res.Spec.ServiceAccountName != "" {
+		// It's possible that this label is already set, because earlier version of the code set this
+		// label explicitly. If it is, it should be safe to override it with the new spec field
+		// since the values will be the same.
+		v3res.Labels[apiv3.LabelServiceAccount] = v3res.Spec.ServiceAccountName
+	}
+
 	v1value := &model.WorkloadEndpoint{
 		State:        "active",
 		Name:         v3res.Spec.InterfaceName,

--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -115,7 +115,7 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		cmac = &cnet.MAC{mac}
+		cmac = &cnet.MAC{HardwareAddr: mac}
 	}
 
 	// Convert the EndpointPort type from the API pkg to the v1 model equivalent type
@@ -139,14 +139,15 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 		}
 	}
 
-	// Add a label for the WEP's serviceaccount if present. We only do this in the syncer
-	// because it is possible that a serviceaccount name is longer than the allowable character limit
-	// for a label. See https://github.com/projectcalico/calico/issues/4529.
+	// Add a label for the WEP's serviceaccount if present. We do this in the syncer rather than on the
+	// workload endpoint when we create it, because it is possible that a serviceaccount name is longer than
+	// the allowable character limit for a label.
+	// See https://github.com/projectcalico/calico/issues/4529.
 	if v3res.Spec.ServiceAccountName != "" {
 		// It's possible that this label is already set, because earlier version of the code set this
-		// label explicitly. If it is, it should be safe to override it with the new spec field
-		// since the values will be the same.
-		v3res.Labels[apiv3.LabelServiceAccount] = v3res.Spec.ServiceAccountName
+		// label on the WorkloadEndpoint directly. If it is, it should be safe to override it
+		// with the new spec field since the values will be the same.
+		labels[apiv3.LabelServiceAccount] = v3res.Spec.ServiceAccountName
 	}
 
 	v1value := &model.WorkloadEndpoint{


### PR DESCRIPTION
Cherry pick of #1422 on release-v3.19.

#1422: Use a spec field on WEPs for ServiceAccount name


```release-note
Fix issue with serviceaccount names larger than 63 characters.
```