### PR TITLE
Fix that Pod ports without a name were being sent to Felix

### DIFF
--- a/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -122,11 +122,15 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 	// Convert the EndpointPort type from the API pkg to the v1 model equivalent type
 	ports := []model.EndpointPort{}
 	for _, port := range v3res.Spec.Ports {
-		ports = append(ports, model.EndpointPort{
-			Name:     port.Name,
-			Protocol: port.Protocol.ToV1(),
-			Port:     port.Port,
-		})
+		// The v1 API doesn't yet support ports which have no name. However, this is allowed on the
+		// v3 API and used by the CNI plugin only. Filter these out since Felix doesn't use them anyway.
+		if port.Name != "" {
+			ports = append(ports, model.EndpointPort{
+				Name:     port.Name,
+				Protocol: port.Protocol.ToV1(),
+				Port:     port.Port,
+			})
+		}
 	}
 
 	// Make sure there are no "namespace" or "serviceaccount" labels on the wep

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -154,6 +154,12 @@ func init() {
 			Protocol: protoUDP,
 			Port:     1234,
 		}, false),
+		Entry("should accept EndpointPort with empty name but HostPort specified", libapiv3.WorkloadEndpointPort{
+			Name:     "",
+			Protocol: protoUDP,
+			Port:     1234,
+			HostPort: 2345,
+		}, true),
 		Entry("should reject EndpointPort with no protocol", libapiv3.WorkloadEndpointPort{
 			Name: "a-valid-port",
 			Port: 1234,
@@ -905,7 +911,7 @@ func init() {
 			api.IPPool{
 				ObjectMeta: v1.ObjectMeta{Name: "pool.name"},
 				Spec: api.IPPoolSpec{
-					CIDR:      netv4_4,
+					CIDR: netv4_4,
 					AllowedUses: []api.IPPoolAllowedUse{
 						api.IPPoolAllowedUseWorkload,
 						api.IPPoolAllowedUseTunnel,
@@ -916,7 +922,7 @@ func init() {
 			api.IPPool{
 				ObjectMeta: v1.ObjectMeta{Name: "pool.name"},
 				Spec: api.IPPoolSpec{
-					CIDR:      netv4_4,
+					CIDR: netv4_4,
 					AllowedUses: []api.IPPoolAllowedUse{
 						"Garbage",
 					},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Candidate fix. The alternative (and probably correct, long term) fix is to continue to send these through to Felix, and update v1 validation to allow them and update Felix to properly ignore ports with no name.

Original bug introduced here: https://github.com/projectcalico/libcalico-go/pull/1471

Specifically this line: https://github.com/projectcalico/libcalico-go/pull/1471/files#diff-ad5531a876b7340a4c22c36f5ebe5e906b08325bc375f96e3c36f50c5d22428aR187

Felix and Typha don't expect ports without a Name field, but that's needed in some cases for hostPorts. Typha just drops any WEP that doesn't pass its internal validation, meaning any pod with hostPorts set never receives networking. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix bug where invalid port structures were being sent to Felix, preventing pods with hostPorts specified from working. 
```