### PR TITLE
Add MaxRestartTime testing (for BGP graceful restart timer)

### DIFF
--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1412,6 +1412,11 @@ func init() {
 			SourceAddress: api.SourceAddress("rubbish"),
 		}, false),
 
+		// BGPPeer MaxRestartTime
+		Entry("BGPPeer with valid MaxRestartTime", api.BGPPeerSpec{
+			MaxRestartTime: &v1.Duration{10 * time.Second},
+		}, true),
+
 		// (API) NodeSpec
 		Entry("should accept node with IPv4 BGP", libapiv3.NodeSpec{BGP: &libapiv3.NodeBGPSpec{IPv4Address: netv4_1}}, true),
 		Entry("should accept node with IPv6 BGP", libapiv3.NodeSpec{BGP: &libapiv3.NodeBGPSpec{IPv6Address: netv6_1}}, true),


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add validator testing for the MaxRestartTime field in BGPPeerSpec, which is used by confd to set BGP graceful restart timer in BIRD.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
