### PR TITLE
[v3.19] Add round tripping of ContainerID to KDD.

### DIFF
--- a/lib/backend/k8s/conversion/constants.go
+++ b/lib/backend/k8s/conversion/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,10 @@ const (
 	AnnotationPodIP = "cni.projectcalico.org/podIP"
 	// AnnotationPodIPs is similar for the plural PodIPs field.
 	AnnotationPodIPs = "cni.projectcalico.org/podIPs"
+	// AnnotationContainerID stores the container ID of the pod.  This allows us to disambiguate different pods
+	// that have the same name and namespace.  For example, stateful set pod that is restarted.  May be missing
+	// on older Pods.
+	AnnotationContainerID = "cni.projectcalico.org/containerID"
 
 	// NameLabel is a label that can be used to match a serviceaccount or namespace
 	// name exactly.

--- a/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -210,6 +210,10 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		}
 	}
 
+	// Get the container ID if present.  This is used in the CNI plugin to distinguish different pods that have
+	// the same name.  For example, restarted stateful set pods.
+	containerID := pod.Annotations[AnnotationContainerID]
+
 	// Create the workload endpoint.
 	wep := apiv3.NewWorkloadEndpoint()
 	wep.ObjectMeta = metav1.ObjectMeta{
@@ -224,6 +228,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		Orchestrator:       "k8s",
 		Node:               pod.Spec.NodeName,
 		Pod:                pod.Name,
+		ContainerID:        containerID,
 		Endpoint:           "eth0",
 		InterfaceName:      interfaceName,
 		Profiles:           profiles,

--- a/lib/backend/k8s/resources/workloadendpoint.go
+++ b/lib/backend/k8s/resources/workloadendpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ func (c *WorkloadEndpointClient) Create(ctx context.Context, kvp *model.KVPair) 
 	// Note: it's a bit odd to do this in the Create, but the CNI plugin uses CreateOrUpdate().  Doing it
 	// here makes sure that, if the update fails: we retry here, and, we don't report success without
 	// making the patch.
-	return c.patchInPodIPs(ctx, kvp)
+	return c.patchInAnnotations(ctx, kvp)
 }
 
 func (c *WorkloadEndpointClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -68,7 +68,7 @@ func (c *WorkloadEndpointClient) Update(ctx context.Context, kvp *model.KVPair) 
 	// As a special case for the CNI plugin, try to patch the Pod with the IP that we've calculated.
 	// This works around a bug in kubelet that causes it to delay writing the Pod IP for a long time:
 	// https://github.com/kubernetes/kubernetes/issues/39113.
-	return c.patchInPodIPs(ctx, kvp)
+	return c.patchInAnnotations(ctx, kvp)
 }
 
 func (c *WorkloadEndpointClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -77,16 +77,17 @@ func (c *WorkloadEndpointClient) DeleteKVP(ctx context.Context, kvp *model.KVPai
 
 func (c *WorkloadEndpointClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
 	log.Debug("Delete for WorkloadEndpoint, patching out annotations.")
-	return c.patchOutPodIPs(ctx, key, revision, uid)
+	return c.patchOutAnnotations(ctx, key, revision, uid)
 }
 
-// patchInPodIPs PATCHes the Kubernetes Pod associated with the given KVPair with the IP addresses it contains.
+// patchInAnnotations PATCHes the Kubernetes Pod associated with the given KVPair with the IP addresses it contains.
 // This is a no-op if there is no IP address.
 //
 // We store the IP addresses in annotations because patching the PodStatus directly races with changes that
 // kubelet makes so kubelet can undo our changes.
-func (c *WorkloadEndpointClient) patchInPodIPs(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	ips := kvp.Value.(*apiv3.WorkloadEndpoint).Spec.IPNetworks
+func (c *WorkloadEndpointClient) patchInAnnotations(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	wep := kvp.Value.(*apiv3.WorkloadEndpoint)
+	ips := wep.Spec.IPNetworks
 	if len(ips) == 0 {
 		return kvp, nil
 	}
@@ -96,16 +97,20 @@ func (c *WorkloadEndpointClient) patchInPodIPs(ctx context.Context, kvp *model.K
 
 	// Note: we drop the revision here because the CNI plugin can't handle a retry right now (and the kubelet
 	// ensures that only one CNI ADD for a given UID can be in progress).
-	return c.patchPodIPAnnotations(ctx, key, "", kvp.UID, ips)
+	return c.patchPodAnnotations(ctx, key, "", kvp.UID, wep.Spec.ContainerID, ips)
 }
 
-// patchOutPodIPs sets our pod IP annotations to empty strings; this is used to signal that the IP has been removed
+// patchOutAnnotations sets our pod IP annotations to empty strings; this is used to signal that the IP has been removed
 // from the pod at teardown.
-func (c *WorkloadEndpointClient) patchOutPodIPs(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
-	return c.patchPodIPAnnotations(ctx, key, revision, uid, nil)
+func (c *WorkloadEndpointClient) patchOutAnnotations(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
+	// Passing "" for containerID means "don't touch".  Passing nil for IPs will result in all annotations being
+	// explicitly set to the empty string.  Setting the podIPs to empty string is used to signal that the CNI DEL
+	// has removed the IP from the Pod.  We leave the container ID in place to allow any repeat invocations of the
+	// CNI DEL to tell which instance of a Pod they are seeing.
+	return c.patchPodAnnotations(ctx, key, revision, uid, "", nil)
 }
 
-func (c *WorkloadEndpointClient) patchPodIPAnnotations(ctx context.Context, key model.Key, revision string, uid *types.UID, ips []string) (*model.KVPair, error) {
+func (c *WorkloadEndpointClient) patchPodAnnotations(ctx context.Context, key model.Key, revision string, uid *types.UID, containerID string, ips []string) (*model.KVPair, error) {
 	wepID, err := c.converter.ParseWorkloadEndpointName(key.(model.ResourceKey).Name)
 	if err != nil {
 		return nil, err
@@ -120,11 +125,15 @@ func (c *WorkloadEndpointClient) patchPodIPAnnotations(ctx context.Context, key 
 	if len(ips) > 0 {
 		firstIP = ips[0]
 	}
-	patch, err := calculateAnnotationPatch(
-		revision, uid,
-		conversion.AnnotationPodIP, firstIP,
-		conversion.AnnotationPodIPs, strings.Join(ips, ","),
-	)
+	annotations := map[string]string{
+		conversion.AnnotationPodIP:  firstIP,
+		conversion.AnnotationPodIPs: strings.Join(ips, ","),
+	}
+	if containerID != "" {
+		log.WithField("containerID", containerID).Debug("Container ID specified, including in patch")
+		annotations[conversion.AnnotationContainerID] = containerID
+	}
+	patch, err := calculateAnnotationPatch(revision, uid, annotations)
 	if err != nil {
 		log.WithError(err).Error("failed to calculate Pod patch.")
 		return nil, err
@@ -144,16 +153,12 @@ func (c *WorkloadEndpointClient) patchPodIPAnnotations(ctx context.Context, key 
 	return kvps[0], nil
 }
 
-func calculateAnnotationPatch(revision string, uid *types.UID, namesAndValues ...string) ([]byte, error) {
+func calculateAnnotationPatch(revision string, uid *types.UID, annotations map[string]string) ([]byte, error) {
 	patch := map[string]interface{}{}
 	metadata := map[string]interface{}{}
 	patch["metadata"] = metadata
-	annotations := map[string]interface{}{}
 	metadata["annotations"] = annotations
 
-	for i := 0; i < len(namesAndValues); i += 2 {
-		annotations[namesAndValues[i]] = namesAndValues[i+1]
-	}
 	if revision != "" {
 		// We have a revision.  Since the revision is immutable, if our patch revision doesn't match then the
 		// patch will fail.

--- a/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,7 +123,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 						Namespace: "testNamespace",
 					},
 					Spec: apiv3.WorkloadEndpointSpec{
-						IPNetworks: []string{"192.168.91.117/32", "192.168.91.118/32"},
+						ContainerID: "abcde12345",
+						IPNetworks:  []string{"192.168.91.117/32", "192.168.91.118/32"},
 					},
 				}
 
@@ -142,8 +143,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
-					conversion.AnnotationPodIP:  "192.168.91.117/32",
-					conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationPodIP:       "192.168.91.117/32",
+					conversion.AnnotationPodIPs:      "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationContainerID: "abcde12345",
 				}))
 			})
 		})
@@ -226,7 +228,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 						Namespace: "testNamespace",
 					},
 					Spec: apiv3.WorkloadEndpointSpec{
-						IPNetworks: []string{"192.168.91.117/32", "192.168.91.118/32"},
+						IPNetworks:  []string{"192.168.91.117/32", "192.168.91.118/32"},
+						ContainerID: "abcd1234",
 					},
 				}
 
@@ -245,8 +248,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
-					conversion.AnnotationPodIP:  "192.168.91.117/32",
-					conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationPodIP:       "192.168.91.117/32",
+					conversion.AnnotationPodIPs:      "192.168.91.117/32,192.168.91.118/32",
+					conversion.AnnotationContainerID: "abcd1234",
 				}))
 			})
 		})
@@ -254,15 +258,16 @@ var _ = Describe("WorkloadEndpointClient", func() {
 
 	Describe("Delete", func() {
 		Context("WorkloadEndpoint has no IPs set", func() {
-			It("zeros out the cni.projectcalico.org/podIP and cni.projectcalico.org/podIPs annotations", func() {
+			It("zeros out the annotations", func() {
 				podUID := types.UID(uuid.NewV4().String())
 				k8sClient := fake.NewSimpleClientset(&k8sapi.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simplePod",
 						Namespace: "testNamespace",
 						Annotations: map[string]string{
-							conversion.AnnotationPodIP:  "192.168.91.117/32",
-							conversion.AnnotationPodIPs: "192.168.91.117/32,192.168.91.118/32",
+							conversion.AnnotationPodIP:       "192.168.91.117/32",
+							conversion.AnnotationPodIPs:      "192.168.91.117/32,192.168.91.118/32",
+							conversion.AnnotationContainerID: "abcde12345",
 						},
 						UID: podUID,
 					},
@@ -309,8 +314,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pod.GetAnnotations()).Should(Equal(map[string]string{
-					conversion.AnnotationPodIP:  "",
-					conversion.AnnotationPodIPs: "",
+					conversion.AnnotationPodIP:       "",
+					conversion.AnnotationPodIPs:      "",
+					conversion.AnnotationContainerID: "abcde12345",
 				}))
 			})
 		})
@@ -322,6 +328,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "simplePod",
 					Namespace: "testNamespace",
+					Annotations: map[string]string{
+						conversion.AnnotationContainerID: "abcde12345",
+					},
 				},
 				Spec: k8sapi.PodSpec{
 					NodeName: "test-node",
@@ -367,6 +376,7 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Profiles:      []string{"kns.testNamespace"},
 					IPNetworks:    []string{},
 					InterfaceName: "caliedff4356bd6",
+					ContainerID:   "abcde12345",
 				},
 			}))
 		})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Backport #1472 

This should fix the following issue:
https://github.com/projectcalico/calico/issues/4710
beause the CNI plugin will now hit the container ID-based guard
logic.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that podIP annotation could be incorrectly clobbered for stateful set pods: https://github.com/projectcalico/calico/issues/4710
```
