### PR TITLE
Update syncer test framework to have better kvp comparison and defaulted filtering of updates

### DIFF
--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -223,7 +223,7 @@ func (c cb) ExpectExists(updates []api.Update) {
 		})
 
 		// Expect the key to have existed.
-		Expect(matches).To(Equal(true), fmt.Sprintf("Expected update not found: %v", update.Key))
+		ExpectWithOffset(1, matches).To(Equal(true), fmt.Sprintf("Expected update not found: %v", update.Key))
 	}
 }
 
@@ -252,7 +252,7 @@ func (c cb) ExpectDeleted(kvps []model.KVPair) {
 		})
 
 		// Expect the key to not exist.
-		Expect(exists).To(Equal(false), fmt.Sprintf("Expected key not to exist: %v", kvp.Key))
+		ExpectWithOffset(1, exists).To(Equal(false), fmt.Sprintf("Expected key not to exist: %v", kvp.Key))
 	}
 }
 
@@ -274,15 +274,15 @@ poll:
 		select {
 		case e := <-events:
 			// Got an event. Check it's OK.
-			Expect(e.Error).NotTo(HaveOccurred())
-			Expect(e.Type).To(Equal(type_))
+			ExpectWithOffset(2, e.Error).NotTo(HaveOccurred())
+			ExpectWithOffset(2, e.Type).To(Equal(type_))
 			receivedEvent = &e
 			break poll
 		default:
 			time.Sleep(50 * time.Millisecond)
 		}
 	}
-	Expect(receivedEvent).NotTo(BeNil(), "Did not receive watch event")
+	ExpectWithOffset(2, receivedEvent).NotTo(BeNil(), "Did not receive watch event")
 	return receivedEvent
 }
 
@@ -449,8 +449,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		})
 
 		By("Deleting the namespace", func() {
-			err := c.ClientSet.CoreV1().Namespaces().Delete(ctx, ns.ObjectMeta.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			testutils.DeleteNamespace(c.ClientSet, ns.ObjectMeta.Name)
 		})
 
 		By("Checking the correct entries are no longer in our cache", func() {
@@ -500,8 +499,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		})
 
 		By("deleting a namespace", func() {
-			err := c.ClientSet.CoreV1().Namespaces().Delete(ctx, ns.ObjectMeta.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			testutils.DeleteNamespace(c.ClientSet, ns.ObjectMeta.Name)
 		})
 
 		By("Checking the correct entries are in no longer in our cache", func() {
@@ -1155,14 +1153,13 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		})
 
 		By("Deleting the namespace", func() {
-			err := c.ClientSet.CoreV1().Namespaces().Delete(ctx, ns.ObjectMeta.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			testutils.DeleteNamespace(c.ClientSet, ns.ObjectMeta.Name)
 		})
 
 		By("Listing all Network Sets in a non-existent namespace", func() {
 			kvps, err := c.List(ctx, model.ResourceListOptions{Namespace: ns.ObjectMeta.Name, Kind: apiv3.KindNetworkSet}, "")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(kvps.KVPairs).To(HaveLen(1))
+			Expect(kvps.KVPairs).To(HaveLen(0))
 		})
 	})
 
@@ -3024,8 +3021,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Inline kubeconfig support", testuti
 			Expect(err).NotTo(HaveOccurred())
 		})
 		By("Deleting the namespace", func() {
-			err := c.ClientSet.CoreV1().Namespaces().Delete(ctx, ns.ObjectMeta.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			testutils.DeleteNamespace(c.ClientSet, ns.ObjectMeta.Name)
 		})
 	})
 })

--- a/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,21 +19,23 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/projectcalico/libcalico-go/lib/backend/encap"
-	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
-
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
+
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	libapiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/encap"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+	resources2 "github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
 	"github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/ipam"
 	"github.com/projectcalico/libcalico-go/lib/net"
@@ -41,6 +43,146 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/resources"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
+
+// calculateDefaultFelixSyncerEntries determines the expected set of Felix configuration for the currently configured
+// cluster.
+func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.DatastoreType) (expected []model.KVPair) {
+	// Add 2 for the default-allow profile that is always there.
+	// However, no profile labels are in the list because the
+	// default-allow profile doesn't specify labels.
+	expectedProfile := resources.DefaultAllowProfile()
+	expected = append(expected, *expectedProfile)
+	expected = append(expected, model.KVPair{
+		Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "projectcalico-default-allow"}},
+		Value: &model.ProfileRules{
+			InboundRules:  []model.Rule{{Action: "allow"}},
+			OutboundRules: []model.Rule{{Action: "allow"}},
+		},
+	})
+
+	if dt == apiconfig.Kubernetes {
+		// Grab the k8s converter (we use this for converting some of the resources below).
+		converter := conversion.NewConverter()
+
+		// Add one for each node resource.
+		nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range nodes.Items {
+			// Nodes get updated frequently, so don't include the revision info.
+			node.ResourceVersion = ""
+			cnodekv, err := resources2.K8sNodeToCalico(&node, false)
+			Expect(err).NotTo(HaveOccurred())
+			expected = append(expected, *cnodekv)
+
+			if node.Name == "kind-control-plane" {
+				for _, ip := range cnodekv.Value.(*libapiv3.Node).Spec.Addresses {
+					if ip.Type == libapiv3.InternalIP {
+						expected = append(expected, model.KVPair{
+							Key: model.HostIPKey{
+								Hostname: node.Name,
+							},
+							Value: net.ParseIP(ip.Address),
+						})
+					}
+				}
+			}
+		}
+
+		// Add endpoint slices.
+		epss, err := cs.DiscoveryV1beta1().EndpointSlices("").List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, eps := range epss.Items {
+			// Endpoints slices get updated frequently, so don't include the revision info.
+			eps.ResourceVersion = ""
+			epskv, err := converter.EndpointSliceToKVP(&eps)
+			Expect(err).NotTo(HaveOccurred())
+			expected = append(expected, *epskv)
+		}
+
+		// Add resources for the namespaces we expect in the cluster.
+		namespaces, err := cs.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, ns := range namespaces.Items {
+			name := "kns." + ns.Name
+
+			// Expect profile rules for each namespace providing default allow behavior.
+			expected = append(expected, model.KVPair{
+				Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: name}},
+				Value: &model.ProfileRules{
+					InboundRules:  []model.Rule{{Action: "allow"}},
+					OutboundRules: []model.Rule{{Action: "allow"}},
+				},
+			})
+
+			// Expect profile labels for each namespace as well. The labels should include the name
+			// of the namespace.
+			expected = append(expected, model.KVPair{
+				Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
+				Value: map[string]string{
+					"pcns.projectcalico.org/name": ns.Name,
+				},
+			})
+
+			// And expect a v3 profile for each namespace.
+			prof := apiv3.Profile{
+				TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, UID: ns.UID, CreationTimestamp: ns.CreationTimestamp},
+				Spec: apiv3.ProfileSpec{
+					LabelsToApply: map[string]string{
+						"pcns.projectcalico.org/name": ns.Name,
+					},
+					Ingress: []apiv3.Rule{{Action: apiv3.Allow}},
+					Egress:  []apiv3.Rule{{Action: apiv3.Allow}},
+				},
+			}
+			expected = append(expected, model.KVPair{
+				Key:   model.ResourceKey{Kind: "Profile", Name: name},
+				Value: &prof,
+			})
+
+			serviceAccounts, err := cs.CoreV1().ServiceAccounts(ns.Name).List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, sa := range serviceAccounts.Items {
+				name := "ksa." + ns.Name + "." + sa.Name
+
+				// Expect profile rules for the serviceaccounts in each namespace.
+				expected = append(expected, model.KVPair{
+					Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: name}},
+					Value: &model.ProfileRules{
+						InboundRules:  nil,
+						OutboundRules: nil,
+					},
+				})
+
+				// Expect profile labels for each default serviceaccount as well. The labels should include the name
+				// of the service account.
+				expected = append(expected, model.KVPair{
+					Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
+					Value: map[string]string{
+						"pcsa.projectcalico.org/name": sa.Name,
+					},
+				})
+
+				//  We also expect one v3 Profile to be present for each ServiceAccount.
+				prof := apiv3.Profile{
+					TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
+					ObjectMeta: metav1.ObjectMeta{Name: name, UID: sa.UID, CreationTimestamp: sa.CreationTimestamp},
+					Spec: apiv3.ProfileSpec{
+						LabelsToApply: map[string]string{
+							"pcsa.projectcalico.org/name": sa.Name,
+						},
+					},
+				}
+				expected = append(expected, model.KVPair{
+					Key:   model.ResourceKey{Kind: "Profile", Name: name},
+					Value: &prof,
+				})
+			}
+		}
+	}
+
+	return
+}
 
 var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 
@@ -98,123 +240,29 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			syncTester.ExpectStatusUpdate(api.ResyncInProgress)
 			syncTester.ExpectStatusUpdate(api.InSync)
 
-			// Add 2 for the default-allow profile that is always there.
-			// However, no profile labels are in the list because the
-			// default-allow profile doesn't specify labels.
-			expectedProfile := resources.DefaultAllowProfile()
-			syncTester.ExpectData(*expectedProfile)
-			expectedCacheSize += 1
-			syncTester.ExpectData(model.KVPair{
-				Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: "projectcalico-default-allow"}},
-				Value: &model.ProfileRules{
-					InboundRules:  []model.Rule{{Action: "allow"}},
-					OutboundRules: []model.Rule{{Action: "allow"}},
-				},
-			})
-			expectedCacheSize += 1
-
-			// Kubernetes will have a profile for each of the namespaces that is configured.
-			// We expect:  default, kube-system, kube-public, namespace-1, namespace-2
-			if config.Spec.DatastoreType == apiconfig.Kubernetes {
-				// Add one for each node resource.
-				nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				expectedCacheSize += len(nodes.Items)
-
-				// Add one for the hostIPKey for the control-plane node.
-				expectedCacheSize += 1
-
-				// Add resources for the namespaces we expect in the cluster.
-				namespaces, err := cs.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				for _, ns := range namespaces.Items {
-					name := "kns." + ns.Name
-
-					// Expect profile rules for each namespace providing default allow behavior.
-					syncTester.ExpectData(model.KVPair{
-						Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: name}},
-						Value: &model.ProfileRules{
-							InboundRules:  []model.Rule{{Action: "allow"}},
-							OutboundRules: []model.Rule{{Action: "allow"}},
-						},
-					})
-					expectedCacheSize += 1
-
-					// Expect profile labels for each namespace as well. The labels should include the name
-					// of the namespace.
-					syncTester.ExpectData(model.KVPair{
-						Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
-						Value: map[string]string{
-							"pcns.projectcalico.org/name": ns.Name,
-						},
-					})
-					expectedCacheSize += 1
-
-					// And expect a v3 profile for each namespace.
-					prof := v3.Profile{
-						TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
-						ObjectMeta: metav1.ObjectMeta{Name: name, UID: ns.UID, CreationTimestamp: ns.CreationTimestamp},
-						Spec: v3.ProfileSpec{
-							LabelsToApply: map[string]string{
-								"pcns.projectcalico.org/name": ns.Name,
-							},
-							Ingress: []v3.Rule{{Action: v3.Allow}},
-							Egress:  []v3.Rule{{Action: v3.Allow}},
-						},
-					}
-					syncTester.ExpectData(model.KVPair{
-						Key:   model.ResourceKey{Kind: "Profile", Name: name},
-						Value: &prof,
-					})
-					expectedCacheSize += 1
-
-					serviceAccounts, err := cs.CoreV1().ServiceAccounts(ns.Name).List(context.Background(), metav1.ListOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					for _, sa := range serviceAccounts.Items {
-						name := "ksa." + ns.Name + "." + sa.Name
-
-						// Expect profile rules for the serviceaccounts in each namespace.
-						syncTester.ExpectData(model.KVPair{
-							Key: model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: name}},
-							Value: &model.ProfileRules{
-								InboundRules:  nil,
-								OutboundRules: nil,
-							},
-						})
-						expectedCacheSize += 1
-
-						// Expect profile labels for each default serviceaccount as well. The labels should include the name
-						// of the service account.
-						syncTester.ExpectData(model.KVPair{
-							Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
-							Value: map[string]string{
-								"pcsa.projectcalico.org/name": sa.Name,
-							},
-						})
-						expectedCacheSize += 1
-
-						//  We also expect one v3 Profile to be present for each ServiceAccount.
-						prof := v3.Profile{
-							TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
-							ObjectMeta: metav1.ObjectMeta{Name: name, UID: sa.UID, CreationTimestamp: sa.CreationTimestamp},
-							Spec: v3.ProfileSpec{
-								LabelsToApply: map[string]string{
-									"pcsa.projectcalico.org/name": sa.Name,
-								},
-							},
-						}
-						syncTester.ExpectData(model.KVPair{
-							Key:   model.ResourceKey{Kind: "Profile", Name: name},
-							Value: &prof,
-						})
-						expectedCacheSize += 1
-					}
-				}
-
-				// Expect two endpoint slices.
-				expectedCacheSize += 2
+			By("Checking updates match those expected.")
+			defaultCacheEntries := calculateDefaultFelixSyncerEntries(cs, config.Spec.DatastoreType)
+			expectedCacheSize += len(defaultCacheEntries)
+			for _, r := range defaultCacheEntries {
+				// Expect the correct cache values.
+				syncTester.ExpectData(r)
 			}
 
+			// Expect the correct updates - should have a new entry for each of these entries. Note that we don't do
+			// any more update checks below because we filter out host related updates since they are chatty outside
+			// of our control (and a lot of the tests below are focussed on host data), instead the tests below will
+			// just check the final cache entry.
+			var expectedEvents []api.Update
+			for _, r := range defaultCacheEntries {
+				expectedEvents = append(expectedEvents, api.Update{
+					KVPair:     r,
+					UpdateType: api.UpdateTypeKVNew,
+				})
+			}
+			syncTester.ExpectUpdates(expectedEvents, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify our cache size is correct.
 			syncTester.ExpectCacheSize(expectedCacheSize)
 
 			var node *libapiv3.Node
@@ -381,7 +429,6 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			// The pool will add as single entry ( +1 ), plus will also create the default
 			// Felix config with IPIP enabled.
 			expectedCacheSize += 2
-			syncTester.ExpectCacheSize(expectedCacheSize)
 			syncTester.ExpectData(model.KVPair{
 				Key: model.IPPoolKey{CIDR: net.MustParseCIDR("192.124.0.0/21")},
 				Value: &model.IPPool{
@@ -398,6 +445,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				Key:   model.GlobalConfigKey{"IpInIpEnabled"},
 				Value: "true",
 			})
+			syncTester.ExpectCacheSize(expectedCacheSize)
 
 			By("Creating a GlobalNetworkSet")
 			gns := apiv3.NewGlobalNetworkSet()
@@ -414,7 +462,6 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				options.SetOptions{},
 			)
 			expectedCacheSize++
-			syncTester.ExpectCacheSize(expectedCacheSize)
 			_, expGNet, err := net.ParseCIDROrIP("11.0.0.0/16")
 			Expect(err).NotTo(HaveOccurred())
 			syncTester.ExpectData(model.KVPair{
@@ -429,6 +476,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				},
 				Revision: gns.ResourceVersion,
 			})
+			syncTester.ExpectCacheSize(expectedCacheSize)
 
 			By("Creating a NetworkSet")
 			ns := apiv3.NewNetworkSet()
@@ -446,7 +494,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				options.SetOptions{},
 			)
 			expectedCacheSize++
-			syncTester.ExpectCacheSize(expectedCacheSize)
+
 			_, expNet, err := net.ParseCIDROrIP("11.0.0.0/16")
 			Expect(err).NotTo(HaveOccurred())
 			syncTester.ExpectData(model.KVPair{
@@ -465,6 +513,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				},
 				Revision: ns.ResourceVersion,
 			})
+			syncTester.ExpectCacheSize(expectedCacheSize)
 
 			By("Creating a HostEndpoint")
 			hep, err := c.HostEndpoints().Create(
@@ -497,11 +546,10 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				},
 				options.SetOptions{},
 			)
-
 			Expect(err).NotTo(HaveOccurred())
 			// The host endpoint will add as single entry ( +1 )
 			expectedCacheSize += 1
-			syncTester.ExpectCacheSize(expectedCacheSize)
+
 			syncTester.ExpectData(model.KVPair{
 				Key: model.HostEndpointKey{Hostname: "127.0.0.1", EndpointID: "hosta.eth0-a"},
 				Value: &model.HostEndpoint{
@@ -527,6 +575,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				},
 				Revision: hep.ResourceVersion,
 			})
+			syncTester.ExpectCacheSize(expectedCacheSize)
 
 			By("Allocating an IP")
 			err = c.IPAM().AssignIP(ctx, ipam.AssignIPArgs{
@@ -565,10 +614,6 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			syncTester.ExpectStatusUpdate(api.ResyncInProgress)
 			syncTester.ExpectCacheSize(len(current))
 			for _, e := range current {
-				if config.Spec.DatastoreType == apiconfig.Kubernetes {
-					// Don't check revisions for K8s since the node data gets updated constantly.
-					e.Revision = ""
-				}
 				syncTester.ExpectData(e)
 			}
 			syncTester.ExpectStatusUpdate(api.InSync)

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -131,6 +131,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 	var kc *kubernetes.Clientset
 	BeforeEach(func() {
 		var err error
+		config.Spec.K8sClientQPS = 500
 		bc, err = backend.NewClient(config)
 		Expect(err).NotTo(HaveOccurred())
 		ic = NewIPAMClient(bc, ipPools)

--- a/lib/testutils/delete.go
+++ b/lib/testutils/delete.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package testutils
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DeleteNamespace deletes the namespace and waits for it to complete.
+func DeleteNamespace(client *kubernetes.Clientset, name string) {
+	var zero int64
+	err := client.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+	})
+	if err != nil && !kerrors.IsNotFound(err) {
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	}
+	EventuallyWithOffset(1, func() bool {
+		_, err = client.CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
+		return kerrors.IsNotFound(err)
+	}, 30*time.Second).Should(BeTrue())
+}


### PR DESCRIPTION
Few changes:
- Remove some of the less than ideal sync tester methods and replace with something I hope is more robust
- Add a new fv-fast makefile target for testing fvs when you write them
- Add endpoint slices to felix FVs
- When dumping the syncer cache include details of whether an entry has been explicitly checked - this should make it a lot easier to spot unexpected cache entries and make debugging a lot faster.
- Add a utils for namespace deletion which waits for completion. Update tests to use that

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
