### PR TITLE
Automated cherry pick of #1443: Add EndpointSlices and new service policy rules to syncer

### DIFF
--- a/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -444,6 +444,12 @@ spec:
                   to false. This reduces the number of metrics reported, reducing
                   Prometheus load. [Default: true]'
                 type: boolean
+              prometheusWireGuardMetricsEnabled:
+                description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                  metrics collection, which the Prometheus client does by default,
+                  when set to false. This reduces the number of metrics reported,
+                  reducing Prometheus load. [Default: true]'
+                type: boolean
               removeExternalRoutes:
                 description: Whether or not to remove device routes that have not
                   been programmed by Felix. Disabling this will allow external applications
@@ -524,6 +530,10 @@ spec:
               wireguardEnabled:
                 description: 'WireguardEnabled controls whether Wireguard is enabled.
                   [Default: false]'
+                type: boolean
+              wireguardHostEncryptionEnabled:
+                description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                  host-to-host encryption is enabled. [Default: false]'
                 type: boolean
               wireguardInterfaceName:
                 description: 'WireguardInterfaceName specifies the name to use for

--- a/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -66,16 +66,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -161,6 +162,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object
@@ -271,16 +292,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -366,6 +388,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object
@@ -397,16 +439,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -492,6 +535,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object
@@ -602,16 +665,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -697,6 +761,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object

--- a/config/crd/crd.projectcalico.org_networkpolicies.yaml
+++ b/config/crd/crd.projectcalico.org_networkpolicies.yaml
@@ -55,16 +55,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -150,6 +151,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object
@@ -260,16 +281,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -355,6 +377,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object
@@ -386,16 +428,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -481,6 +524,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object
@@ -591,16 +654,17 @@ spec:
                             contains a selector expression. Only traffic that originates
                             from (or terminates at) endpoints within the selected
                             namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
                           type: string
                         nets:
                           description: Nets is an optional field that restricts the
@@ -686,6 +750,26 @@ spec:
                                 account that matches the given label selector. If
                                 both Names and Selector are specified then they are
                                 AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
                               type: string
                           type: object
                       type: object

--- a/go.sum
+++ b/go.sum
@@ -101,7 +101,6 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.11.2-0.20200112161605-a7c079c43d51+incompatible h1:+fJW2EnKiYk9OFmYBJosMlm4NsBFyIpIOY8fvGL0xXU=
 github.com/emicklei/go-restful v2.11.2-0.20200112161605-a7c079c43d51+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -134,7 +133,6 @@ github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDB
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
-github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/jsonreference v0.19.4-0.20191224164422-1f9748e5f45e h1:i8QNKoMPpxNJcSSwX9Sx9Jt50ABaA7yuvdsIXkANz9o=
 github.com/go-openapi/jsonreference v0.19.4-0.20191224164422-1f9748e5f45e/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
@@ -142,7 +140,6 @@ github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8
 github.com/go-openapi/spec v0.19.5 h1:Xm0Ao53uqnk9QE/LlYV5DEU09UAgpliA85QoT9LzqPw=
 github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.7 h1:VRuXN2EnMSsZdauzdss6JBC29YotDqG59BZ+tdlIL1s=
 github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
@@ -206,7 +203,6 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -737,7 +733,6 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -128,6 +128,12 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 	kubeClient.registerResourceClient(
 		reflect.TypeOf(model.ResourceKey{}),
 		reflect.TypeOf(model.ResourceListOptions{}),
+		model.KindKubernetesEndpointSlice,
+		resources.NewKubernetesEndpointSliceClient(cs),
+	)
+	kubeClient.registerResourceClient(
+		reflect.TypeOf(model.ResourceKey{}),
+		reflect.TypeOf(model.ResourceListOptions{}),
 		apiv3.KindNetworkSet,
 		resources.NewNetworkSetClient(cs, crdClientV1),
 	)

--- a/lib/backend/k8s/resources/kubeendpointslice.go
+++ b/lib/backend/k8s/resources/kubeendpointslice.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NewKubernetesEndpointSliceClient returns a new client for interacting with Kubernetes EndpointSlice objects.
+// Note that this client is only intended for use by the felix syncer in KDD mode, and as such is largely unimplemented
+// except for the functions required by the syncer.
+func NewKubernetesEndpointSliceClient(c *kubernetes.Clientset) K8sResourceClient {
+	return &endpointSliceClient{
+		Converter: conversion.NewConverter(),
+		clientSet: c,
+	}
+}
+
+// Implements the api.Client interface for Kubernetes EndpointSlice.
+type endpointSliceClient struct {
+	conversion.Converter
+	clientSet *kubernetes.Clientset
+}
+
+func (c *endpointSliceClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Debug("Received Create request on EndpointSlice type")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "Create",
+	}
+}
+
+func (c *endpointSliceClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	log.Debug("Received Update request on EndpointSlice type")
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "Update",
+	}
+}
+
+func (c *endpointSliceClient) Apply(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: kvp.Key,
+		Operation:  "Apply",
+	}
+}
+
+func (c *endpointSliceClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	return c.Delete(ctx, kvp.Key, kvp.Revision, kvp.UID)
+}
+
+func (c *endpointSliceClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: key,
+		Operation:  "Delete",
+	}
+}
+
+func (c *endpointSliceClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	return nil, cerrors.ErrorOperationNotSupported{
+		Identifier: key,
+		Operation:  "Get",
+	}
+}
+
+func (c *endpointSliceClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	log.Debug("Received List request on Kubernetes EndpointSlice type")
+	// List all of the k8s EndpointSlice objects.
+	endpointSlices := discovery.EndpointSliceList{}
+	req := c.clientSet.DiscoveryV1beta1().RESTClient().
+		Get().
+		Resource("endpointslices")
+	err := req.Do(ctx).Into(&endpointSlices)
+	if err != nil {
+		log.WithError(err).Info("Unable to list K8s EndpointSlice resources")
+		return nil, K8sErrorToCalico(err, list)
+	}
+
+	kvps := model.KVPairList{KVPairs: []*model.KVPair{}}
+	for _, es := range endpointSlices.Items {
+		kvp, err := c.EndpointSliceToKVP(&es)
+		if err != nil {
+			log.WithError(err).Info("Failed to convert K8s EndpointSlice")
+			return nil, err
+		}
+		kvps.KVPairs = append(kvps.KVPairs, kvp)
+	}
+
+	// Add in the Revision information.
+	kvps.Revision = endpointSlices.ResourceVersion
+	log.WithFields(log.Fields{
+		"num_kvps": len(kvps.KVPairs),
+		"revision": kvps.Revision}).Debug("Returning Kubernetes EndpointSlice KVPs")
+	return &kvps, nil
+}
+
+func (c *endpointSliceClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+	// Build watch options to pass to k8s.
+	opts := metav1.ListOptions{Watch: true}
+	_, ok := list.(model.ResourceListOptions)
+	if !ok {
+		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
+	}
+
+	opts.ResourceVersion = revision
+	log.Debugf("Watching Kubernetes EndpointSlice at revision %q", revision)
+	k8sRawWatch, err := c.clientSet.DiscoveryV1beta1().EndpointSlices("").Watch(ctx, opts)
+	if err != nil {
+		return nil, K8sErrorToCalico(err, list)
+	}
+	converter := func(r Resource) (*model.KVPair, error) {
+		es, ok := r.(*discovery.EndpointSlice)
+		if !ok {
+			return nil, errors.New("KubernetesEndpointSlice conversion with incorrect k8s resource type")
+		}
+
+		return c.EndpointSliceToKVP(es)
+	}
+	return newK8sWatcherConverter(ctx, "KubernetesEndpointSlice", converter, k8sRawWatch), nil
+}
+
+func (c *endpointSliceClient) EnsureInitialized() error {
+	return nil
+}

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -279,6 +279,8 @@ func KeyFromDefaultPath(path string) Key {
 		return k
 	} else if k := (ResourceListOptions{Kind: apiv3.KindProfile}).KeyFromDefaultPath(path); k != nil {
 		return k
+	} else if k := (ResourceListOptions{Kind: KindKubernetesEndpointSlice}).KeyFromDefaultPath(path); k != nil {
+		return k
 	} else if k := (HostEndpointStatusListOptions{}).KeyFromDefaultPath(path); k != nil {
 		return k
 	} else if k := (WorkloadEndpointStatusListOptions{}).KeyFromDefaultPath(path); k != nil {

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -314,7 +314,7 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 		if ip == nil {
 			return nil, nil
 		}
-		return &net.IP{ip}, nil
+		return &net.IP{IP: ip}, nil
 	}
 	value := reflect.New(valueType)
 	elem := value.Elem()

--- a/lib/backend/model/kubeendpointslice.go
+++ b/lib/backend/model/kubeendpointslice.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+const (
+	KindKubernetesEndpointSlice = "KubernetesEndpointSlice"
+)

--- a/lib/backend/model/resource.go
+++ b/lib/backend/model/resource.go
@@ -22,6 +22,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	discoveryv1 "k8s.io/api/discovery/v1"
+
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	libapiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/namespace"
@@ -103,6 +105,11 @@ func init() {
 		KindKubernetesNetworkPolicy,
 		"kubernetesnetworkpolicies",
 		reflect.TypeOf(apiv3.NetworkPolicy{}),
+	)
+	registerResourceInfo(
+		KindKubernetesEndpointSlice,
+		"kubernetesendpointslices",
+		reflect.TypeOf(discoveryv1.EndpointSlice{}),
 	)
 	registerResourceInfo(
 		apiv3.KindNetworkSet,

--- a/lib/backend/model/rule.go
+++ b/lib/backend/model/rule.go
@@ -40,16 +40,18 @@ type Rule struct {
 	NotICMPType *int `json:"!icmp_type,omitempty" validate:"omitempty,gte=0,lt=255"`
 	NotICMPCode *int `json:"!icmp_code,omitempty" validate:"omitempty,gte=0,lte=255"`
 
-	SrcTag      string             `json:"src_tag,omitempty" validate:"omitempty,tag"`
-	SrcNet      *net.IPNet         `json:"src_net,omitempty" validate:"omitempty"`
-	SrcNets     []*net.IPNet       `json:"src_nets,omitempty" validate:"omitempty"`
-	SrcSelector string             `json:"src_selector,omitempty" validate:"omitempty,selector"`
-	SrcPorts    []numorstring.Port `json:"src_ports,omitempty" validate:"omitempty,dive"`
-	DstTag      string             `json:"dst_tag,omitempty" validate:"omitempty,tag"`
-	DstSelector string             `json:"dst_selector,omitempty" validate:"omitempty,selector"`
-	DstNet      *net.IPNet         `json:"dst_net,omitempty" validate:"omitempty"`
-	DstNets     []*net.IPNet       `json:"dst_nets,omitempty" validate:"omitempty"`
-	DstPorts    []numorstring.Port `json:"dst_ports,omitempty" validate:"omitempty,dive"`
+	SrcTag              string             `json:"src_tag,omitempty" validate:"omitempty,tag"`
+	SrcNet              *net.IPNet         `json:"src_net,omitempty" validate:"omitempty"`
+	SrcNets             []*net.IPNet       `json:"src_nets,omitempty" validate:"omitempty"`
+	SrcSelector         string             `json:"src_selector,omitempty" validate:"omitempty,selector"`
+	SrcPorts            []numorstring.Port `json:"src_ports,omitempty" validate:"omitempty,dive"`
+	DstTag              string             `json:"dst_tag,omitempty" validate:"omitempty,tag"`
+	DstSelector         string             `json:"dst_selector,omitempty" validate:"omitempty,selector"`
+	DstNet              *net.IPNet         `json:"dst_net,omitempty" validate:"omitempty"`
+	DstNets             []*net.IPNet       `json:"dst_nets,omitempty" validate:"omitempty"`
+	DstPorts            []numorstring.Port `json:"dst_ports,omitempty" validate:"omitempty,dive"`
+	DstService          string             `json:"dst_service,omitempty" validate:"omitempty"`
+	DstServiceNamespace string             `json:"dst_service_ns,omitempty" validate:"omitempty"`
 
 	NotSrcTag      string             `json:"!src_tag,omitempty" validate:"omitempty,tag"`
 	NotSrcNet      *net.IPNet         `json:"!src_net,omitempty" validate:"omitempty"`

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -210,7 +210,11 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 						expectedCacheSize += 1
 					}
 				}
+
+				// Expect two endpoint slices.
+				expectedCacheSize += 2
 			}
+
 			syncTester.ExpectCacheSize(expectedCacheSize)
 
 			var node *libapiv3.Node

--- a/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncerv1.go
@@ -89,9 +89,12 @@ func New(client api.Client, cfg apiconfig.CalicoAPIConfigSpec, callbacks api.Syn
 				ListInterface:   model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy},
 				UpdateProcessor: updateprocessors.NewNetworkPolicyUpdateProcessor(),
 			})
+			additionalTypes = append(additionalTypes, watchersyncer.ResourceType{
+				ListInterface: model.ResourceListOptions{Kind: model.KindKubernetesEndpointSlice},
+			})
 		}
 
-		// If using Calico IPAM, include IPAM resources the felix cares about.
+		// If using Calico IPAM, include IPAM resources that felix cares about.
 		if !cfg.K8sUsePodCIDR {
 			additionalTypes = append(additionalTypes, watchersyncer.ResourceType{ListInterface: model.BlockListOptions{}})
 		}

--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -149,6 +149,12 @@ func RuleAPIV2ToBackend(ar apiv3.Rule, ns string) model.Rule {
 		dstServiceAcctMatch = *ar.Destination.ServiceAccounts
 	}
 
+	var service, serviceNS string
+	if ar.Destination.Services != nil {
+		service = ar.Destination.Services.Name
+		serviceNS = ar.Destination.Services.Namespace
+	}
+
 	r := model.Rule{
 		Action:      ruleActionAPIV2ToBackend(ar.Action),
 		IPVersion:   ar.IPVersion,
@@ -159,12 +165,14 @@ func RuleAPIV2ToBackend(ar apiv3.Rule, ns string) model.Rule {
 		NotICMPCode: notICMPCode,
 		NotICMPType: notICMPType,
 
-		SrcNets:     ConvertStringsToNets(ar.Source.Nets),
-		SrcSelector: sourceSelector,
-		SrcPorts:    ar.Source.Ports,
-		DstNets:     NormalizeIPNets(ar.Destination.Nets),
-		DstSelector: destSelector,
-		DstPorts:    ar.Destination.Ports,
+		SrcNets:             ConvertStringsToNets(ar.Source.Nets),
+		SrcSelector:         sourceSelector,
+		SrcPorts:            ar.Source.Ports,
+		DstNets:             NormalizeIPNets(ar.Destination.Nets),
+		DstSelector:         destSelector,
+		DstPorts:            ar.Destination.Ports,
+		DstService:          service,
+		DstServiceNamespace: serviceNS,
 
 		NotSrcNets:     ConvertStringsToNets(ar.Source.NotNets),
 		NotSrcSelector: ar.Source.NotSelector,

--- a/lib/backend/syncersv1/updateprocessors/rules_test.go
+++ b/lib/backend/syncersv1/updateprocessors/rules_test.go
@@ -450,6 +450,30 @@ var _ = Describe("Test the Rules Conversion Functions", func() {
 		})
 	})
 
+	It("should parse a services match", func() {
+		r := apiv3.Rule{
+			Action: apiv3.Allow,
+			Destination: apiv3.EntityRule{
+				Services: &apiv3.ServiceMatch{
+					Name:      "kube-dns",
+					Namespace: "kube-system",
+				},
+			},
+		}
+
+		// Process the rule and get the corresponding v1 representation.
+		rulev1 := updateprocessors.RuleAPIV2ToBackend(r, "")
+
+		By("generating an empty source selector", func() {
+			Expect(rulev1.SrcSelector).To(Equal(""))
+		})
+
+		By("copying the service names", func() {
+			Expect(rulev1.DstService).To(Equal("kube-dns"))
+			Expect(rulev1.DstServiceNamespace).To(Equal("kube-system"))
+		})
+	})
+
 	It("should parse a serviceaccount match with selector and namespace", func() {
 		dste := fmt.Sprintf("(pcns.nskey == \"nsvalue\") && (((%skey == \"value2\") && (%s in {\"%s\"})) && (has(label1)))", conversion.ServiceAccountLabelPrefix, apiv3.LabelServiceAccount, "sa3")
 

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1064,6 +1064,38 @@ func validateEntityRule(structLevel validator.StructLevel) {
 		structLevel.ReportError(reflect.ValueOf(rule.NamespaceSelector),
 			"NamespaceSelector field", "", reason(globalSelectorOnly), "")
 	}
+
+	if rule.Services != nil {
+		// Make sure it's not empty.
+		if rule.Services.Name == "" {
+			structLevel.ReportError(reflect.ValueOf(rule.Services),
+				"Services field", "", reason("must specify a service name"), "")
+		}
+
+		// Make sure the rest of the entity rule is consistent.
+		if rule.NamespaceSelector != "" {
+			structLevel.ReportError(reflect.ValueOf(rule.Services),
+				"Services field", "", reason("cannot specify NamespaceSelector and Services on the same rule"), "")
+		}
+		if rule.Selector != "" || rule.NotSelector != "" {
+			structLevel.ReportError(reflect.ValueOf(rule.Services),
+				"Services field", "", reason("cannot specify Selector/NotSelector and Services on the same rule"), "")
+		}
+		if rule.ServiceAccounts != nil {
+			structLevel.ReportError(reflect.ValueOf(rule.Services),
+				"Services field", "", reason("cannot specify ServiceAccounts and Services on the same rule"), "")
+		}
+		if len(rule.Ports) != 0 || len(rule.NotPorts) != 0 {
+			// Service rules use ports specified on the endpoints.
+			structLevel.ReportError(reflect.ValueOf(rule.Services),
+				"Services field", "", reason("cannot specify Ports/NotPorts and Services on the same rule"), "")
+		}
+		if len(rule.Nets) != 0 || len(rule.NotNets) != 0 {
+			// Service rules use ports specified on the endpoints.
+			structLevel.ReportError(reflect.ValueOf(rule.Services),
+				"Services field", "", reason("cannot specify Nets/NotNets and Services on the same rule"), "")
+		}
+	}
 }
 
 func validateNodeSpec(structLevel validator.StructLevel) {
@@ -1193,13 +1225,35 @@ func validateNetworkPolicy(structLevel validator.StructLevel) {
 	validateObjectMetaAnnotations(structLevel, np.Annotations)
 	validateObjectMetaLabels(structLevel, np.Labels)
 
-	// Check (and disallow) rules with application layer policy for egress rules.
-	if len(spec.Egress) > 0 {
-		for _, r := range spec.Egress {
-			useALP, v, f := ruleUsesAppLayerPolicy(&r)
-			if useALP {
-				structLevel.ReportError(v, f, "", reason("not allowed in egress rule"), "")
-			}
+	for _, r := range spec.Egress {
+		// Services are only allowed as a destination.
+		if r.Source.Services != nil {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Source.Services), "Services", "",
+				reason("not allowed in egress rule source"), "",
+			)
+		}
+
+		// Check (and disallow) rules with application layer policy for egress rules.
+		useALP, v, f := ruleUsesAppLayerPolicy(&r)
+		if useALP {
+			structLevel.ReportError(v, f, "", reason("not allowed in egress rule"), "")
+		}
+	}
+
+	// Services are only allowed on egress rules.
+	for _, r := range spec.Ingress {
+		if r.Source.Services != nil {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Source.Services), "Services", "",
+				reason("not allowed in ingress rule"), "",
+			)
+		}
+		if r.Destination.Services != nil {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Destination.Services), "Services", "",
+				reason("not allowed in ingress rule"), "",
+			)
 		}
 	}
 
@@ -1323,13 +1377,46 @@ func validateGlobalNetworkPolicy(structLevel validator.StructLevel) {
 		}
 	}
 
-	// Check (and disallow) rules with application layer policy for egress rules.
-	if len(spec.Egress) > 0 {
-		for _, r := range spec.Egress {
-			useALP, v, f := ruleUsesAppLayerPolicy(&r)
-			if useALP {
-				structLevel.ReportError(v, f, "", reason("not allowed in egress rules"), "")
-			}
+	for _, r := range spec.Egress {
+		// Services are only allowed as a destination.
+		if r.Source.Services != nil {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Source.Services), "Services", "",
+				reason("not allowed in egress rule source"), "",
+			)
+		}
+
+		// Check (and disallow) rules with application layer policy for egress rules.
+		useALP, v, f := ruleUsesAppLayerPolicy(&r)
+		if useALP {
+			structLevel.ReportError(v, f, "", reason("not allowed in egress rules"), "")
+		}
+	}
+
+	// Services are only allowed on egress rules.
+	for _, r := range spec.Ingress {
+		if r.Source.Services != nil {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Source.Services), "Services", "",
+				reason("not allowed in ingress rule"), "",
+			)
+		}
+		if r.Destination.Services != nil {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Destination.Services), "Services", "",
+				reason("not allowed in ingress rule"), "",
+			)
+		}
+	}
+
+	// If a ServiceSelector is specified by name, we also need a namespace. At a global scope,
+	// service names are not fully qualified and so need a namespace.
+	for _, r := range spec.Egress {
+		if r.Destination.Services != nil && r.Destination.NamespaceSelector == "" {
+			structLevel.ReportError(
+				reflect.ValueOf(r.Destination.NamespaceSelector), "NamespaceSelector", "",
+				reason("must specify a namespace selector"), "",
+			)
 		}
 	}
 

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -1952,6 +1952,220 @@ func init() {
 				},
 			}, true,
 		),
+		Entry("allow a Service match in an egress rule destination",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Egress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, true,
+		),
+		Entry("disallow a Service match in an egress rule source",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Egress: []api.Rule{
+						{
+							Action: "Allow",
+							Source: api.EntityRule{
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+
+		Entry("disallow a Service match in an ingress rule",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Source: api.EntityRule{
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a ServiceAccount match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								ServiceAccounts: &api.ServiceAccountMatch{
+									Names: []string{"serviceaccount"},
+								},
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a Ports match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								Ports: []numorstring.Port{
+									{MinPort: 80, MaxPort: 80},
+								},
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a NotPorts match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								NotPorts: []numorstring.Port{
+									{MinPort: 80, MaxPort: 80},
+								},
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a Nets match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								Nets: []string{"10.0.0.0/8"},
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a NotNets match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								NotNets: []string{"10.0.0.0/8"},
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a Selector match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								Selector: "x == 'y'",
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a NotSelector match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								NotSelector: "x == 'y'",
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry("disallow a Service match AND a NamespaceSelector match",
+			&api.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{Name: "thing"},
+				Spec: api.NetworkPolicySpec{
+					Ingress: []api.Rule{
+						{
+							Action: "Allow",
+							Destination: api.EntityRule{
+								NamespaceSelector: "x == 'y'",
+								Services: &api.ServiceMatch{
+									Name:      "service1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}, false,
+		),
+
 		// Validate EntityRule against special selectors global().
 		// Extra spaces added in some cases to make sure validation handles it.
 		Entry("disallow global() in EntityRule selector field",


### PR DESCRIPTION
Cherry pick of #1443 on release-v3.20.

#1443: Add EndpointSlices and new service policy rules to syncer

```release-note
Support for Services in NetworkPolicy egress rules
```