### PR TITLE
(Staged)Policies should not have AOF=true; only global policies should

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
@@ -67,7 +67,7 @@ func convertNetworkPolicyV2ToV1Value(val interface{}) (interface{}, error) {
 		OutboundRules:  RulesAPIV2ToBackend(spec.Egress, v3res.Namespace),
 		Selector:       selector,
 		Types:          policyTypesAPIV2ToBackend(spec.Types),
-		ApplyOnForward: true,
+		ApplyOnForward: false,
 	}
 
 	return v1value, nil

--- a/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 				Value: &model.Policy{
 					Namespace:      ns1,
 					Selector:       "projectcalico.org/namespace == 'namespace1'",
-					ApplyOnForward: true,
+					ApplyOnForward: false,
 				},
 				Revision: testRev,
 			}))
@@ -188,7 +188,7 @@ var expected1 = []*model.KVPair{
 			Order:          &testDefaultPolicyOrder,
 			Selector:       "(projectcalico.org/orchestrator == 'k8s') && projectcalico.org/namespace == 'default'",
 			Types:          []string{"egress"},
-			ApplyOnForward: true,
+			ApplyOnForward: false,
 			OutboundRules: []model.Rule{
 				{
 					Action:      "allow",
@@ -230,7 +230,7 @@ var expected2 = []*model.KVPair{
 			Order:          &testDefaultPolicyOrder,
 			Selector:       "(projectcalico.org/orchestrator == 'k8s') && projectcalico.org/namespace == 'default'",
 			Types:          []string{"ingress"},
-			ApplyOnForward: true,
+			ApplyOnForward: false,
 			InboundRules: []model.Rule{
 				{
 					Action:                       "allow",

--- a/lib/backend/syncersv1/updateprocessors/shared_test.go
+++ b/lib/backend/syncersv1/updateprocessors/shared_test.go
@@ -207,7 +207,7 @@ func fullNPv1(namespace string) (p model.Policy) {
 		Order:          &testPolicyOrder101,
 		InboundRules:   []model.Rule{ir},
 		OutboundRules:  []model.Rule{or},
-		ApplyOnForward: true,
+		ApplyOnForward: false,
 		Types:          []string{"ingress", "egress"},
 	}
 }


### PR DESCRIPTION
## Description
Network policies were previously created with the ApplyOnForward flag, which should only be available for global network policies. I do not know exactly what the impact of this bug is to end users, but if you have code that depends on applyOnForward only being available for GlobalNetworkPolicies, this could have resulted into bugs.

## Todos
- [x] Release note

## Release Note

```release-note
- Fixed a bug that set `applyOnForward=true` for all network policies and staged network policies. This flag is meant only for global network policies and should be set to` false` for non-global policies.
```
