### PR TITLE
Add IPAM capability to release block affinity given a block object

### DIFF
--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -80,7 +80,7 @@ type Interface interface {
 	ReleasePoolAffinities(ctx context.Context, pool cnet.IPNet) error
 
 	// ReleaseBlockAffinity releases the affinity of the exact block provided.
-	ReleaseBlockAffinity(ctx context.Context, block *model.AllocationBlock, mustBeEmpty bool)
+	ReleaseBlockAffinity(ctx context.Context, block *model.AllocationBlock, mustBeEmpty bool) error
 
 	// GetIPAMConfig returns the global IPAM configuration.  If no IPAM configuration
 	// has been set, returns a default configuration with StrictAffinity disabled

--- a/lib/ipam/interface.go
+++ b/lib/ipam/interface.go
@@ -17,6 +17,7 @@ package ipam
 import (
 	"context"
 
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -77,6 +78,9 @@ type Interface interface {
 	// ReleasePoolAffinities releases affinity for all blocks within
 	// the specified pool across all hosts.
 	ReleasePoolAffinities(ctx context.Context, pool cnet.IPNet) error
+
+	// ReleaseBlockAffinity releases the affinity of the exact block provided.
+	ReleaseBlockAffinity(ctx context.Context, block *model.AllocationBlock, mustBeEmpty bool)
 
 	// GetIPAMConfig returns the global IPAM configuration.  If no IPAM configuration
 	// has been set, returns a default configuration with StrictAffinity disabled


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Using `ReleaseAffinity` asserts that the given CIDR is within an IP pool
- it needs to do this becuase its arguments allow for CIDRs that span
several blocks / pools. 

this newer function is smaller in scope, so can avoid that limitation,
and is more appropriate for functions like the IPAM GC controller which
has blocks in-hand when attempting to release their affinity.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```