### PR TITLE
Improve IPAM logging info returned by AutoAssign()

### DIFF
--- a/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -210,16 +210,17 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 			var blockAffinityKeyV1 model.BlockAffinityKey
 			if config.Spec.DatastoreType != apiconfig.Kubernetes {
 				By("Allocating an IP address and checking that we get an allocation block")
-				ipV4Nets1, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+				v4ia1, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
 					Num4:     1,
 					Hostname: "127.0.0.1",
 				})
+				Expect(v4ia1).ToNot(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 
 				var ips1 []net.IP
-				for _, ipnet := range ipV4Nets1 {
+				for _, ipnet := range v4ia1.IPs {
 					ips1 = append(ips1, net.IP{ipnet.IP})
 				}
-				Expect(err).NotTo(HaveOccurred())
 
 				// Allocating an IP will create an affinity block that we should be notified of.  Not sure
 				// what CIDR will be chosen, so search the cached entries.
@@ -245,17 +246,18 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 				expectedCacheSize += 1
 				syncTester.ExpectCacheSize(expectedCacheSize)
 
-				ipV4Nets2, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+				v4ia2, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
 					Num4:     1,
 					Hostname: hostname,
 				})
+				Expect(v4ia2).ToNot(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 
 				var ips2 []net.IP
-				for _, ipnet := range ipV4Nets2 {
+				for _, ipnet := range v4ia2.IPs {
 					ips2 = append(ips2, net.IP{ipnet.IP})
 				}
 
-				Expect(err).NotTo(HaveOccurred())
 				syncTester.ExpectCacheSize(expectedCacheSize)
 
 				By("Releasing the IP addresses and checking for no updates")

--- a/lib/clientv3/ippool_e2e_test.go
+++ b/lib/clientv3/ippool_e2e_test.go
@@ -993,12 +993,13 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			Expect(err).NotTo(HaveOccurred())
 
 			// Allocate an IP so that a block is allocated
-			assignedV4, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1, Hostname: host})
+			v4ia, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1, Hostname: host})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v4ia).ToNot(BeNil())
 			var assigned []cnet.IP
-			for _, ipnet := range assignedV4 {
+			for _, ipnet := range v4ia.IPs {
 				assigned = append(assigned, cnet.IP{ipnet.IP})
 			}
-			Expect(err).NotTo(HaveOccurred())
 			Expect(assigned).To(HaveLen(1))
 
 			// Delete the pool
@@ -1068,9 +1069,10 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			Expect(err).NotTo(HaveOccurred())
 
 			// Allocate an IP so that a block is allocated
-			assigned, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1, Hostname: host})
+			v4ia, _, err := c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{Num4: 1, Hostname: host})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(assigned).To(HaveLen(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(v4ia.IPs).To(HaveLen(1))
 
 			By("creating a pool with a different cidr and block size")
 			p2, err := c.IPPools().Create(ctx, &apiv3.IPPool{
@@ -1084,9 +1086,10 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 
 			// Allocate an IP so that a block is allocated
 			pool2 := []cnet.IPNet{cnet.MustParseCIDR(p2.Spec.CIDR)}
-			assigned, _, err = c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{IPv4Pools: pool2, Num4: 1, Hostname: host})
+			v4ia, _, err = c.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{IPv4Pools: pool2, Num4: 1, Hostname: host})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(assigned).To(HaveLen(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(v4ia.IPs).To(HaveLen(1))
 
 			By("modifying the second IP pool")
 			p2.Spec.NATOutgoing = true

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -36,7 +36,7 @@ type Interface interface {
 	// which is useful for dataplanes that need to know the subnet (such as Windows).
 	//
 	// In case of error, returns the IPs allocated so far along with the error.
-	AutoAssign(ctx context.Context, args AutoAssignArgs) ([]cnet.IPNet, []cnet.IPNet, error)
+	AutoAssign(ctx context.Context, args AutoAssignArgs) (*IPAMAssignments, *IPAMAssignments, error)
 
 	// ReleaseIPs releases any of the given IP addresses that are currently assigned,
 	// so that they are available to be used in another assignment.

--- a/lib/ipam/ipam_block_reader_writer_test.go
+++ b/lib/ipam/ipam_block_reader_writer_test.go
@@ -215,12 +215,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						applyNode(bc, kc, testhost, nil)
 						defer deleteNode(bc, kc, testhost)
 
-						ips, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, 4, testhost, 0, nil)
+						ia, err := ic.autoAssign(ctx, 1, &testhost, nil, nil, 4, testhost, 0, nil)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)
 							testErr = err
 						}
-						if len(ips) != 1 {
+						if len(ia.IPs) != 1 {
 							// All hosts should get an IP, although some will be from non-affine blocks.
 							log.WithError(err).Errorf("No IPs assigned for host %s", testhost)
 							testErr = fmt.Errorf("No IPs assigned to %s", testhost)
@@ -303,12 +303,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 					go func() {
 						defer GinkgoRecover()
 
-						ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, testhost, 0, nil)
+						ia, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, testhost, 0, nil)
 						if err != nil {
 							log.WithError(err).Errorf("Auto assign failed for host %s", testhost)
 							testErr = err
 						}
-						if len(ips) != 1 {
+						if len(ia.IPs) != 1 {
 							log.WithError(err).Errorf("No IPs assigned for host %s", testhost)
 							testErr = fmt.Errorf("No IPs assigned to %s", testhost)
 						}
@@ -716,13 +716,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			}
 
 			By("attempting to claim the block on multiple hosts at the same time", func() {
-				ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, hostA, 0, nil)
+				ia, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, hostA, 0, nil)
 
 				// Shouldn't return an error.
 				Expect(err).NotTo(HaveOccurred())
 
 				// Should return a single IP.
-				Expect(len(ips)).To(Equal(1))
+				Expect(len(ia.IPs)).To(Equal(1))
 			})
 
 			By("checking that the other host has the affinity", func() {
@@ -746,13 +746,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			})
 
 			By("attempting to claim another address", func() {
-				ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, hostA, 0, nil)
+				ia, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, hostA, 0, nil)
 
 				// Shouldn't return an error.
 				Expect(err).NotTo(HaveOccurred())
 
 				// Should return a single IP.
-				Expect(len(ips)).To(Equal(1))
+				Expect(len(ia.IPs)).To(Equal(1))
 			})
 
 			By("checking that the pending affinity was cleaned up", func() {
@@ -1019,10 +1019,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 				pools:             p,
 				blockReaderWriter: rw,
 			}
-			ips, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, host, 0, rsvdAttr)
+			ia, err := ic.autoAssign(ctx, 1, nil, nil, nil, 4, host, 0, rsvdAttr)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(len(ips)).To(Equal(1))
-			Expect(ips[0].String()).To(Equal("10.0.0.2/30"))
+			Expect(len(ia.IPs)).To(Equal(1))
+			Expect(ia.IPs[0].String()).To(Equal("10.0.0.2/30"))
 
 		})
 	})

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -192,9 +192,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(err).NotTo(HaveOccurred())
 				ic = NewIPAMClient(bc, pa)
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, IPv4Pools: pool32, Hostname: hostname})
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, IPv4Pools: pool32, Hostname: hostname})
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
 			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
@@ -208,9 +209,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(err).NotTo(HaveOccurred())
 				ic = NewIPAMClient(bc, pa)
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, IPv4Pools: pool26, Hostname: hostname})
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, IPv4Pools: pool26, Hostname: hostname})
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
 			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
@@ -224,9 +226,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(err).NotTo(HaveOccurred())
 				ic = NewIPAMClient(bc, pa)
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, IPv4Pools: pool20, Hostname: hostname})
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, IPv4Pools: pool20, Hostname: hostname})
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
 			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
@@ -240,9 +243,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(err).NotTo(HaveOccurred())
 				ic = NewIPAMClient(bc, pa)
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 64, IPv4Pools: pool20, Hostname: hostname})
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 64, IPv4Pools: pool20, Hostname: hostname})
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(64))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(64))
 			})
 
 			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
@@ -256,9 +260,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(err).NotTo(HaveOccurred())
 				ic = NewIPAMClient(bc, pa)
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname})
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname})
 				v4IP := make([]cnet.IP, 0, 0)
-				for _, ipNets := range v4 {
+				Expect(v4ia).ToNot(BeNil())
+				for _, ipNets := range v4ia.IPs {
 					IP, _, _ := cnet.ParseCIDR(ipNets.String())
 					v4IP = append(v4IP, *IP)
 				}
@@ -286,26 +291,29 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				applyNode(bc, kc, node, map[string]string{"foo": "bar"})
 				for i := 0; i < 6; i++ {
 					// 6 addresses of each family per-node.
-					v4, v6, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Num6: 1, Hostname: node})
+					v4ia, v6ia, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Num6: 1, Hostname: node})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(v4)).To(Equal(1))
-					Expect(len(v6)).To(Equal(1))
-					for _, net := range v4 {
+					Expect(v4ia).ToNot(BeNil())
+					Expect(len(v4ia.IPs)).To(Equal(1))
+					Expect(v6ia).ToNot(BeNil())
+					Expect(len(v6ia.IPs)).To(Equal(1))
+					for _, net := range v4ia.IPs {
 						ip, _, _ := cnet.ParseCIDR(net.String())
 						ips = append(ips, *ip)
 					}
-					for _, net := range v6 {
+					for _, net := range v6ia.IPs {
 						ip, _, _ := cnet.ParseCIDR(net.String())
 						ips = append(ips, *ip)
 					}
 				}
 
 				// Allocate a few addresses with the same handle.
-				v4, v6, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 13, Num6: 0, Hostname: node})
+				v4ia, v6ia, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 13, Num6: 0, Hostname: node})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(13))
-				Expect(len(v6)).To(Equal(0))
-				for _, net := range v4 {
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(13))
+				Expect(v6ia).To(BeNil())
+				for _, net := range v4ia.IPs {
 					ip, _, _ := cnet.ParseCIDR(net.String())
 					ips = append(ips, *ip)
 				}
@@ -435,9 +443,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		It("should only release empty blocks", func() {
 			// Allocate an IP address in a block.
 			handle := "test-handle"
-			v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 
 			// Get the block that was allocated. It should have an affinity matching the host.
 			blocks, err := bc.List(context.Background(), model.BlockListOptions{}, "")
@@ -475,9 +484,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			// per each block.
 			handle := "test-handle"
 			for i := 0; i < 12; i++ {
-				v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
+				v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			}
 
 			// Release them all, leaving just the empty blocks.
@@ -490,9 +500,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(blocks.KVPairs)).To(Equal(3))
 
 			// Allocate a single address, which will make one of the blocks non empty.
-			v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 
 			// Release host affinities. It should clean up the two empty blocks, but leave the block with an address allocated.
 			// It should return an error because it cannot release all three.
@@ -510,9 +521,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			// per each block.
 			handle := "test-handle"
 			for i := 0; i < 12; i++ {
-				v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
+				v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Hostname: hostname, HandleID: &handle})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			}
 
 			// Expect three blocks.
@@ -566,10 +578,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1},
 			}
-			ips, _, bulkAssignErr := ic.AutoAssign(context.Background(), args)
+			v4ia, _, bulkAssignErr := ic.AutoAssign(context.Background(), args)
 
 			Expect(bulkAssignErr).NotTo(HaveOccurred())
-			Expect(len(ips)).To(Equal(64))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(64))
 		})
 
 		It("Should release with sentinel IP duplicated in the request args", func() {
@@ -596,9 +609,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1},
 			}
-			ips, _, err := ic.AutoAssign(context.Background(), args)
+			v4ia, _, err := ic.AutoAssign(context.Background(), args)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).To(Equal(0), "An IP has been assigned twice!")
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(0), "An IP has been assigned twice!")
 		})
 	})
 
@@ -632,7 +646,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 					Hostname: hostA,
 				}
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), args)
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 
 				blocks := getAffineBlocks(bc, hostA)
 				for _, b := range blocks {
@@ -641,7 +655,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 					}
 				}
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(pool1.IPNet.Contains(v4[0].IP)).To(BeTrue())
+				Expect(v4ia).ToNot(BeNil())
+				Expect(pool1.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 			})
 
 			It("should auto-assign another IP from the same pool into the same allocation block", func() {
@@ -651,9 +666,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 					Hostname: hostA,
 				}
 
-				v4, _, outErr := ic.AutoAssign(context.Background(), args)
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(block.IPNet.Contains(v4[0].IP)).To(BeTrue())
+				Expect(v4ia).ToNot(BeNil())
+				Expect(block.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 			})
 
 			It("should assign from a new pool for a new host (old pool is removed)", func() {
@@ -671,9 +687,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 					Num6:     0,
 					Hostname: hostB,
 				}
-				v4, _, outErr := ic.AutoAssign(context.Background(), args)
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(pool2.IPNet.Contains(v4[0].IP)).To(BeTrue())
+				Expect(v4ia).ToNot(BeNil())
+				Expect(pool2.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 			})
 
 			It("should not assign from an existing affine block for the first host since the pool is removed)", func() {
@@ -682,9 +699,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 					Num6:     0,
 					Hostname: hostA,
 				}
-				v4, _, outErr := ic.AutoAssign(context.Background(), args)
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(pool2.IPNet.Contains(v4[0].IP)).To(BeTrue())
+				Expect(v4ia).ToNot(BeNil())
+				Expect(pool2.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 			})
 		})
 	})
@@ -710,9 +728,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			By("Assigning an IP address", func() {
 				args := AutoAssignArgs{Num4: 1, HandleID: &handle, Hostname: "test-host"}
-				v4, _, err := ic.AutoAssign(context.Background(), args)
+				v4ia, _, err := ic.AutoAssign(context.Background(), args)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
 			By("Querying the IP by handle and expecting one", func() {
@@ -761,34 +780,35 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			applyPoolWithBlockSize("10.0.0.0/28", true, `foo == "bar"`, 28)
 
-			v4Node0, _, errNode0 := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode0, _, errNode0 := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 			})
 			Expect(errNode0).ToNot(HaveOccurred())
-			Expect(len(v4Node0)).To(Equal(1))
+			Expect(len(v4iaNode0.IPs)).To(Equal(1))
 
-			v4Node1, _, errNode1 := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode1, _, errNode1 := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node2,
 			})
 			Expect(errNode1).ToNot(HaveOccurred())
-			Expect(len(v4Node1)).To(Equal(1))
+			Expect(v4iaNode1).ToNot(BeNil())
+			Expect(len(v4iaNode1.IPs)).To(Equal(1))
 
 			// StrictAffinity is true
 			cfg = IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: true}
 			err = ic.SetIPAMConfig(ctx, cfg)
 			Expect(err).NotTo(HaveOccurred())
 
-			v4Node0, _, errNode0 = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode0, _, errNode0 = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 			})
 
-			v4Node1, _, errNode1 = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode1, _, errNode1 = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node2,
@@ -796,12 +816,15 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			if errNode0 != nil {
 				Expect(errNode1).NotTo(HaveOccurred())
-				Expect(len(v4Node1)).To(Equal(1))
-				Expect(len(v4Node0)).To(Equal(0))
+				Expect(v4iaNode1).ToNot(BeNil())
+				Expect(len(v4iaNode1.IPs)).To(Equal(1))
+				Expect(v4iaNode0).To(BeNil())
 			} else {
 				Expect(errNode0).NotTo(HaveOccurred())
-				Expect(len(v4Node0)).To(Equal(1))
-				Expect(len(v4Node1)).To(Equal(0))
+				Expect(v4iaNode0).ToNot(BeNil())
+				Expect(len(v4iaNode0.IPs)).To(Equal(1))
+				Expect(v4iaNode1).ToNot(BeNil())
+				Expect(len(v4iaNode1.IPs)).To(Equal(0))
 			}
 
 			// StrictAffinity is false
@@ -809,21 +832,23 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			err = ic.SetIPAMConfig(ctx, cfg)
 			Expect(err).NotTo(HaveOccurred())
 
-			v4Node0, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode0, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(v4Node0)).To(Equal(1))
+			Expect(v4iaNode0).ToNot(BeNil())
+			Expect(len(v4iaNode0.IPs)).To(Equal(1))
 
-			v4Node1, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode1, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node2,
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(v4Node1)).To(Equal(1))
+			Expect(v4iaNode1).ToNot(BeNil())
+			Expect(len(v4iaNode1.IPs)).To(Equal(1))
 		})
 
 		It("should borrow and release borrowed IPs as normal", func() {
@@ -852,23 +877,24 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			handle1 := "handle-1"
 			handle2 := "handle-2"
-			v4Node0, _, errNode0 := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode0, _, errNode0 := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 				HandleID: &handle1,
 			})
 			Expect(errNode0).ToNot(HaveOccurred())
-			Expect(len(v4Node0)).To(Equal(1))
+			Expect(len(v4iaNode0.IPs)).To(Equal(1))
 
-			v4Node1, _, errNode1 := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4iaNode1, _, errNode1 := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node2,
 				HandleID: &handle2,
 			})
 			Expect(errNode1).ToNot(HaveOccurred())
-			Expect(len(v4Node1)).To(Equal(1))
+			Expect(v4iaNode1).ToNot(BeNil())
+			Expect(len(v4iaNode1.IPs)).To(Equal(1))
 
 			err = ic.ReleaseByHandle(context.Background(), handle2)
 			Expect(err).ToNot(HaveOccurred())
@@ -898,51 +924,55 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// We should be able to assign 8 addresses to node0, fully using its two blocks.
 			for i := 0; i < 8; i++ {
-				v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+				v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 					Num4:     1,
 					Num6:     0,
 					Hostname: node1,
 					HandleID: &node1,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(v4)).To(Equal(1))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(1))
 			}
 
 			// Attempting to allocate a ninth address should fail, since
 			// it would require allcoating a third block.
-			v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 				HandleID: &node1,
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(len(v4)).To(Equal(0))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(0))
 
 			// Allocate a block for the OTHER node with a single address.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node2,
 				HandleID: &node2,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 
 			// Attempting to allocate a ninth address should still fail, due to
 			// strict affinity.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 				HandleID: &node1,
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(len(v4)).To(Equal(0))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(0))
 
 			// And, we should respect the global config even if a per-request value is provided,
 			// if it is more restrictive.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:             1,
 				Num6:             0,
 				Hostname:         node1,
@@ -950,7 +980,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				MaxBlocksPerHost: 3,
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(len(v4)).To(Equal(0))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(0))
 
 			// Increase the global limit.
 			cfg = IPAMConfig{AutoAllocateBlocks: true, StrictAffinity: true, MaxBlocksPerHost: 3}
@@ -959,7 +990,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// Try again, but with a more restrictive per-request value that will still fail,
 			// since the more restrictive value takes precedence.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:             1,
 				Num6:             0,
 				Hostname:         node1,
@@ -967,18 +998,20 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				MaxBlocksPerHost: 2,
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(len(v4)).To(Equal(0))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(0))
 
 			// Finally, send a request with no-limit. Now that the global value is higher,
 			// we should get a new block.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 				HandleID: &node1,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 		})
 	})
 
@@ -1022,10 +1055,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			args.Hostname = longHostname
 			args.Num6 = 1
 
-			v4, v6, err := ic.AutoAssign(context.Background(), args)
+			v4ia, v6ia, err := ic.AutoAssign(context.Background(), args)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
-			Expect(len(v6)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
+			Expect(v6ia).ToNot(BeNil())
+			Expect(len(v6ia.IPs)).To(Equal(1))
 
 			// The block should have an affinity to the host.
 			opts := model.BlockAffinityListOptions{Host: longHostname, IPVersion: 6}
@@ -1042,10 +1077,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			args.Hostname = longHostname2
 			args.Num6 = 1
-			v4, v6, err = ic.AutoAssign(context.Background(), args)
+			v4ia, v6ia, err = ic.AutoAssign(context.Background(), args)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
-			Expect(len(v6)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
+			Expect(v6ia).ToNot(BeNil())
+			Expect(len(v6ia.IPs)).To(Equal(1))
 
 			// Expect two block affinities.
 			opts = model.BlockAffinityListOptions{IPVersion: 6}
@@ -1069,16 +1106,18 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool("10.0.0.0/24", true, "")
 			applyPool("20.0.0.0/24", true, "")
 
-			v4, _, err := ic.AutoAssign(context.Background(), args)
+			v4ia, _, err := ic.AutoAssign(context.Background(), args)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4) == 1).To(BeTrue())
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 		})
 
 		// Call again to trigger an assignment from the newly created block.
 		It("should have assigned an IP address with no error", func() {
-			v4, _, err := ic.AutoAssign(context.Background(), args)
+			v4ia, _, err := ic.AutoAssign(context.Background(), args)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 		})
 	})
 
@@ -1116,7 +1155,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				IPv4Pools: []cnet.IPNet{pool1},
 			}
 
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 			blocks := getAffineBlocks(bc, host)
 			for _, b := range blocks {
 				if pool1.Contains(b.IPNet.IP) {
@@ -1125,7 +1164,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(pool1.IPNet.Contains(v4[0].IP)).To(BeTrue())
+			Expect(v4ia).ToNot(BeNil())
+			Expect(pool1.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 
 			usage, err := ic.GetUtilization(context.Background(), GetUtilizationArgs{})
 			Expect(err).NotTo(HaveOccurred())
@@ -1146,7 +1186,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				IPv4Pools: []cnet.IPNet{pool2},
 			}
 
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 			blocks := getAffineBlocks(bc, host)
 			for _, b := range blocks {
 				if pool2.Contains(b.IPNet.IP) {
@@ -1155,7 +1195,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(block2.IPNet.Contains(v4[0].IP)).To(BeTrue())
+			Expect(v4ia).ToNot(BeNil())
+			Expect(block2.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 
 			usage, err := ic.GetUtilization(context.Background(), GetUtilizationArgs{})
 			Expect(err).NotTo(HaveOccurred())
@@ -1175,9 +1216,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1},
 			}
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(block1.IPNet.Contains(v4[0].IP)).To(BeTrue())
+			Expect(v4ia).ToNot(BeNil())
+			Expect(block1.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 		})
 
 		It("should get an IP from pool2 in the same allocation block as the first IP from pool2", func() {
@@ -1188,9 +1230,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				IPv4Pools: []cnet.IPNet{pool2},
 			}
 
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(block2.IPNet.Contains(v4[0].IP)).To(BeTrue())
+			Expect(v4ia).ToNot(BeNil())
+			Expect(block2.IPNet.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 		})
 
 		It("should have strict IP pool affinity", func() {
@@ -1204,21 +1247,23 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			By("allocating the rest of the IPs in the pool", func() {
-				v4, _, outErr := ic.AutoAssign(context.Background(), args)
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(254))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(254))
 
 				// Expect all the IPs to be in pool2.
-				for _, a := range v4 {
+				for _, a := range v4ia.IPs {
 					Expect(pool2.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool2))
 				}
 			})
 
 			By("attempting to allocate an IP when there are no more left in the pool", func() {
 				args.Num4 = 1
-				v4, _, outErr := ic.AutoAssign(context.Background(), args)
+				v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
 				Expect(outErr).NotTo(HaveOccurred())
-				Expect(len(v4)).To(Equal(0))
+				Expect(v4ia).ToNot(BeNil())
+				Expect(len(v4ia.IPs)).To(Equal(0))
 			})
 		})
 	})
@@ -1237,16 +1282,17 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool2.String(), true, `foo != "bar"`)
 
 			// Attempt to assign 300 ips but only the 256 ips from pool1 should be used.
-			v4, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     300,
 				Num6:     0,
 				Hostname: host,
 			})
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(256))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(256))
 
 			// Expect all the IPs to be from pool1.
-			for _, a := range v4 {
+			for _, a := range v4ia.IPs {
 				Expect(pool1.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool1))
 			}
 		})
@@ -1266,13 +1312,14 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool1.String(), true, `foo == "bar"`)
 
 			// Assign three addresses to the node.
-			v4nets, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     3,
 				Num6:     0,
 				Hostname: host,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4nets)).To(Equal(3))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(3))
 
 			// Should have one affine block to this host.
 			blocks := getAffineBlocks(bc, host)
@@ -1280,7 +1327,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// Expect all the IPs to be from pool1.
 			var v4IPs []cnet.IP
-			for _, a := range v4nets {
+			for _, a := range v4ia.IPs {
 				Expect(pool1.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool1))
 				v4IPs = append(v4IPs, cnet.IP{IP: a.IP})
 			}
@@ -1338,41 +1385,44 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			handleID3 := "handle3"
 
 			// Assign three addresses to the node.
-			v4net1, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia1, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: host,
 				HandleID: &handleID1,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4net1)).To(Equal(1))
+			Expect(v4ia1).ToNot(BeNil())
+			Expect(len(v4ia1.IPs)).To(Equal(1))
 
-			v4net2, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia2, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: host,
 				HandleID: &handleID2,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4net2)).To(Equal(1))
+			Expect(v4ia2).ToNot(BeNil())
+			Expect(len(v4ia2.IPs)).To(Equal(1))
 
-			v4net3, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia3, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: host,
 				HandleID: &handleID3,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4net3)).To(Equal(1))
+			Expect(v4ia3).ToNot(BeNil())
+			Expect(len(v4ia3.IPs)).To(Equal(1))
 
 			// Should have one affine block to this host.
 			blocks := getAffineBlocks(bc, host)
 			Expect(len(blocks)).To(Equal(1))
 
 			// Expect all the IPs to be from pool1.
-			Expect(pool1.IPNet.Contains(v4net1[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4net1[0].IP, pool1))
-			Expect(pool1.IPNet.Contains(v4net2[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4net2[0].IP, pool1))
-			Expect(pool1.IPNet.Contains(v4net3[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4net3[0].IP, pool1))
+			Expect(pool1.IPNet.Contains(v4ia1.IPs[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4ia1.IPs[0].IP, pool1))
+			Expect(pool1.IPNet.Contains(v4ia2.IPs[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4ia2.IPs[0].IP, pool1))
+			Expect(pool1.IPNet.Contains(v4ia3.IPs[0].IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", v4ia3.IPs[0].IP, pool1))
 
 			// Release one of the IPs.
 			err = ic.ReleaseByHandle(context.Background(), handleID1)
@@ -1424,13 +1474,14 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPoolWithBlockSize(pool1.String(), true, `foo == "bar"`, 30)
 
 			// Assign 3 of the 4 total addresses to node1.
-			v4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     3,
 				Num6:     0,
 				Hostname: node1,
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(v4)).To(Equal(3))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(3))
 
 			// Should have one affine block to node1.
 			blocks := getAffineBlocks(bc, node1)
@@ -1441,30 +1492,31 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyNode(bc, kc, node2, map[string]string{"foo": "bar"})
 
 			// Assign 1 address to node1, expect an error.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node1,
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("no configured Calico pools for node host1"))
-			Expect(len(v4)).To(Equal(0))
+			Expect(v4ia).To(BeNil())
 
 			// Assign 1 address to node2.
-			v4, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     1,
 				Num6:     0,
 				Hostname: node2,
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
 
 			// The block should still be affine to node 1.
 			blocks = getAffineBlocks(bc, node1)
 			Expect(len(blocks)).To(Equal(1))
 
 			// The address assigned to node2 should come from the block affine to node1.
-			node2IP := v4[0].IP
+			node2IP := v4ia.IPs[0].IP
 			Expect(pool1.IPNet.Contains(node2IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", node2IP, pool1))
 		})
 
@@ -1482,13 +1534,14 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool1.String(), true, `foo == "bar"`)
 
 			// Assign three addresses to the node.
-			v4nets, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     3,
 				Num6:     0,
 				Hostname: host,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4nets)).To(Equal(3))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(3))
 
 			// Should have one affine block to this host.
 			blocks := getAffineBlocks(bc, host)
@@ -1496,7 +1549,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// Expect all the IPs to be from pool1.
 			var v4IPs []cnet.IP
-			for _, a := range v4nets {
+			for _, a := range v4ia.IPs {
 				Expect(pool1.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool1))
 				v4IPs = append(v4IPs, cnet.IP{IP: a.IP})
 			}
@@ -1523,17 +1576,18 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool2.String(), true, "all()")
 
 			// Assign three addresses to the node.
-			v4nets, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     3,
 				Num6:     0,
 				Hostname: host,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4nets)).To(Equal(3))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(3))
 
 			// Expect all the IPs to be from pool2.
 			v4IPs = []cnet.IP{}
-			for _, a := range v4nets {
+			for _, a := range v4ia.IPs {
 				Expect(pool2.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool2))
 				v4IPs = append(v4IPs, cnet.IP{IP: a.IP})
 			}
@@ -1564,13 +1618,14 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool1.String(), true, `foo == "bar"`)
 
 			// Assign three addresses to the node.
-			v4nets, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:     3,
 				Num6:     0,
 				Hostname: host,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4nets)).To(Equal(3))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(3))
 
 			// Should have one affine block to this host.
 			blocks := getAffineBlocks(bc, host)
@@ -1578,7 +1633,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// Expect all the IPs to be from pool1.
 			var v4IPs []cnet.IP
-			for _, a := range v4nets {
+			for _, a := range v4ia.IPs {
 				Expect(pool1.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool1))
 				v4IPs = append(v4IPs, cnet.IP{IP: a.IP})
 			}
@@ -1602,14 +1657,15 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool2.String(), true, "all()")
 
 			// Assign three addresses to the node.
-			v4nets, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
+			v4ia, _, err = ic.AutoAssign(context.Background(), AutoAssignArgs{
 				Num4:      3,
 				Num6:      0,
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool2},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(v4nets)).To(Equal(3))
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(3))
 
 			// The block should still have an affinity to this host.
 			Expect(len(getAffineBlocks(bc, host))).To(Equal(2))
@@ -1666,12 +1722,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1, pool2},
 			}
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
-			log.Printf("IPAM returned: %v\n", v4)
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
+			Expect(v4ia).ToNot(BeNil())
+			log.Printf("IPAM returned: %v\n", v4ia.IPs)
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(1))
-			Expect(pool1.Contains(v4[0].IP)).To(BeTrue())
+			Expect(len(v4ia.IPs)).To(Equal(1))
+			Expect(pool1.Contains(v4ia.IPs[0].IP)).To(BeTrue())
 		})
 
 		It("should allocate 300 IP addresses from two enabled pools that contain sufficient addresses", func() {
@@ -1681,11 +1738,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1, pool2},
 			}
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
-			log.Printf("v4: %d IPs\n", len(v4))
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
+			Expect(v4ia).ToNot(BeNil())
+			log.Printf("v4: %d IPs\n", len(v4ia.IPs))
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4)).To(Equal(300))
+			Expect(len(v4ia.IPs)).To(Equal(300))
 		})
 
 		It("should fail to allocate another 300 IP addresses from the same pools due to lack of addresses (partial allocation)", func() {
@@ -1695,12 +1753,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1, pool2},
 			}
-			v4, _, outErr := ic.AutoAssign(context.Background(), args)
-			log.Printf("v4: %d IPs\n", len(v4))
+			v4ia, _, outErr := ic.AutoAssign(context.Background(), args)
+			Expect(v4ia).ToNot(BeNil())
+			log.Printf("v4: %d IPs\n", len(v4ia.IPs))
 
 			// Expect 211 entries since we have a total of 512, we requested 1 + 300 already.
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(v4).To(HaveLen(211))
+			Expect(v4ia.IPs).To(HaveLen(211))
 		})
 
 		It("should fail to allocate any address when requesting an invalid pool and a valid pool", func() {
@@ -1710,11 +1769,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Hostname:  host,
 				IPv4Pools: []cnet.IPNet{pool1, pool5_doesnot_exist},
 			}
-			v4, _, err := ic.AutoAssign(context.Background(), args)
-			log.Printf("v4: %d IPs\n", len(v4))
+			v4ia, _, err := ic.AutoAssign(context.Background(), args)
+			log.Printf("v4 IPAM Assignments: %v\n", v4ia)
+			Expect(v4ia).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal("the given pool (40.0.0.0/24) does not exist, or is not enabled"))
-			Expect(len(v4)).To(Equal(0))
 		})
 	})
 
@@ -1968,8 +2027,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 	})
 
 	DescribeTable("AutoAssign: requested IPs vs returned IPs",
-		func(host string, cleanEnv bool, pools []pool, usePool string, inv4, inv6, expv4, expv6 int, blockLimit int, expError error) {
-
+		func(host string, cleanEnv bool, pools []pool, usePool string, inv4, inv6 int, expv4ia, expv6ia *IPAMAssignments, blockLimit int, strictAffinity bool, expError error) {
 			if cleanEnv {
 				bc.Clean()
 				deleteAllPools()
@@ -1990,51 +2048,250 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				MaxBlocksPerHost: blockLimit,
 			}
 
-			outv4, outv6, err := ic.AutoAssign(context.Background(), args)
+			if strictAffinity {
+				setAffinity(ic, true)
+				defer setAffinity(ic, false)
+			}
+
+			outv4ia, outv6ia, err := ic.AutoAssign(context.Background(), args)
 			if expError != nil {
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(expError))
 			} else {
 				Expect(err).ToNot(HaveOccurred())
 			}
-			Expect(outv4).To(HaveLen(expv4))
-			Expect(outv6).To(HaveLen(expv6))
+
+			if expv4ia == nil {
+				Expect(outv4ia).To(BeNil())
+			} else {
+				Expect(outv4ia).ToNot(BeNil())
+				Expect(len(outv4ia.IPs)).To(Equal(len(expv4ia.IPs)))
+				Expect(outv4ia.IPVersion).To(Equal(expv4ia.IPVersion))
+				Expect(outv4ia.NumRequested).To(Equal(expv4ia.NumRequested))
+				Expect(outv4ia.HostReservedAttr).To(Equal(expv4ia.HostReservedAttr))
+				Expect(outv4ia.Msgs).To(Equal(expv4ia.Msgs))
+			}
+
+			if expv6ia == nil {
+				Expect(outv6ia).To(BeNil())
+			} else {
+				Expect(outv6ia).ToNot(BeNil())
+				Expect(len(outv6ia.IPs)).To(Equal(len(expv6ia.IPs)))
+				Expect(outv6ia.IPVersion).To(Equal(expv6ia.IPVersion))
+				Expect(outv6ia.NumRequested).To(Equal(expv6ia.NumRequested))
+				Expect(outv6ia.HostReservedAttr).To(Equal(expv6ia.HostReservedAttr))
+				Expect(outv6ia.Msgs).To(Equal(expv6ia.Msgs))
+			}
 		},
 
 		// Test 1a: AutoAssign 1 IPv4, 1 IPv6 with tiny block - expect one of each to be returned.
-		Entry("1 v4 1 v6 - tiny block", "test-host", true, []pool{{"192.168.1.0/24", 32, true, ""}, {"fd80:24e2:f998:72d6::/120", 128, true, ""}}, "192.168.1.0/24", 1, 1, 1, 1, 0, nil),
+		Entry("1 v4 1 v6 - tiny block", "test-host", true,
+			[]pool{{"192.168.1.0/24", 32, true, ""}, {"fd80:24e2:f998:72d6::/120", 128, true, ""}}, "192.168.1.0/24", 1, 1,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        4,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        6,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			0, false, nil),
 
 		// Test 1b: AutoAssign 1 IPv4, 1 IPv6 with massive block - expect one of each to be returned.
-		Entry("1 v4 1 v6 - big block", "test-host", true, []pool{{"192.168.0.0/16", 20, true, ""}, {"fd80:24e2:f998:72d6::/110", 116, true, ""}}, "192.168.0.0/16", 1, 1, 1, 1, 0, nil),
+		Entry("1 v4 1 v6 - big block", "test-host", true,
+			[]pool{{"192.168.0.0/16", 20, true, ""}, {"fd80:24e2:f998:72d6::/110", 116, true, ""}},
+			"192.168.0.0/16", 1, 1,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        4,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        6,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			0, false, nil),
 
 		// Test 1c: AutoAssign 1 IPv4, 1 IPv6 with default block - expect one of each to be returned.
-		Entry("1 v4 1 v6 - default block", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 1, 1, 1, 1, 0, nil),
+		Entry("1 v4 1 v6 - default block", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/24", 1, 1,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        4,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        6,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			0, false, nil),
 
 		// Test 2a: AutoAssign 256 IPv4, 256 IPv6 with default blocksize- expect 256 IPv4 + IPv6 addresses.
-		Entry("256 v4 256 v6", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 256, 256, 256, 256, 0, nil),
+		Entry("256 v4 256 v6", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/24", 256, 256,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 256),
+				IPVersion:        4,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			&IPAMAssignments{
+				IPs:          make([]cnet.IPNet, 256),
+				IPVersion:    6,
+				NumRequested: 256,
+				Msgs:         nil,
+			},
+			0, false, nil),
 
 		// Test 2b: AutoAssign 256 IPv4, 256 IPv6 with small blocksize- expect 256 IPv4 + IPv6 addresses.
-		Entry("256 v4 256 v6 - small blocks", "test-host", true, []pool{{"192.168.1.0/24", 30, true, ""}, {"fd80:24e2:f998:72d6::/120", 126, true, ""}}, "192.168.1.0/24", 256, 256, 256, 256, 256, nil),
+		Entry("256 v4 256 v6 - small blocks", "test-host", true,
+			[]pool{{"192.168.1.0/24", 30, true, ""}, {"fd80:24e2:f998:72d6::/120", 126, true, ""}},
+			"192.168.1.0/24", 256, 256,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 256),
+				IPVersion:        4,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 256),
+				IPVersion:        6,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			256, false, nil),
 
 		// Test 2a: AutoAssign 256 IPv4, 256 IPv6 with num blocks limit expect 64 IPv4 + IPv6 addresses.
-		Entry("256 v4 0 v6 block limit", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 256, 0, 64, 0, 1, ErrBlockLimit),
-		Entry("256 v4 0 v6 block limit 2", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 256, 0, 128, 0, 2, ErrBlockLimit),
-		Entry("0 v4 256 v6 block limit", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 0, 256, 0, 64, 1, ErrBlockLimit),
+		Entry("256 v4 0 v6 block limit", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/24", 256, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 64),
+				IPVersion:        4,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             []string{"Need to allocate an IPAM block but could not - limit of 1 blocks reached for this node"},
+			},
+			nil, 1, false, ErrBlockLimit),
+		Entry("256 v4 0 v6 block limit 2", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/24", 256, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 128),
+				IPVersion:        4,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             []string{"Need to allocate an IPAM block but could not - limit of 2 blocks reached for this node"},
+			},
+			nil, 2, false, ErrBlockLimit),
+		Entry("0 v4 256 v6 block limit", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/24", 0, 256, nil,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 64),
+				IPVersion:        6,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             []string{"Need to allocate an IPAM block but could not - limit of 1 blocks reached for this node"},
+			},
+			1, false, ErrBlockLimit),
 
 		// Test 3: AutoAssign 257 IPv4, 0 IPv6 - expect 256 IPv4 addresses, no IPv6, and no error.
-		Entry("257 v4 0 v6", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 257, 0, 256, 0, 0, nil),
+		Entry("257 v4 0 v6", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 257, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 256),
+				IPVersion:        4,
+				NumRequested:     257,
+				HostReservedAttr: nil,
+				Msgs:             []string{"No IPs available in pools: [192.168.1.0/24]"},
+			},
+			nil, 0, false, nil),
 
 		// Test 4: AutoAssign 0 IPv4, 257 IPv6 - expect 256 IPv6 addresses, no IPv6, and no error.
-		Entry("0 v4 257 v6", "test-host", true, []pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}}, "192.168.1.0/24", 0, 257, 0, 256, 0, nil),
+		Entry("0 v4 257 v6", "test-host", true,
+			[]pool{{"192.168.1.0/24", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/24", 0, 257, nil,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 256),
+				IPVersion:        6,
+				NumRequested:     257,
+				HostReservedAttr: nil,
+				Msgs:             []string{"No IPs available in pools: [fd80:24e2:f998:72d6::/120]"},
+			},
+			0, false, nil),
 
 		// Test 5: (use pool of size /25 so only two blocks are contained):
 		// - Assign 1 address on host A (Expect 1 address).
-		Entry("1 v4 0 v6 host-a", "host-a", true, []pool{{"10.0.0.0/25", 26, true, ""}, {"fd80:24e2:f998:72d6::/121", 122, true, ""}}, "10.0.0.0/25", 1, 0, 1, 0, 0, nil),
+		Entry("1 v4 0 v6 host-a", "host-a", true,
+			[]pool{{"10.0.0.0/25", 26, true, ""}, {"fd80:24e2:f998:72d6::/121", 122, true, ""}},
+			"10.0.0.0/25", 1, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        4,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			nil, 0, false, nil),
 
 		// - Assign 1 address on host B (Expect 1 address, different block).
-		Entry("1 v4 0 v6 host-b", "host-b", false, []pool{{"10.0.0.0/25", 26, true, ""}, {"fd80:24e2:f998:72d6::/121", 122, true, ""}}, "10.0.0.0/25", 1, 0, 1, 0, 0, nil),
+		Entry("1 v4 0 v6 host-b", "host-b", false,
+			[]pool{{"10.0.0.0/25", 26, true, ""}, {"fd80:24e2:f998:72d6::/121", 122, true, ""}},
+			"10.0.0.0/25", 1, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 1),
+				IPVersion:        4,
+				NumRequested:     1,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			nil, 0, false, nil),
 
 		// - Assign 64 more addresses on host A (Expect 63 addresses from host A's block, 1 address from host B's block).
-		Entry("64 v4 0 v6 host-a", "host-a", false, []pool{{"10.0.0.0/25", 26, true, ""}, {"fd80:24e2:f998:72d6::/121", 122, true, ""}}, "10.0.0.0/25", 64, 0, 64, 0, 0, nil),
+		Entry("64 v4 0 v6 host-a", "host-a", false,
+			[]pool{{"10.0.0.0/25", 26, true, ""}, {"fd80:24e2:f998:72d6::/121", 122, true, ""}},
+			"10.0.0.0/25", 64, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 64),
+				IPVersion:        4,
+				NumRequested:     64,
+				HostReservedAttr: nil,
+				Msgs:             nil,
+			},
+			nil, 0, false, nil),
+		// - Try to assign 256 addresses with strict affinity enabled, expect 64 addresses.
+		Entry("256 v4 0 v6 strict affinity", "test-host", true,
+			[]pool{{"192.168.1.0/26", 26, true, ""}, {"192.168.1.64/26", 26, true, ""}, {"fd80:24e2:f998:72d6::/120", 122, true, ""}},
+			"192.168.1.0/26", 256, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 64),
+				IPVersion:        4,
+				NumRequested:     256,
+				HostReservedAttr: nil,
+				Msgs:             []string{"No more free affine blocks and strict affinity enabled"},
+			},
+			nil, 0, true, nil),
 	)
 
 	DescribeTable("AssignIP: requested IP vs returned error",
@@ -2115,12 +2372,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			if autoAssignNumIPv4 != 0 {
-				assignedIPv4, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
+				v4ia, _, err := ic.AutoAssign(context.Background(), AutoAssignArgs{
 					Num4:     autoAssignNumIPv4,
 					Hostname: hostname,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				for _, ipnet := range assignedIPv4 {
+				Expect(v4ia).ToNot(BeNil())
+				for _, ipnet := range v4ia.IPs {
 					inIPs = append(inIPs, cnet.MustParseIP(ipnet.IP.String()))
 				}
 				inIPs = inIPs[1:]
@@ -2490,3 +2748,86 @@ func deleteNode(c bapi.Client, kc *kubernetes.Clientset, host string) {
 		c.Delete(context.Background(), &model.ResourceKey{Name: host, Kind: libapiv3.KindNode}, "")
 	}
 }
+
+var _ = DescribeTable("IPAMAssignmentInfo.String() tests", func(ia *IPAMAssignments, expErr error) {
+
+	if expErr == nil {
+		Expect(ia.PartialFulfillmentError()).To(BeNil())
+	} else {
+		Expect(ia.PartialFulfillmentError()).To(Equal(expErr))
+	}
+},
+	Entry("No error, 1 addr",
+		&IPAMAssignments{
+			IPs:              make([]cnet.IPNet, 1),
+			IPVersion:        4,
+			NumRequested:     1,
+			Msgs:             nil,
+			HostReservedAttr: nil,
+		},
+		nil),
+	Entry("No error, 256 addrs",
+		&IPAMAssignments{
+			IPs:              make([]cnet.IPNet, 256),
+			IPVersion:        4,
+			NumRequested:     256,
+			Msgs:             []string{},
+			HostReservedAttr: nil,
+		},
+		nil),
+	Entry("Strict affinity",
+		&IPAMAssignments{
+			IPs:              []cnet.IPNet{},
+			IPVersion:        4,
+			NumRequested:     1,
+			Msgs:             []string{"No more free affine blocks and strict affinity enabled"},
+			HostReservedAttr: nil,
+		},
+		errors.New("Assigned 0 out of 1 requested IPv4 addresses; No more free affine blocks and strict affinity enabled")),
+	Entry("Block limit",
+		&IPAMAssignments{
+			IPs:              []cnet.IPNet{},
+			IPVersion:        4,
+			NumRequested:     1,
+			Msgs:             []string{"Need to allocate an IPAM block but could not - limit of 20 blocks reached for this node"},
+			HostReservedAttr: nil,
+		},
+		errors.New("Assigned 0 out of 1 requested IPv4 addresses; Need to allocate an IPAM block but could not - limit of 20 blocks reached for this node")),
+	Entry("Exhausted IP Pools",
+		&IPAMAssignments{
+			IPs:              []cnet.IPNet{},
+			IPVersion:        4,
+			NumRequested:     1,
+			Msgs:             []string{"No IPs available in pools: [192.168.0.0/24 192.168.1.0/24]"},
+			HostReservedAttr: nil,
+		},
+		errors.New("Assigned 0 out of 1 requested IPv4 addresses; No IPs available in pools: [192.168.0.0/24 192.168.1.0/24]")),
+	Entry("HostReservedAttr",
+		&IPAMAssignments{
+			IPs:          []cnet.IPNet{},
+			IPVersion:    4,
+			NumRequested: 1,
+			Msgs:         nil,
+			HostReservedAttr: &HostReservedAttr{
+				StartOfBlock: 3,
+				EndOfBlock:   1,
+				Handle:       WindowsReservedHandle,
+				Note:         "ipam ut",
+			},
+		},
+		errors.New("Assigned 0 out of 1 requested IPv4 addresses; HostReservedAttr: windows-reserved-ipam-handle")),
+	Entry("Multiple msgs",
+		&IPAMAssignments{
+			IPs:          []cnet.IPNet{},
+			IPVersion:    4,
+			NumRequested: 1,
+			Msgs:         []string{"Need to allocate an IPAM block but could not - limit of 20 blocks reached for this node", "No IPs available in pools: [192.168.0.0/24 192.168.1.0/24]"},
+			HostReservedAttr: &HostReservedAttr{
+				StartOfBlock: 3,
+				EndOfBlock:   1,
+				Handle:       WindowsReservedHandle,
+				Note:         "ipam ut",
+			},
+		},
+		errors.New("Assigned 0 out of 1 requested IPv4 addresses; Need to allocate an IPAM block but could not - limit of 20 blocks reached for this node; No IPs available in pools: [192.168.0.0/24 192.168.1.0/24]; HostReservedAttr: windows-reserved-ipam-handle")),
+)

--- a/lib/ipam/ipam_win_test.go
+++ b/lib/ipam/ipam_win_test.go
@@ -146,14 +146,19 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 			}
 
 			ctx := context.WithValue(context.Background(), "windowsHost", windowsHost)
-			outv4, _, outErr := ic.AutoAssign(ctx, args)
+			outv4ia, _, outErr := ic.AutoAssign(ctx, args)
 			if expError != nil {
-				Expect(outErr).To(HaveOccurred())
+				Expect(outErr).To(Equal(expError))
 			} else {
 				Expect(outErr).ToNot(HaveOccurred())
 			}
 
-			Expect(len(outv4)).To(Equal(expv4))
+			if expv4 > 0 {
+				Expect(outv4ia).ToNot(BeNil())
+				Expect(len(outv4ia.IPs)).To(Equal(expv4))
+			} else {
+				Expect(outv4ia).To(BeNil())
+			}
 
 			reservedIPs := []string{
 				"100.0.0.0", "100.0.0.1", "100.0.0.2", "100.0.0.63",
@@ -162,7 +167,7 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				"100.0.0.192", "100.0.0.193", "100.0.0.194", "100.0.0.255",
 			}
 
-			for _, ip := range outv4 {
+			for _, ip := range outv4ia.IPs {
 				Expect(reservedIPs).NotTo(ContainElement(ip.String()))
 			}
 
@@ -222,9 +227,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				IPv4Pools:             []cnet.IPNet{fromPool},
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
-			outv4_1, _, outErr := ic.AutoAssign(ctx1, args1)
+			outv4ia_1, _, outErr := ic.AutoAssign(ctx1, args1)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_1)).To(Equal(1))
+			Expect(outv4ia_1).ToNot(BeNil())
+			Expect(len(outv4ia_1.IPs)).To(Equal(1))
 
 			By("Trying to allocate an ip for windows host 2")
 			args2 := AutoAssignArgs{
@@ -234,9 +240,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				IPv4Pools:             []cnet.IPNet{fromPool},
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
-			outv4_2, _, outErr := ic.AutoAssign(ctx1, args2)
+			outv4ia_2, _, outErr := ic.AutoAssign(ctx1, args2)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_2)).To(Equal(1))
+			Expect(outv4ia_2).ToNot(BeNil())
+			Expect(len(outv4ia_2.IPs)).To(Equal(1))
 
 			// Linux Hosts
 			By("Trying to allocate an ip for linux host 1")
@@ -248,9 +255,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				IPv4Pools:             []cnet.IPNet{fromPool},
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
-			outv4_3, _, outErr := ic.AutoAssign(ctx2, args3)
+			outv4ia_3, _, outErr := ic.AutoAssign(ctx2, args3)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_3)).To(Equal(1))
+			Expect(outv4ia_3).ToNot(BeNil())
+			Expect(len(outv4ia_3.IPs)).To(Equal(1))
 
 			By("Trying to allocate an ip for linux host 2")
 			args4 := AutoAssignArgs{
@@ -261,9 +269,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
 
-			outv4_4, _, outErr := ic.AutoAssign(ctx2, args4)
+			outv4ia_4, _, outErr := ic.AutoAssign(ctx2, args4)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_4)).To(Equal(1))
+			Expect(outv4ia_4).ToNot(BeNil())
+			Expect(len(outv4ia_4.IPs)).To(Equal(1))
 
 			By("Trying to allocate 100 IPs for windows host 1")
 			args5 := AutoAssignArgs{
@@ -273,9 +282,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				IPv4Pools:             []cnet.IPNet{fromPool},
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
-			outv4_5, _, outErr := ic.AutoAssign(ctx1, args5)
+			outv4ia_5, _, outErr := ic.AutoAssign(ctx1, args5)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_5)).To(Equal(59))
+			Expect(outv4ia_5).ToNot(BeNil())
+			Expect(len(outv4ia_5.IPs)).To(Equal(59))
 
 			By("Trying to allocate 100 IPs for linux host 1")
 			args6 := AutoAssignArgs{
@@ -285,9 +295,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				IPv4Pools:             []cnet.IPNet{fromPool},
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
-			outv4_6, _, outErr := ic.AutoAssign(ctx2, args6)
+			outv4ia_6, _, outErr := ic.AutoAssign(ctx2, args6)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_6)).To(Equal(59))
+			Expect(outv4ia_6).ToNot(BeNil())
+			Expect(len(outv4ia_6.IPs)).To(Equal(59))
 
 			By("Trying to allocate 100 IPs for linux host 2")
 			args7 := AutoAssignArgs{
@@ -297,9 +308,10 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				IPv4Pools:             []cnet.IPNet{fromPool},
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
-			outv4_7, _, outErr := ic.AutoAssign(ctx2, args7)
+			outv4ia_7, _, outErr := ic.AutoAssign(ctx2, args7)
 			Expect(outErr).ToNot(HaveOccurred())
-			Expect(len(outv4_7)).To(Equal(59))
+			Expect(outv4ia_7).ToNot(BeNil())
+			Expect(len(outv4ia_7.IPs)).To(Equal(59))
 		})
 	})
 
@@ -332,18 +344,20 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 			ipPoolsWindows.pools["100.0.0.0/24"] = pool{cidr: "100.0.0.0/24", enabled: true, blockSize: 26}
 			ipPoolsWindows.pools["200.0.0.0/24"] = pool{cidr: "200.0.0.0/24", enabled: true, blockSize: 26}
 			ctx := context.WithValue(context.Background(), "windowsHost", "windows")
-			v4, _, outErr := ic.AutoAssign(ctx, args)
+			v4ia, _, outErr := ic.AutoAssign(ctx, args)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4) == 1).To(BeTrue())
-			Expect(checkWindowsValidIP(v4[0].IP, 26)).To(BeTrue())
-			Expect(isValidWindowsHandle(bc, ipPoolsWindows, v4[0].IP, ctx)).To(BeTrue())
+			Expect(v4ia).ToNot(BeNil())
+			Expect(len(v4ia.IPs)).To(Equal(1))
+			Expect(checkWindowsValidIP(v4ia.IPs[0].IP, 26)).To(BeTrue())
+			Expect(isValidWindowsHandle(bc, ipPoolsWindows, v4ia.IPs[0].IP, ctx)).To(BeTrue())
 
 			By("Calling again to trigger an assignment from the newly created block.")
-			v4_next, _, outErr := ic.AutoAssign(ctx, args)
+			v4ia_next, _, outErr := ic.AutoAssign(ctx, args)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4_next)).To(Equal(1))
-			Expect(checkWindowsValidIP(v4_next[0].IP, 26)).To(BeTrue())
-			Expect(isValidWindowsHandle(bc, ipPoolsWindows, v4_next[0].IP, ctx)).To(BeTrue())
+			Expect(v4ia_next).ToNot(BeNil())
+			Expect(len(v4ia_next.IPs)).To(Equal(1))
+			Expect(checkWindowsValidIP(v4ia_next.IPs[0].IP, 26)).To(BeTrue())
+			Expect(isValidWindowsHandle(bc, ipPoolsWindows, v4ia_next.IPs[0].IP, ctx)).To(BeTrue())
 		})
 
 	})
@@ -383,7 +397,7 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 			}
 
 			ctx := context.WithValue(context.Background(), "windowsHost", "windows")
-			v4_1, _, outErr := ic.AutoAssign(ctx, args_1)
+			v4ia_1, _, outErr := ic.AutoAssign(ctx, args_1)
 			blocks := getAffineBlocks(bc, host)
 			for _, b := range blocks {
 				if pool1.Contains(b.IPNet.IP) {
@@ -392,7 +406,8 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 			}
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(pool1.IPNet.Contains(v4_1[0].IP)).To(BeTrue())
+			Expect(v4ia_1).ToNot(BeNil())
+			Expect(pool1.IPNet.Contains(v4ia_1.IPs[0].IP)).To(BeTrue())
 
 			By("Windows: Should get an IP from pool2 when explicitly requesting from that pool")
 
@@ -404,7 +419,7 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 				HostReservedAttrIPv4s: rsvdAttrWindows,
 			}
 
-			v4_2, _, outErr := ic.AutoAssign(ctx, args_2)
+			v4ia_2, _, outErr := ic.AutoAssign(ctx, args_2)
 			blocks = getAffineBlocks(bc, host)
 			for _, b := range blocks {
 				if pool2.Contains(b.IPNet.IP) {
@@ -413,46 +428,51 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 			}
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(block2.IPNet.Contains(v4_2[0].IP)).To(BeTrue())
+			Expect(v4ia_2).ToNot(BeNil())
+			Expect(block2.IPNet.Contains(v4ia_2.IPs[0].IP)).To(BeTrue())
 
 			By("Windows: Should get an IP from pool1 in the same allocation block as the first IP from pool1")
 
-			v4_3, _, outErr := ic.AutoAssign(ctx, args_1)
+			v4ia_3, _, outErr := ic.AutoAssign(ctx, args_1)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(block1.IPNet.Contains(v4_3[0].IP)).To(BeTrue())
+			Expect(v4ia_3).ToNot(BeNil())
+			Expect(block1.IPNet.Contains(v4ia_3.IPs[0].IP)).To(BeTrue())
 
 			By("Windows: Should get an IP from pool2 in the same allocation block as the first IP from pool2")
 
-			v4_4, _, outErr := ic.AutoAssign(ctx, args_2)
+			v4ia_4, _, outErr := ic.AutoAssign(ctx, args_2)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(block2.IPNet.Contains(v4_4[0].IP)).To(BeTrue())
+			Expect(v4ia_4).ToNot(BeNil())
+			Expect(block2.IPNet.Contains(v4ia_4.IPs[0].IP)).To(BeTrue())
 
 			// Assign the rest of the addresses in pool2.
 			// A /24 has 256 addresses and block size is 26 so we would have 16 reserved ips and We've assigned 2 already, so assign (256-18) 238 more.
 			args_2.Num4 = 238
 
 			By("Windows: Allocating the rest of the IPs in the pool")
-			v4_5, _, outErr := ic.AutoAssign(ctx, args_2)
+			v4ia_5, _, outErr := ic.AutoAssign(ctx, args_2)
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4_5)).To(Equal(238))
+			Expect(v4ia_5).ToNot(BeNil())
+			Expect(len(v4ia_5.IPs)).To(Equal(238))
 
 			// Expect all the IPs to be in pool2.
-			for _, a := range v4_5 {
+			for _, a := range v4ia_5.IPs {
 				Expect(pool2.IPNet.Contains(a.IP)).To(BeTrue(), fmt.Sprintf("%s not in pool %s", a.IP, pool2))
 			}
 
 			By("Windows: Attempting to allocate an IP when there are no more left in the pool")
 			args_2.Num4 = 1
-			v4_6, _, outErr := ic.AutoAssign(ctx, args_2)
+			v4ia_6, _, outErr := ic.AutoAssign(ctx, args_2)
 
 			Expect(outErr).NotTo(HaveOccurred())
-			Expect(len(v4_6)).To(Equal(0))
+			Expect(v4ia_6).ToNot(BeNil())
+			Expect(len(v4ia_6.IPs)).To(Equal(0))
 		})
 
 	})
 
 	DescribeTable("Windows: AutoAssign: requested IPs vs returned IPs",
-		func(host string, cleanEnv bool, pools []pool, rsvd *HostReservedAttr, usePool string, inv4, inv6, expv4, expv6 int, expError error) {
+		func(host string, cleanEnv bool, pools []pool, rsvd *HostReservedAttr, usePool string, inv4, inv6 int, expv4ia, expv6ia *IPAMAssignments, expError error) {
 			if cleanEnv {
 				bc.Clean()
 				deleteAllPoolsWindows()
@@ -481,35 +501,97 @@ var _ = testutils.E2eDatastoreDescribe("Windows: IPAM tests", testutils.Datastor
 			}
 
 			ctx := context.WithValue(context.Background(), "windowsHost", "windows")
-			outv4, outv6, outErr := ic.AutoAssign(ctx, args)
+			outv4ia, outv6ia, outErr := ic.AutoAssign(ctx, args)
 			if expError != nil {
 				Expect(outErr).To(Equal(expError))
 			} else {
 				Expect(outErr).ToNot(HaveOccurred())
 			}
-			Expect(outv4).To(HaveLen(expv4))
-			Expect(outv6).To(HaveLen(expv6))
+
+			if expv4ia == nil {
+				Expect(outv4ia).To(BeNil())
+			} else {
+				Expect(outv4ia).ToNot(BeNil())
+				Expect(len(outv4ia.IPs)).To(Equal(len(expv4ia.IPs)))
+				Expect(outv4ia.IPVersion).To(Equal(expv4ia.IPVersion))
+				Expect(outv4ia.NumRequested).To(Equal(expv4ia.NumRequested))
+				Expect(outv4ia.HostReservedAttr).To(Equal(expv4ia.HostReservedAttr))
+				Expect(outv4ia.Msgs).To(Equal(expv4ia.Msgs))
+			}
+
+			if expv6ia == nil {
+				Expect(outv6ia).To(BeNil())
+			} else {
+				Expect(outv6ia).ToNot(BeNil())
+				Expect(len(outv6ia.IPs)).To(Equal(len(expv6ia.IPs)))
+				Expect(outv6ia.IPVersion).To(Equal(expv6ia.IPVersion))
+				Expect(outv6ia.NumRequested).To(Equal(expv6ia.NumRequested))
+				Expect(outv6ia.HostReservedAttr).To(Equal(expv6ia.HostReservedAttr))
+				Expect(outv6ia.Msgs).To(Equal(expv6ia.Msgs))
+			}
 		},
 
 		// Test 1: AutoAssign 256 IPv4, 256 IPv6 - expect 240 IPv4 + IPv6 addresses.
 		Entry("256 v4 256 v6", "testHost", true, []pool{
 			{cidr: "192.168.1.0/24", blockSize: 26, enabled: true},
 			{cidr: "fd80:24e2:f998:72d6::/120", blockSize: 122, enabled: true},
-		}, rsvdAttrWindows, "192.168.1.0/24", 256, 256, 240, 240, nil),
+		}, rsvdAttrWindows, "192.168.1.0/24", 256, 256,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 240),
+				IPVersion:        4,
+				NumRequested:     256,
+				HostReservedAttr: rsvdAttrWindows,
+				Msgs:             []string{"No more free affine blocks and strict affinity enabled"},
+			},
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 240),
+				IPVersion:        6,
+				NumRequested:     256,
+				HostReservedAttr: rsvdAttrWindows,
+				Msgs:             []string{"No more free affine blocks and strict affinity enabled"},
+			},
+			nil),
 
 		// Test 2: AutoAssign 257 IPv4, 0 IPv6 - expect 240 IPv4 addresses, no IPv6, and no error.
-		Entry("257 v4 0 v6", "testHost", true, []pool{{cidr: "192.168.1.0/24", blockSize: 26, enabled: true}}, rsvdAttrWindows, "192.168.1.0/24", 257, 0, 240, 0, nil),
+		Entry("257 v4 0 v6", "testHost", true, []pool{{cidr: "192.168.1.0/24", blockSize: 26, enabled: true}}, rsvdAttrWindows, "192.168.1.0/24", 257, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 240),
+				IPVersion:        4,
+				NumRequested:     257,
+				HostReservedAttr: rsvdAttrWindows,
+				Msgs:             []string{"No more free affine blocks and strict affinity enabled"},
+			},
+			nil, nil),
 
 		// Test 3: AutoAssign 0 IPv4, 257 IPv6 - expect 240 IPv6 addresses, no IPv4, and no error.
 		Entry("0 v4 257 v6", "testHost", true, []pool{
 			{cidr: "192.168.1.0/24", blockSize: 26, enabled: true},
 			{cidr: "fd80:24e2:f998:72d6::/120", blockSize: 122, enabled: true},
-		}, rsvdAttrWindows, "192.168.1.0/24", 0, 257, 0, 240, nil),
+		}, rsvdAttrWindows, "192.168.1.0/24", 0, 257, nil,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 240),
+				IPVersion:        6,
+				NumRequested:     257,
+				HostReservedAttr: rsvdAttrWindows,
+				Msgs:             []string{"No more free affine blocks and strict affinity enabled"},
+			},
+			nil),
 
 		// Test 4: AutoAssign with invalid HostReserveAttr should return error.
-		Entry("1 v4 0 v6", "testHost", true, []pool{{cidr: "192.168.1.0/24", blockSize: 26, enabled: true}}, rsvdAttrTooBig, "192.168.1.0/24", 1, 0, 0, 0, ErrNoQualifiedPool),
+		Entry("1 v4 0 v6", "testHost", true, []pool{{cidr: "192.168.1.0/24", blockSize: 26, enabled: true}}, rsvdAttrTooBig, "192.168.1.0/24", 1, 0, nil, nil, ErrNoQualifiedPool),
 
-		Entry("0 v4 1 v6", "testHost", true, []pool{{cidr: "fd80:24e2:f998:72d6::/120", blockSize: 122, enabled: true}}, rsvdAttrTooBig, "fd80:24e2:f998:72d6::/120", 0, 1, 0, 0, ErrNoQualifiedPool),
+		Entry("0 v4 1 v6", "testHost", true, []pool{{cidr: "fd80:24e2:f998:72d6::/120", blockSize: 122, enabled: true}}, rsvdAttrTooBig, "fd80:24e2:f998:72d6::/120", 0, 1, nil, nil, ErrNoQualifiedPool),
+
+		// Test 5 AutoAssign 240 IPv4, expect 240 IPv4 and empty IPAMAssingments.Msgs
+		Entry("240 v4 0 v6", "testHost", true, []pool{{cidr: "192.168.1.0/24", blockSize: 26, enabled: true}}, rsvdAttrWindows, "192.168.1.0/24", 240, 0,
+			&IPAMAssignments{
+				IPs:              make([]cnet.IPNet, 240),
+				IPVersion:        4,
+				NumRequested:     240,
+				HostReservedAttr: rsvdAttrWindows,
+				Msgs:             nil,
+			},
+			nil, nil),
 	)
 })
 


### PR DESCRIPTION
## Description
Improve logging output from AutoAssign() for more clarity, especially when not all requested IPs are successfully assigned, stating the reasons for it.

Add `type IPAMAssignmentInfo struct` to ipam.go and return v4 and v6 versions of it from autoAssign() and propagate it to AutoAssign().

Change signature AutoAssign() in interface.go, and change every call of both functions to accommodate the new return values.

IPAMAssignmentInfo has as String() method which returns a formatted log message of the success/failure/reasons of the assignment. I would appreciate feedback on the message/output, thanks.

Add IPAMAssignmentInfo verification to AutoAssign fv tests in ipam_test.go and ipam_win_test.go and add a IPAMAssignmentInfo.String() ut test case to ipam_test.go.

Also: fix a typo in a log msg in findOrClaimBlock() and make AutoAssign tests in ipam_test.go check the error obtained against the expected (instead of just expecting any error to occur).

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
```release-note
Added enhanced error logging for IPAM failures
```