### PR TITLE
Use Info log level on allocation performance measurement tests

### DIFF
--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -147,6 +147,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		var hostname string
 		var err error
 		var pool20, pool32, pool26 []cnet.IPNet
+		var origLogLevel log.Level
 
 		BeforeEach(func() {
 			// Remove all data in the datastore.
@@ -179,16 +180,21 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			// Create the node object.
 			hostname = "host-perf"
 			applyNode(bc, kc, hostname, map[string]string{"foo": "bar"})
+
+			// Set log level to Info and save original value to be restored later
+			origLogLevel = log.GetLevel()
+			log.SetLevel(log.InfoLevel)
+
 		})
 
 		AfterEach(func() {
 			deleteNode(bc, kc, hostname)
+
+			// Restore original log level value
+			log.SetLevel(origLogLevel)
 		})
 
 		Measure("It should be able to allocate a single address quickly - blocksize 32", func(b Benchmarker) {
-			origLevel := log.GetLevel()
-			defer log.SetLevel(origLevel)
-			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -206,9 +212,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 26", func(b Benchmarker) {
-			origLevel := log.GetLevel()
-			defer log.SetLevel(origLevel)
-			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -226,9 +229,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 20", func(b Benchmarker) {
-			origLevel := log.GetLevel()
-			defer log.SetLevel(origLevel)
-			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -246,9 +246,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 100)
 
 		Measure("It should be able to allocate a lot of addresses quickly", func(b Benchmarker) {
-			origLevel := log.GetLevel()
-			defer log.SetLevel(origLevel)
-			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -266,9 +263,6 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 20)
 
 		Measure("It should be able to allocate and release addresses quickly", func(b Benchmarker) {
-			origLevel := log.GetLevel()
-			defer log.SetLevel(origLevel)
-			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.

--- a/lib/ipam/ipam_test.go
+++ b/lib/ipam/ipam_test.go
@@ -186,6 +186,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		})
 
 		Measure("It should be able to allocate a single address quickly - blocksize 32", func(b Benchmarker) {
+			origLevel := log.GetLevel()
+			defer log.SetLevel(origLevel)
+			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -203,6 +206,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 26", func(b Benchmarker) {
+			origLevel := log.GetLevel()
+			defer log.SetLevel(origLevel)
+			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -220,6 +226,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 20", func(b Benchmarker) {
+			origLevel := log.GetLevel()
+			defer log.SetLevel(origLevel)
+			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -237,6 +246,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 100)
 
 		Measure("It should be able to allocate a lot of addresses quickly", func(b Benchmarker) {
+			origLevel := log.GetLevel()
+			defer log.SetLevel(origLevel)
+			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.
@@ -254,6 +266,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		}, 20)
 
 		Measure("It should be able to allocate and release addresses quickly", func(b Benchmarker) {
+			origLevel := log.GetLevel()
+			defer log.SetLevel(origLevel)
+			log.SetLevel(log.InfoLevel)
 			runtime := b.Time("runtime", func() {
 				// Build a new backend client. We use a different client for each iteration of the test
 				// so that the k8s QPS /burst limits don't carry across tests. This is more realistic.


### PR DESCRIPTION
Use Info log level (as opposed to Debug) on allocation performance measurement tests in ipam_test.go

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
