### PR TITLE
Add round tripping of ContainerID to KDD.

### DIFF
--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,10 @@ const (
 	AnnotationPodIP = "cni.projectcalico.org/podIP"
 	// AnnotationPodIPs is similar for the plural PodIPs field.
 	AnnotationPodIPs = "cni.projectcalico.org/podIPs"
+	// AnnotationContainerID stores the container ID of the pod.  This allows us to disambiguate different pods
+	// that have the same name and namespace.  For example, stateful set pod that is restarted.  May be missing
+	// on older Pods.
+	AnnotationContainerID = "cni.projectcalico.org/containerID"
 
 	// NameLabel is a label that can be used to match a serviceaccount or namespace
 	// name exactly.

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -211,6 +211,10 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		}
 	}
 
+	// Get the container ID if present.  This is used in the CNI plugin to distinguish different pods that have
+	// the same name.  For example, restarted stateful set pods.
+	containerID := pod.Annotations[AnnotationContainerID]
+
 	// Create the workload endpoint.
 	wep := libapiv3.NewWorkloadEndpoint()
 	wep.ObjectMeta = metav1.ObjectMeta{
@@ -225,6 +229,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		Orchestrator:       "k8s",
 		Node:               pod.Spec.NodeName,
 		Pod:                pod.Name,
+		ContainerID:        containerID,
 		Endpoint:           "eth0",
 		InterfaceName:      interfaceName,
 		Profiles:           profiles,

--- a/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -124,7 +124,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 						Namespace: "testNamespace",
 					},
 					Spec: libapiv3.WorkloadEndpointSpec{
-						IPNetworks: []string{"192.168.91.117/32", "192.168.91.118/32"},
+						ContainerID: "abcde12345",
+						IPNetworks:  []string{"192.168.91.117/32", "192.168.91.118/32"},
 					},
 				}
 
@@ -143,8 +144,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
-					conversion.AnnotationPodIP:  "192.168.91.117/32",
-					conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationPodIP:       "192.168.91.117/32",
+					conversion.AnnotationPodIPs:      "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationContainerID: "abcde12345",
 				}))
 			})
 		})
@@ -227,7 +229,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 						Namespace: "testNamespace",
 					},
 					Spec: libapiv3.WorkloadEndpointSpec{
-						IPNetworks: []string{"192.168.91.117/32", "192.168.91.118/32"},
+						IPNetworks:  []string{"192.168.91.117/32", "192.168.91.118/32"},
+						ContainerID: "abcd1234",
 					},
 				}
 
@@ -246,8 +249,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
-					conversion.AnnotationPodIP:  "192.168.91.117/32",
-					conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationPodIP:       "192.168.91.117/32",
+					conversion.AnnotationPodIPs:      "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationContainerID: "abcd1234",
 				}))
 			})
 		})
@@ -255,15 +259,16 @@ var _ = Describe("WorkloadEndpointClient", func() {
 
 	Describe("Delete", func() {
 		Context("WorkloadEndpoint has no IPs set", func() {
-			It("zeros out the cni.projectcalico.org/podIP and cni.projectcalico.org/podIPs annotations", func() {
+			It("zeros out the annotations", func() {
 				podUID := types.UID(uuid.NewString())
 				k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simplePod",
 						Namespace: "testNamespace",
 						Annotations: map[string]string{
-							conversion.AnnotationPodIP:  "192.168.91.117/32",
-							conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+							conversion.AnnotationPodIP:       "192.168.91.117/32",
+							conversion.AnnotationPodIPs:      "192.168.91.117/32,192.168.91.118/32",
+							conversion.AnnotationContainerID: "abcde12345",
 						},
 						UID: podUID,
 					},
@@ -310,8 +315,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
-					conversion.AnnotationPodIP:  "",
-					conversion.AnnotationPodIPs: "",
+					conversion.AnnotationPodIP:       "",
+					conversion.AnnotationPodIPs:      "",
+					conversion.AnnotationContainerID: "abcde12345",
 				}))
 			})
 		})
@@ -323,6 +329,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "simplePod",
 					Namespace: "testNamespace",
+					Annotations: map[string]string{
+						conversion.AnnotationContainerID: "abcde12345",
+					},
 				},
 				Spec: k8sapi.PodSpec{
 					NodeName: "test-node",
@@ -368,6 +377,7 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Profiles:      []string{"kns.testNamespace"},
 					IPNetworks:    []string{},
 					InterfaceName: "caliedff4356bd6",
+					ContainerID:   "abcde12345",
 				},
 			}))
 		})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This should fix the following issue:
https://github.com/projectcalico/calico/issues/4710
because the CNI plugin will now hit the container ID-based guard logic.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that podIP annotation could be incorrectly clobbered for stateful set pods: https://github.com/projectcalico/calico/issues/4710
```
