### PR TITLE
Add release Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,3 +262,45 @@ ci: clean static-checks test
 ###############################################################################
 update-pins: update-api-pin
 
+###############################################################################
+# Release
+###############################################################################
+
+## Tags and builds a release from start to finish.
+release: release-prereqs
+	$(MAKE) VERSION=$(VERSION) release-tag
+
+	@echo ""
+	@echo "Release tagged. Next, push the tag."
+	@echo ""
+	@echo "  make VERSION=$(VERSION) release-publish"
+	@echo ""
+
+## Produces a git tag for the release.
+release-tag: release-prereqs release-notes
+	git tag $(VERSION) -F release-notes-$(VERSION)
+
+## Generates release notes.
+release-notes: release-prereqs
+	echo "This release is for build purposes only and this should not be referenced externally." > release-notes-$(VERSION)
+	echo "libcalico is not a stable interface." >> release-notes-$(VERSION)
+	echo "If you need an API you should use [projectcalico/api](https://github.com/projectcalico/api)." >> release-notes-$(VERSION)
+
+## Pushes a github tag `make release-tag`.
+release-publish: release-prereqs
+	# Push the git tag.
+	git push origin $(VERSION)
+
+## Nothing specifically to do for this target, just including the target for consistency
+release-publish-latest:
+	@echo "Nothing to publish libcalico-go for latest"
+
+# release-prereqs checks that the environment is configured properly to create a release.
+release-prereqs:
+ifndef VERSION
+	$(error VERSION is undefined - run using make release VERSION=vX.Y.Z)
+endif
+ifdef LOCAL_BUILD
+	$(error LOCAL_BUILD must not be set for a release)
+endif
+


### PR DESCRIPTION
## Description

Adding Makefile targets for creating git tags using the same targets we use in other repos.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
