### PR TITLE
Add backoff handler to deal with multiple watchersyncers needing to backoff

### DIFF
--- a/lib/backend/backoff/backoff.go
+++ b/lib/backend/backoff/backoff.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backoff
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type BackoffHandler interface {
+	// Returns the current backoff time.
+	Backoff() time.Duration
+
+	// Runs the main logic which should watch the update channel
+	// and increment the backoff time accordingly.
+	Run(context.Context)
+}
+
+// backoffHandler implements a single manager to handle backoff times for
+// multiple clients. It implements a leaky bucket algorithm where the leak
+// rate and fill rate are configurable. If the bucket overflows (hits max),
+// it stops increasing the backoff.
+type backoffHandler struct {
+	ticker     *time.Ticker
+	backoff    time.Duration
+	minBackoff time.Duration
+	maxBackoff time.Duration
+	leak       time.Duration
+	backoffFn  func(time.Duration) time.Duration
+	updates    chan time.Time
+	lastUpdate time.Time
+	lock       bool
+}
+
+// Creates a backoff handler which will increase the backoff time by increment each time it is called.
+func NewLinearBackoffHandler(updates chan time.Time, leakTime, leakPeriod, minBackoff, maxBackoff, increment time.Duration) BackoffHandler {
+	backoffFn := func(t time.Duration) time.Duration {
+		return t + increment
+	}
+	return NewBackoffHandler(updates, leakTime, leakPeriod, minBackoff, maxBackoff, backoffFn)
+}
+
+func NewBackoffHandler(updates chan time.Time, leakTime, leakPeriod, minBackoff, maxBackoff time.Duration, backoffFn func(time.Duration) time.Duration) BackoffHandler {
+	return &backoffHandler{
+		ticker:     time.NewTicker(leakPeriod),
+		minBackoff: minBackoff,
+		maxBackoff: maxBackoff,
+		leak:       leakTime,
+		backoffFn:  backoffFn,
+		updates:    updates,
+		backoff:    minBackoff,
+	}
+}
+
+// Backoff returns the current backoff time.
+func (bh *backoffHandler) Backoff() time.Duration {
+	return bh.backoff
+}
+
+// Run is the main logic loop for the backoff handler. It will update the backoff only if the timestamp
+// sent by the caller is newer than the last time it updated the backoff. This should prevent all clients
+// from triggering backoff updates at the same time.
+func (bh *backoffHandler) Run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			log.Debug("Context is done. Returning")
+			return
+		case <-bh.ticker.C:
+			update := bh.backoff - bh.leak
+			// Unlock the handler after waiting 1 ticker period
+			bh.lock = false
+			if update < bh.minBackoff {
+				bh.backoff = bh.minBackoff
+			} else {
+				bh.backoff = update
+			}
+		case timestamp, ok := <-bh.updates:
+			if !ok {
+				// Channel closed, stop the backoff handler.
+				return
+			}
+			// Only update the backoff if the timestamp is after the last update time.
+			if !bh.lock && bh.lastUpdate.Before(timestamp) {
+				bh.lock = true
+				update := bh.backoffFn(bh.backoff)
+				if update > bh.maxBackoff {
+					log.Debug("Backoff limit has reached its max. Do not update the backoff time")
+					bh.backoff = bh.maxBackoff
+				} else {
+					log.Debugf("Updating backoff time from %s to %s", bh.backoff, update)
+					bh.backoff = update
+					bh.lastUpdate = time.Now()
+				}
+			}
+		}
+	}
+}

--- a/lib/backend/backoff/backoff_suite_test.go
+++ b/lib/backend/backoff/backoff_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backoff_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/backend_backoff_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Backend backoff handler test suite", []Reporter{junitReporter})
+}

--- a/lib/backend/backoff/backoff_test.go
+++ b/lib/backend/backoff/backoff_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backoff_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/backoff"
+)
+
+var _ = Describe("Test the backend backoff handler", func() {
+	Context("With a linear backoff handler that backsoff by 100 ms every call and decreases by 50 ms per second", func() {
+		var updateCallCount int
+		ctx := context.Background()
+
+		It("Should increment the backoff correctly", func() {
+			updates := make(chan time.Time)
+			defer close(updates)
+			fn := func(t time.Duration) time.Duration {
+				updateCallCount++
+				return t + 100*time.Millisecond
+			}
+			bh := backoff.NewBackoffHandler(updates, 50*time.Millisecond, 1*time.Second, 0*time.Millisecond, 200*time.Millisecond, fn)
+			go bh.Run(ctx)
+
+			Expect(bh.Backoff()).To(Equal(0 * time.Millisecond))
+			updates <- time.Now()
+			time.Sleep(1 * time.Second)
+			Expect(bh.Backoff()).To(Equal(50 * time.Millisecond))
+			time.Sleep(2 * time.Second)
+		})
+
+		It("Backoff should decrease over time", func() {
+			updates := make(chan time.Time)
+			defer close(updates)
+			fn := func(t time.Duration) time.Duration {
+				updateCallCount++
+				return t + 100*time.Millisecond
+			}
+			bh := backoff.NewBackoffHandler(updates, 50*time.Millisecond, 1*time.Second, 0*time.Millisecond, 200*time.Millisecond, fn)
+			go bh.Run(ctx)
+
+			updates <- time.Now()
+			time.Sleep(1 * time.Second)
+			Expect(bh.Backoff()).To(Equal(50 * time.Millisecond))
+			time.Sleep(1 * time.Second)
+			Expect(bh.Backoff()).To(Equal(0 * time.Millisecond))
+		})
+
+		It("Should only backoff once per leak period", func() {
+			updates := make(chan time.Time)
+			defer close(updates)
+			fn := func(t time.Duration) time.Duration {
+				updateCallCount++
+				return t + 100*time.Millisecond
+			}
+			bh := backoff.NewBackoffHandler(updates, 50*time.Millisecond, 1*time.Second, 0*time.Millisecond, 200*time.Millisecond, fn)
+			go bh.Run(ctx)
+
+			updateCallCount = 0
+			updates <- time.Now()
+			updates <- time.Now()
+			updates <- time.Now()
+			Expect(updateCallCount).To(Equal(1))
+			Expect(bh.Backoff()).To(Equal(100 * time.Millisecond))
+		})
+
+		It("Should never have a backoff greater than the maximum", func() {
+			updates := make(chan time.Time)
+			defer close(updates)
+			fn := func(t time.Duration) time.Duration {
+				updateCallCount++
+				return t + 100*time.Millisecond
+			}
+			bh := backoff.NewBackoffHandler(updates, 50*time.Millisecond, 1*time.Second, 0*time.Millisecond, 200*time.Millisecond, fn)
+			go bh.Run(ctx)
+
+			for i := 0; i < 6; i++ {
+				updates <- time.Now()
+				time.Sleep(1 * time.Second)
+			}
+			Expect(bh.Backoff()).To(Equal(150 * time.Millisecond))
+		})
+	})
+})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds a backoff handler which keeps track of the backoff time for multiple watcher caches to ensure that they backoff with relatively the same frequency. 

This should fix https://github.com/projectcalico/typha/issues/492

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes a bug where Typha was DoSing the K8s API server because reconnection attempts had no backoff times.
```
