### PR TITLE
Add go routine stack trace dumping tooling

### DIFF
--- a/lib/debugtools/stacktrace/go_routine_stacktrace_server.go
+++ b/lib/debugtools/stacktrace/go_routine_stacktrace_server.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package grstacktrace contains utilities for getting go routine stack traces from running go programs. A go program
+// simple needs to run grstacktrace.MaybeRunServer() and set the GR_STACK_TRACE_SERVER_ENABLED environment variable
+// to true and a server will be run in the background that can be accessed to get a go routine stack trace on the
+// running program.
+//
+// The default host and port this server runs on is localhost:8989, but is configurable using the
+// GR_STACK_TRACE_SERVER_HOST and GR_STACK_TRACE_SERVER_PORT environment variables.
+package grstacktrace
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+
+	"github.com/kelseyhightower/envconfig"
+	log "github.com/sirupsen/logrus"
+)
+
+type config struct {
+	GRStackTraceServerEnabled bool   `default:"false" split_words:"true"`
+	GRStackTraceServerHost    string `default:"localhost" split_words:"true"`
+	GRStackTraceServerPort    string `default:"8989" split_words:"true"`
+}
+
+type server struct{}
+
+// ServeHTTP returns the responds to any request with the go routine stack trace created by runtime.Stack.
+func (s server) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	buf := make([]byte, 1<<16)
+	runtime.Stack(buf, true)
+
+	if _, err := fmt.Fprintf(writer, string(buf)); err != nil {
+		log.WithError(err).Error("failed to print out go routine stack trace")
+	}
+}
+
+// MaybeRunServer checks if the GR_STACK_TRACE_SERVER_ENABLED env variable has been set, and if it has been, instantiates
+// and runs and instance of `server` on the host and port specified by the env variables GR_STACK_TRACE_SERVER_HOST and
+// GR_STACK_TRACE_SERVER_PORT
+func MaybeRunServer() {
+	cfg := &config{}
+	if err := envconfig.Process("", cfg); err != nil {
+		log.WithError(err).Error("failed to process stacktrace handler configuration")
+		return
+	}
+
+	if cfg.GRStackTraceServerEnabled {
+		address := fmt.Sprintf("%s:%s", cfg.GRStackTraceServerHost, cfg.GRStackTraceServerPort)
+		log.Infof("Go routine stacktrace handler running on %s", address)
+
+		go func() {
+			if err := http.ListenAndServe(address, &server{}); err != nil {
+				log.WithError(err).Error("failed to serve go routine stacktrace handler")
+			}
+		}()
+	} else {
+		log.Info("Stacktrace handler not enabled.")
+	}
+}


### PR DESCRIPTION
This commit adds tooling that can be used to dump go routine stack trace information on running go programs. This tooling is useful because it's sometimes difficult to reproduce issues that occur in production, but by enabling this in a production cluster you can get a stack trace of what the program is doing, which will aid in diagnosing possible issues.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
