### PR TITLE
Merge pull request #1446 from song-jiang/song-fix-pod-termination

### DIFF
--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -599,6 +599,122 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(ConsistOf("192.168.0.2/32"))
+	})
+
+	It("should treat running pod with empty podIP annotation and no deletion timestamp as Running", func() {
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "podA",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"arbitrary":                   "annotation",
+					"cni.projectcalico.org/podIP": "",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+			Status: kapiv1.PodStatus{
+				PodIP: "192.168.0.1",
+				Phase: kapiv1.PodRunning,
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.HasIPAddress(&pod)).To(BeTrue())
+		Expect(IsFinished(&pod)).To(BeFalse())
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(ConsistOf("192.168.0.1/32"))
+	})
+
+	It("should treat running pod with empty podIP with a deletion timestamp as finished", func() {
+		now := metav1.Now()
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "podA",
+				Namespace:         "default",
+				DeletionTimestamp: &now,
+				Annotations: map[string]string{
+					"arbitrary":                   "annotation",
+					"cni.projectcalico.org/podIP": "",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+			Status: kapiv1.PodStatus{
+				PodIP: "192.168.0.1",
+				Phase: kapiv1.PodRunning,
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.HasIPAddress(&pod)).To(BeTrue())
+		Expect(IsFinished(&pod)).To(BeTrue())
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(BeEmpty())
+	})
+
+	It("should treat running pod with no podIP annoation with a deletion timestamp as running", func() {
+		now := metav1.Now()
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "podA",
+				Namespace:         "default",
+				DeletionTimestamp: &now,
+				Annotations: map[string]string{
+					"arbitrary": "annotation",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+			Status: kapiv1.PodStatus{
+				PodIP: "192.168.0.1",
+				Phase: kapiv1.PodRunning,
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.HasIPAddress(&pod)).To(BeTrue())
+		Expect(IsFinished(&pod)).To(BeFalse())
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(ConsistOf("192.168.0.1/32"))
+	})
+
+	It("should treat finished pod with no podIP annoation with a deletion timestamp as finished", func() {
+		now := metav1.Now()
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "podA",
+				Namespace:         "default",
+				DeletionTimestamp: &now,
+				Annotations: map[string]string{
+					"arbitrary": "annotation",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+			Status: kapiv1.PodStatus{
+				PodIP: "192.168.0.1",
+				Phase: kapiv1.PodSucceeded,
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.HasIPAddress(&pod)).To(BeTrue())
+		Expect(IsFinished(&pod)).To(BeTrue())
+		Expect(wep.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks).To(BeEmpty())
 	})
 
 	DescribeTable("PodToDefaultWorkloadEndpoint reject/accept phase tests",


### PR DESCRIPTION
Fix checking terminating pod for non-calico CNI

(cherry picked from commit 719c24d1975252655045ba5a9c2be108fb2db2c2)

And Revert back to old API v3

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Reinstates logic that falls back to the status of the pod during termination if the pod IP annotation is not set by the Calico CNI plugin.
```
